### PR TITLE
feat: add multi-agent review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Personal Claude Code skills collection, packaged as a Plugin for easy installati
 |-------|-------------|
 | [create-issue](plugins/aoshimash-skills/skills/create-issue/) | Create well-structured issues on any platform (GitHub, GitLab, etc.) with codebase analysis and self-evaluation |
 | [implement-issue](plugins/aoshimash-skills/skills/implement-issue/) | Read a platform issue, plan implementation, get approval, implement changes, and open a PR/MR |
+| [multi-agent-review](plugins/aoshimash-skills/skills/multi-agent-review/) | Run multiple AI CLIs (Claude, Codex, Gemini) in parallel for code review and produce a unified review output |
 
 ## Agents
 

--- a/plugins/aoshimash-skills/skills/multi-agent-review/SKILL.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: multi-agent-review
+description: >
+  Run multiple AI CLIs (Claude, Codex, Gemini) in parallel for code review,
+  then aggregate, deduplicate, and reconcile results into a unified review.
+  Supports both standalone invocation and internal use from other skills.
+  Use when the user says "multi-agent review", "multi review", "マルチレビュー",
+  "複数AIでレビュー", "レビューして", or wants a thorough code review using
+  multiple AI agents.
+---
+
+# Multi-Agent Review
+
+Run multiple AI CLIs in parallel for code review and produce a unified review output.
+
+## Core Principles
+
+1. **All agents, same perspectives** — By default, every agent reviews with the same set of perspectives. Per-agent customization is available via project settings.
+2. **Fault tolerant** — Skip uninstalled or failing CLIs and proceed with available agents.
+3. **Unified output** — Deduplicate, resolve contradictions, and sort by severity into a single review.
+4. **Review only** — This skill produces review output in the conversation. Where to post it (PR comment, file, etc.) is the caller's responsibility.
+
+## Step Tracking
+
+Maintain an internal checklist of completed steps throughout the workflow.
+
+Steps: `setup` -> `prepare` -> `execute` -> `aggregate` -> `present` -> `log-and-improve`
+
+Mark each step as completed when it finishes. If a step is skipped (with reason) or abandoned, record that too. The final `log-and-improve` step is **mandatory**.
+
+## Workflow
+
+### Phase 0: Setup — Agent Configuration
+
+1. Check for existing configuration in `.claude/aoshimash-skills.local.md` (YAML frontmatter).
+2. If configuration exists, load it and proceed to Phase 1.
+3. If no configuration exists (first run):
+   a. Check which CLIs are installed using `command -v claude`, `command -v codex`, `command -v gemini`.
+   b. Present the list of detected CLIs to the user and ask which ones to use.
+   c. Save the selection to `.claude/aoshimash-skills.local.md`.
+
+#### Configuration format
+
+```yaml
+# .claude/aoshimash-skills.local.md frontmatter
+multi-agent-review:
+  agents:
+    - name: claude
+      enabled: true
+      # Optional: override perspectives for this agent
+      # perspectives:
+      #   - correctness
+      #   - security
+    - name: codex
+      enabled: true
+    - name: gemini
+      enabled: true
+  # Optional: override default perspectives for all agents
+  # perspectives:
+  #   - name: custom-perspective
+  #     description: "..."
+  #     prompt: "..."
+```
+
+### Phase 1: Prepare — Diff Acquisition
+
+Determine the review target and obtain the diff.
+
+1. **If PR number/URL is provided** -> `gh pr diff <number>` to get the diff.
+2. **If no PR specified** -> Use local diff:
+   - Detect the default branch (`git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'`).
+   - Get diff: `git diff origin/<default-branch>...HEAD` combined with `git diff` (unstaged) and `git diff --cached` (staged).
+3. Save diff to a temporary file (`mktemp /tmp/multi-review-XXXXXX`).
+4. If diff is empty, report "No changes found" and exit (clean up temp file).
+
+Record the temp file path for use in subsequent phases and cleanup.
+
+See [references/agent-cli.md](references/agent-cli.md) for diff preparation details.
+
+### Phase 2: Execute — Parallel CLI Invocation
+
+Run all enabled agents in parallel using Background Bash.
+
+1. Load review perspectives: project custom perspectives (from settings) merged with defaults from [references/default-perspectives.md](references/default-perspectives.md).
+2. Build the review prompt incorporating all perspectives.
+3. For each enabled agent, invoke its CLI in the background. See [references/agent-cli.md](references/agent-cli.md) for exact commands.
+4. Before invoking each agent, verify the CLI is installed (`command -v <cli>`). Skip if not found.
+5. Wait for all background tasks to complete (timeout: 5 minutes).
+   - All completed -> Phase 3.
+   - Some timed out -> Proceed with completed results, note timed-out agents.
+   - All failed -> Report to user and exit (clean up temp file).
+
+### Phase 3: Aggregate — Unified Review
+
+Combine results from all agents into a single review.
+
+See [references/aggregation.md](references/aggregation.md) for the detailed procedure.
+
+**Summary:**
+1. **Parse** each agent's output into structured findings (severity, file, line, issue, fix).
+2. **Deduplicate** — Merge findings about the same file/line/issue from different agents.
+3. **Resolve contradictions** — When agents disagree:
+   - Majority agrees -> Adopt majority view, note dissent.
+   - No majority -> Present all views to the user for decision.
+4. **Sort by severity** — Critical -> Warning -> Suggestion.
+
+### Phase 4: Present — Output Results
+
+Display the unified review in the conversation using this format:
+
+```markdown
+## Multi-Agent Review
+
+**Agents:** <agent1> <status> | <agent2> <status> | ...
+**Target:** <PR #N / local diff (branch-name)>
+
+### Critical Issues
+#### <title>
+- **File:** `path/to/file:L<line>`
+- **Found by:** <agent names>
+- **Issue:** <description>
+- **Fix:** <suggestion>
+
+### Warnings
+...
+
+### Suggestions
+...
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| Critical | N     |
+| Warning  | N     |
+| Suggestion | N  |
+```
+
+If no issues are found, state that clearly.
+
+### Phase 5: Cleanup
+
+Delete the temporary diff file. This must happen on every exit path (success, error, early termination).
+
+### Phase 6: Log & Improve (mandatory)
+
+**Always execute this phase**, even if the workflow was abandoned or partially completed.
+
+#### Signals to track during execution
+
+- **Agent failure**: A CLI fails to execute or times out
+- **Parse failure**: Agent output cannot be parsed into structured findings
+- **Contradiction**: Agents disagree on a finding
+- **User friction**: User asks for clarification or expresses confusion
+- **Skip**: A step is skipped (e.g., no agents available)
+
+#### Spawn skill-analyzer agent
+
+Pass a session summary containing:
+- `skill`: "multi-agent-review"
+- `project`: repository name
+- `target`: PR number or "local diff"
+- `agents_configured`: list of configured agents
+- `agents_executed`: list of agents that successfully ran
+- `agents_skipped`: list with reasons (not installed, timed out, failed)
+- `steps_completed`: list from step tracking checklist
+- `steps_skipped`: list with reasons
+- `findings_count`: {critical, warning, suggestion}
+- `contradictions`: list of contradictions found
+- `user_friction`: list of friction observations
+- `outcome`: "success", "partial", or "abandoned"
+- `notes`: any additional observations
+
+See [references/log-analysis.md](references/log-analysis.md) for how to handle the agent's results.
+
+## References
+
+- [references/agent-cli.md](references/agent-cli.md) — CLI invocation commands and diff handling
+- [references/default-perspectives.md](references/default-perspectives.md) — Default review perspectives
+- [references/aggregation.md](references/aggregation.md) — Aggregation logic details
+- [references/eval-cases.md](references/eval-cases.md) — Evaluation test cases
+- [references/log-analysis.md](references/log-analysis.md) — Skill-analyzer agent integration

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/agent-cli.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/agent-cli.md
@@ -1,0 +1,127 @@
+# Agent CLI Reference
+
+## Diff Preparation
+
+Save the diff to a temporary file to avoid pipe issues across shell invocations.
+
+```bash
+DIFF_FILE=$(mktemp /tmp/multi-review-XXXXXX)
+echo "$DIFF_FILE"
+```
+
+**Important — Claude Code shell independence:**
+- Each Bash call runs in an independent shell. Shell variables (`$DIFF_FILE`) do not persist across calls.
+- Read the `mktemp` output, remember the actual file path, and embed it as a literal in subsequent commands.
+- Do not rely on `trap` for cleanup — it only works within the same shell. Clean up explicitly.
+
+**Template suffix:** The `mktemp` template must end with `X` characters (macOS BSD `mktemp` constraint). Do not append extensions like `.diff` after the `X`s.
+
+### PR diff
+
+```bash
+gh pr diff <PR_NUMBER> > <DIFF_FILE>
+if [ $? -ne 0 ]; then
+  echo "Error: gh pr diff failed"
+  rm -f <DIFF_FILE>
+  exit 1
+fi
+```
+
+### Local diff
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+{
+  git diff "origin/${DEFAULT_BRANCH}...HEAD"
+  git diff
+  git diff --cached
+} > <DIFF_FILE>
+```
+
+After writing the diff file, verify it is non-empty:
+
+```bash
+if [ ! -s <DIFF_FILE> ]; then
+  echo "No changes found"
+  rm -f <DIFF_FILE>
+  exit 0
+fi
+echo "Diff saved to <DIFF_FILE> ($(wc -l < <DIFF_FILE>) lines)"
+```
+
+## CLI Invocation
+
+All CLIs are run in **Background Bash** for parallel execution. Each CLI runs in read-only / prompt mode to prevent code changes.
+
+### Installation Check
+
+Before invoking each CLI, verify it is installed:
+
+```bash
+command -v <cli_name> >/dev/null 2>&1
+```
+
+If not found, skip the agent and note it in the results.
+
+### Claude CLI
+
+```bash
+claude --model opus -p \
+  "<review_prompt>" \
+  < <DIFF_FILE>
+```
+
+### Codex CLI
+
+Codex `exec` may ignore stdin redirection and reference the local worktree's `git diff`. Use `cat` + pipe to pass diff content.
+
+```bash
+cat <DIFF_FILE> | codex exec -m gpt-5.3-codex -s read-only \
+  "<review_prompt>"
+```
+
+### Gemini CLI
+
+```bash
+gemini --model gemini-3-pro-preview -p \
+  "<review_prompt>" \
+  < <DIFF_FILE>
+```
+
+## Review Prompt Template
+
+The `<review_prompt>` placeholder is replaced with the assembled prompt containing all perspectives. The prompt structure:
+
+```
+Review the following code diff. For each issue found, output structured markdown.
+
+## Review Perspectives
+<perspectives listed here>
+
+## Output Format
+For each issue, use this format:
+### [Critical/Warning/Suggestion] <title>
+- **File:** path/to/file:L<line>
+- **Issue:** <description>
+- **Fix:** <concrete suggestion>
+
+If no issues are found, output: "No issues found."
+```
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| CLI not installed | Skip, note in results |
+| CLI timeout (5 min) | Use completed results only, note timed-out agent |
+| Rate limit (429 / "rate limit" / "too many requests" in output) | Wait 30s and retry once. If still failing, skip the agent |
+| CLI exits with non-zero code | Skip, note the error |
+| Empty output | Skip, note the agent returned no results |
+
+## Cleanup
+
+Delete the temp diff file on **every exit path** — success, error, or early termination.
+
+```bash
+rm -f <DIFF_FILE>
+```

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/aggregation.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/aggregation.md
@@ -1,0 +1,113 @@
+# Aggregation Logic
+
+## Overview
+
+The central agent (Claude Code itself) combines outputs from all AI CLIs into a single unified review.
+
+## Step 1: Parse Agent Outputs
+
+Parse each agent's output into structured findings. Each finding has:
+
+| Field | Description |
+|-------|-------------|
+| **severity** | `Critical`, `Warning`, or `Suggestion` |
+| **title** | Short description of the issue |
+| **file** | File path |
+| **line** | Line number (if available) |
+| **issue** | Detailed description |
+| **fix** | Concrete suggestion |
+| **source** | Which agent(s) found it |
+
+If an agent's output does not follow the expected format, attempt best-effort parsing. If unparseable, include the raw output in a separate "Unparsed Output" section attributed to that agent.
+
+## Step 2: Deduplicate
+
+Merge findings that refer to the same issue:
+
+1. **Same file + same/adjacent line + same issue type** -> Merge into one finding. List all source agents.
+2. **Same file + different line + same issue pattern** -> Keep separate but note the pattern (e.g., "similar issue found at lines 10, 25, 42").
+3. **Different file + same conceptual issue** -> Keep separate. Each file gets its own finding.
+
+When merging, prefer the most detailed description and the most actionable fix suggestion.
+
+## Step 3: Resolve Contradictions
+
+Agents may disagree. Handle as follows:
+
+### Majority Agreement (2+ agents agree out of 3)
+Adopt the majority position as the primary finding. Add a note:
+```
+> **Dissent** (<agent name>): <alternative view>
+```
+
+### No Majority (all agents differ)
+Present all views and ask the user to decide:
+```
+> **Conflicting views — user decision needed:**
+> - **<agent1>:** <view>
+> - **<agent2>:** <view>
+> - **<agent3>:** <view>
+```
+
+### Severity Disagreement Only
+If agents agree on the issue but disagree on severity:
+- Use the **highest** severity as the primary level.
+- Note the range: "Severity: Critical (Claude, Codex) / Warning (Gemini)".
+
+## Step 4: Sort by Severity
+
+Order findings by severity: Critical -> Warning -> Suggestion.
+
+Within the same severity level, sort by:
+1. Number of agents that found the issue (descending — more consensus = higher priority)
+2. File path (alphabetical)
+3. Line number (ascending)
+
+## Output Format
+
+```markdown
+## Multi-Agent Review
+
+**Agents:** <agent1> <status> | <agent2> <status> | ...
+**Target:** <PR #N / local diff (branch-name)>
+
+### Critical Issues
+#### <title>
+- **File:** `path/to/file:L<line>`
+- **Found by:** <agent names>
+- **Issue:** <description>
+- **Fix:** <suggestion>
+
+### Warnings
+#### <title>
+- **File:** `path/to/file:L<line>`
+- **Found by:** <agent names>
+- **Issue:** <description>
+- **Fix:** <suggestion>
+
+### Suggestions
+#### <title>
+- **File:** `path/to/file:L<line>`
+- **Found by:** <agent names>
+- **Issue:** <description>
+- **Fix:** <suggestion>
+
+### Summary
+| Severity | Count |
+|----------|-------|
+| Critical | N     |
+| Warning  | N     |
+| Suggestion | N  |
+```
+
+If a severity category has no findings, omit that section entirely.
+
+If no issues are found by any agent, output:
+```markdown
+## Multi-Agent Review
+
+**Agents:** <agent1> <status> | <agent2> <status> | ...
+**Target:** <PR #N / local diff (branch-name)>
+
+No issues found.
+```

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/default-perspectives.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/default-perspectives.md
@@ -1,0 +1,85 @@
+# Default Review Perspectives
+
+These are language-agnostic review perspectives applied to all agents by default. Projects can override or extend these via `.claude/aoshimash-skills.local.md`.
+
+## Perspectives
+
+### Correctness
+- Logic errors, off-by-one, null/undefined safety
+- Edge cases and boundary conditions
+- Race conditions and state consistency
+- Error propagation — catch blocks that swallow errors, fallbacks that hide problems
+
+### Security
+- Injection vulnerabilities (SQL, XSS, command injection)
+- Authentication and authorization bypass
+- Secrets or credentials exposure
+- Input validation at system boundaries
+
+### Architecture
+- Code organization and separation of concerns
+- Coupling and cohesion
+- Unnecessary complexity or premature abstraction
+- Dead code
+
+### Error Handling
+- Proper error boundaries and meaningful error messages
+- Recovery strategies
+- Silent failures — `console.log` instead of proper error handling, missing error propagation
+
+### Maintainability
+- Naming clarity and consistency
+- Code duplication that should be extracted
+- Comments that are stale, inaccurate, or will rot as code evolves
+- Project convention violations (naming, file structure, patterns)
+
+## Custom Perspectives
+
+Projects can define custom perspectives in `.claude/aoshimash-skills.local.md`:
+
+```yaml
+multi-agent-review:
+  perspectives:
+    - name: performance
+      description: "Performance-critical review"
+      prompt: >
+        Analyze for performance issues: unnecessary allocations,
+        N+1 queries, missing indexes, unbounded loops, large payload
+        serialization.
+    - name: accessibility
+      description: "Web accessibility review"
+      prompt: >
+        Check for accessibility issues: missing ARIA labels,
+        insufficient color contrast, keyboard navigation gaps,
+        missing alt text on images.
+```
+
+Custom perspectives are **merged** with the defaults. To disable a default perspective, set it explicitly with `enabled: false`:
+
+```yaml
+multi-agent-review:
+  perspectives:
+    - name: architecture
+      enabled: false
+```
+
+## Per-Agent Perspective Override
+
+To assign specific perspectives to a single agent instead of the defaults:
+
+```yaml
+multi-agent-review:
+  agents:
+    - name: claude
+      enabled: true
+      perspectives:
+        - correctness
+        - security
+    - name: codex
+      enabled: true
+      perspectives:
+        - architecture
+        - error-handling
+```
+
+When `perspectives` is set on an agent, that agent uses **only** those perspectives (no merging with defaults).

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
@@ -1,0 +1,142 @@
+# Evaluation Test Cases
+
+## Quality Criteria
+
+| # | Criterion | Pass Condition |
+|---|---|---|
+| 1 | Config loaded or created | Existing config loaded without prompting, or first-run setup completed and saved |
+| 2 | CLI availability checked | Each agent's CLI verified with `command -v` before invocation |
+| 3 | Uninstalled CLIs skipped | Missing CLIs skipped gracefully, execution proceeds with available agents |
+| 4 | Diff obtained correctly | PR diff via `gh pr diff` or local diff via `git diff`, saved to temp file |
+| 5 | Agents run in parallel | All enabled agents invoked via Background Bash simultaneously |
+| 6 | Perspectives applied | Default perspectives (or custom overrides) included in review prompt |
+| 7 | Results parsed | Agent outputs parsed into structured findings |
+| 8 | Deduplication applied | Same-issue findings from multiple agents merged |
+| 9 | Contradictions resolved | Disagreements handled (majority rule or user decision) |
+| 10 | Severity sorted | Output ordered Critical -> Warning -> Suggestion |
+| 11 | Output format correct | Unified review follows the specified markdown format |
+| 12 | Temp file cleaned up | Diff temp file deleted on every exit path |
+| 13 | Session log written | skill-analyzer agent spawned with complete session data |
+| 14 | All agents failed handled | When all agents fail, user is notified and temp file cleaned up |
+| 15 | Per-agent perspectives | When agent-specific perspectives are configured, only those are used |
+
+## Test Cases
+
+### Case 1: First run — no configuration exists
+
+**Scenario**: User invokes `/multi-agent-review` for the first time. No `.claude/aoshimash-skills.local.md` exists. Claude and Gemini CLIs are installed, Codex is not.
+
+**Expected behavior**:
+- Detect installed CLIs (Claude, Gemini found; Codex not found)
+- Present available CLIs and ask user which to enable
+- Save selection to `.claude/aoshimash-skills.local.md`
+- Proceed with selected agents
+
+**Criteria to test**: 1, 2, 3
+
+### Case 2: Subsequent run — configuration exists
+
+**Scenario**: User invokes `/multi-agent-review` with existing configuration (Claude and Gemini enabled).
+
+**Expected behavior**:
+- Load configuration without prompting
+- Proceed directly to diff acquisition
+
+**Criteria to test**: 1
+
+### Case 3: PR diff review
+
+**Scenario**: User says `/multi-agent-review #42`. PR #42 exists with changes.
+
+**Expected behavior**:
+- Obtain diff via `gh pr diff 42`
+- Save to temp file
+- Run agents in parallel with default perspectives
+- Aggregate and present unified review
+- Clean up temp file
+
+**Criteria to test**: 4, 5, 6, 7, 8, 10, 11, 12
+
+### Case 4: Local diff review
+
+**Scenario**: User invokes `/multi-agent-review` without PR number. Branch has uncommitted and committed changes vs main.
+
+**Expected behavior**:
+- Detect no PR specified
+- Get local diff (origin/main...HEAD + unstaged + staged)
+- Run agents and produce unified review
+
+**Criteria to test**: 4, 5, 11
+
+### Case 5: No changes found
+
+**Scenario**: User invokes `/multi-agent-review` but there are no changes (clean branch, on main).
+
+**Expected behavior**:
+- Detect empty diff
+- Report "No changes found"
+- Clean up temp file and exit
+
+**Criteria to test**: 4, 12
+
+### Case 6: Agents produce contradicting findings
+
+**Scenario**: Claude says a function is safe, Gemini flags it as Critical security issue, Codex flags it as Warning.
+
+**Expected behavior**:
+- Detect contradiction
+- Majority (Gemini + Codex) flagged an issue -> adopt as finding
+- Note Claude's dissent
+- Use highest severity (Critical) from the majority
+
+**Criteria to test**: 8, 9, 10
+
+### Case 7: All agents fail
+
+**Scenario**: All configured CLIs fail (timeout, error, etc.).
+
+**Expected behavior**:
+- Report that all agents failed with details
+- Clean up temp file
+- Session log records the failures
+
+**Criteria to test**: 12, 13, 14
+
+### Case 8: One agent times out
+
+**Scenario**: Gemini times out after 5 minutes. Claude and Codex complete successfully.
+
+**Expected behavior**:
+- Proceed with Claude and Codex results
+- Note Gemini timeout in the output header
+- Aggregate available results normally
+
+**Criteria to test**: 5, 11, 13
+
+### Case 9: Custom per-agent perspectives
+
+**Scenario**: Configuration has Claude with only "correctness" and "security" perspectives, Codex with "architecture" and "error-handling".
+
+**Expected behavior**:
+- Claude receives prompt with only correctness + security perspectives
+- Codex receives prompt with only architecture + error-handling perspectives
+- Results aggregated normally despite different review scopes
+
+**Criteria to test**: 6, 15
+
+### Case 10: Internal use from another skill
+
+**Scenario**: `implement-issue` skill calls `multi-agent-review` as a subagent to review implementation before creating PR.
+
+**Expected behavior**:
+- Skill loads config, gets local diff, runs agents, returns unified review
+- No interactive prompts (config already exists)
+- Output returned to calling skill context
+
+**Criteria to test**: 1, 4, 5, 11
+
+---
+
+## Evaluation Log
+
+(No evaluations yet)

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/log-analysis.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/log-analysis.md
@@ -1,0 +1,38 @@
+# Log Analysis & Skill Improvement
+
+## Overview
+
+Log analysis and pattern detection are handled by the `skill-analyzer` agent.
+This file documents how the calling skill should act on the agent's results.
+
+## Flow
+
+1. Skill spawns `skill-analyzer` agent with session data
+2. Agent writes log and analyzes patterns
+3. Agent returns results to the calling skill
+4. Calling skill presents findings to the user (if any)
+
+## Handling Agent Results
+
+### No patterns found
+
+The agent returns a message like:
+```
+Session logged (N total entries). No recurring patterns found.
+```
+
+Relay this to the user briefly. No further action needed.
+
+### Patterns found
+
+The agent returns a structured report with improvement suggestions. For each suggestion:
+
+1. **Present to the user** — Show the pattern, root cause, and proposed fix.
+2. **Ask for approval** — Do not modify skill files without explicit user approval.
+3. **If approved**, create a PR:
+   - Branch: `fix/improve-<skill-name>-<description>`
+   - Modify the affected skill files
+   - Update `references/eval-cases.md` evaluation log
+   - Commit: `fix(<skill-name>): <description>`
+   - Push and create PR
+4. **If declined**, acknowledge and move on.


### PR DESCRIPTION
## Summary
- Add `multi-agent-review` skill that runs multiple AI CLIs (Claude, Codex, Gemini) in parallel for code review
- Produces a unified review output with deduplication, contradiction resolution, and severity sorting
- Supports both PR diff and local diff as review targets
- Configurable per-project via `.claude/aoshimash-skills.local.md`

Closes #5

## Changes
- `plugins/aoshimash-skills/skills/multi-agent-review/SKILL.md` — Main skill definition with 6-phase workflow (Setup, Prepare, Execute, Aggregate, Present, Log & Improve)
- `plugins/aoshimash-skills/skills/multi-agent-review/references/agent-cli.md` — CLI invocation commands, diff handling, error handling
- `plugins/aoshimash-skills/skills/multi-agent-review/references/default-perspectives.md` — Language-agnostic default review perspectives with customization support
- `plugins/aoshimash-skills/skills/multi-agent-review/references/aggregation.md` — Deduplication, contradiction resolution, severity sorting logic
- `plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md` — 10 test cases with 15 quality criteria
- `plugins/aoshimash-skills/skills/multi-agent-review/references/log-analysis.md` — skill-analyzer agent integration
- `README.md` — Added multi-agent-review to skills table

## Test Plan
- [ ] SKILL.md is under 500 lines (181 lines)
- [ ] Frontmatter has only `name` and `description`
- [ ] All 10 acceptance criteria from issue #5 are addressed
- [ ] No references to external sources in any file
- [ ] eval-cases.md covers all 15 quality criteria across 10 test cases
- [ ] Consistent with existing skill patterns (create-issue, implement-issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)