### PR TITLE
fix: add bypassPermissions to skill-analyzer spawning

### DIFF
--- a/plugins/aoshimash-skills/skills/create-issue/references/log-analysis.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/log-analysis.md
@@ -12,6 +12,17 @@ This file documents how the calling skill should act on the agent's results.
 3. Agent returns results to the calling skill
 4. Calling skill presents findings to the user (if any)
 
+## Spawning the Agent
+
+When spawning the `skill-analyzer` agent, set `mode: "bypassPermissions"` on the Agent tool call. The agent needs to create directories and write log files via Bash/Write tools. Without this mode, tool calls may be silently blocked — especially when running in the background — because the user cannot respond to approval prompts.
+
+```
+Agent tool call:
+  subagent_type: "aoshimash-skills:skill-analyzer"
+  mode: "bypassPermissions"
+  run_in_background: true
+```
+
 ## Handling Agent Results
 
 ### No patterns found

--- a/plugins/aoshimash-skills/skills/implement-issue/references/log-analysis.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/log-analysis.md
@@ -12,6 +12,17 @@ This file documents how the calling skill should act on the agent's results.
 3. Agent returns results to the calling skill
 4. Calling skill presents findings to the user (if any)
 
+## Spawning the Agent
+
+When spawning the `skill-analyzer` agent, set `mode: "bypassPermissions"` on the Agent tool call. The agent needs to create directories and write log files via Bash/Write tools. Without this mode, tool calls may be silently blocked — especially when running in the background — because the user cannot respond to approval prompts.
+
+```
+Agent tool call:
+  subagent_type: "aoshimash-skills:skill-analyzer"
+  mode: "bypassPermissions"
+  run_in_background: true
+```
+
 ## Handling Agent Results
 
 ### No patterns found


### PR DESCRIPTION
## Summary
- Add `Spawning the Agent` section to `log-analysis.md` in create-issue and implement-issue skills
- Document that `mode: "bypassPermissions"` must be set when spawning skill-analyzer agent to prevent silent tool blocking

## Changes
- `plugins/aoshimash-skills/skills/create-issue/references/log-analysis.md` — Add spawning instructions
- `plugins/aoshimash-skills/skills/implement-issue/references/log-analysis.md` — Add spawning instructions

Note: `multi-agent-review` skill's `log-analysis.md` will be updated in #6 before merge.

## Test plan
- [ ] Verify skill-analyzer agent can write logs when spawned with `mode: "bypassPermissions"` in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)