### PR TITLE
docs: add multi-agent-review skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Personal Claude Code skills collection, packaged as a Plugin for easy installati
 |-------|-------------|
 | [create-issue](plugins/aoshimash-skills/skills/create-issue/) | Create well-structured issues on any platform (GitHub, GitLab, etc.) with codebase analysis and self-evaluation |
 | [implement-issue](plugins/aoshimash-skills/skills/implement-issue/) | Read a platform issue, plan implementation, get approval, implement changes, and open a PR/MR |
+| [multi-agent-review](plugins/aoshimash-skills/skills/multi-agent-review/) | Run multiple AI CLIs (Claude, Codex, Gemini) in parallel for code review and produce a unified review output |
 
 ## Agents
 


### PR DESCRIPTION
## Summary
- Add multi-agent-review skill entry to the Skills table in README.md

## Test plan
- [ ] Verify link points to correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)