### PR TITLE
Enforce one question at a time in create-issue Step 3

### DIFF
--- a/plugins/aoshimash-skills/skills/create-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/create-issue/SKILL.md
@@ -40,7 +40,7 @@ Infer the issue type from conversation context. If unclear, ask using plain lang
 
 ### 3. Gather Information
 
-Collect information through conversation using natural, plain-language questions. Do not ask for all fields at once — build on each response.
+Collect information through conversation using natural, plain-language questions. Do not ask for all fields at once — build on each response. Ask exactly one question at a time. Never combine multiple questions or sub-questions into a single message. Use AskUserQuestion when presenting choices.
 
 **Step-by-step:**
 


### PR DESCRIPTION
## Summary
- Add explicit instruction to create-issue SKILL.md Step 3 to ask exactly one question at a time
- Prevents combining multiple questions or sub-questions into a single message

Closes #17

## Changes
- `plugins/aoshimash-skills/skills/create-issue/SKILL.md`: Added "Ask exactly one question at a time. Never combine multiple questions or sub-questions into a single message. Use AskUserQuestion when presenting choices." to Step 3 (Gather Information)

## Test Plan
- [ ] Run create-issue skill and verify that questions are asked one at a time
- [ ] Confirm no multiple questions are combined in a single message during information gathering

🤖 Generated with [Claude Code](https://claude.com/claude-code)