### PR TITLE
Explicit self-review reporting and AskUserQuestion for choices

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -29,7 +29,7 @@ Read an issue, plan the implementation, get approval, implement, and create a PR
    - GitLab: [references/platform-gitlab.md](references/platform-gitlab.md)
 2. Obtain the issue identifier (number or URL) from the user if not already provided.
 3. Fetch the issue content using the platform CLI.
-4. Ask the user where to implement. Options:
+4. Ask the user where to implement using `AskUserQuestion` with numbered options:
    - **Worktree** (default) — Create a git worktree for isolated work. Keeps current branch untouched.
    - **New branch** — Create a new branch in the current working tree.
    - **Current branch** — Work directly on the current branch (useful if already on a feature branch).
@@ -41,7 +41,7 @@ See [references/workflow.md](references/workflow.md) for the detailed procedure.
 **Summary:**
 1. Parse the issue — extract motivation, background, proposal, acceptance criteria.
 2. Analyze the codebase — identify files, patterns, dependencies relevant to the issue.
-3. Resolve design decisions — if multiple valid approaches exist, present options with pros/cons and a recommendation. Wait for the user's choice.
+3. Resolve design decisions — if multiple valid approaches exist, use `AskUserQuestion` to present numbered options with pros/cons and a recommendation. Wait for the user's choice.
 4. Draft implementation plan — list files to create/modify, approach for each, edge cases.
 5. Self-evaluate — verify plan addresses all acceptance criteria and stays in scope.
 6. Present the plan to the user and wait for approval.
@@ -56,7 +56,7 @@ See [references/workflow.md](references/workflow.md) for the detailed procedure.
 1. Prepare working environment (worktree / new branch / current branch).
 2. Implement changes following the approved plan.
 3. Run project checks (tests, lint, type-check, format) — loop until all pass.
-4. AI self-review of the full diff — loop until clean. Escalate to user when human judgment is needed.
+4. AI self-review of the full diff — loop until clean. Escalate to user (via `AskUserQuestion`) when human judgment is needed. After completion, output a visible self-review summary (e.g., "Self-review: N round(s), N issue(s) found, N fixed").
 5. Commit with a message referencing the issue.
 
 ### Phase 3: Pull/Merge Request

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -42,14 +42,13 @@ Before drafting the plan, identify any decisions that require human judgment. Ex
 - Technology or library choices not dictated by CLAUDE.md
 - Scope boundaries (what's "good enough" for this issue)
 
-For each decision point:
+For each decision point, use `AskUserQuestion` with numbered options:
 
 1. **Present options** (2–4 choices) with:
    - A short label for each option
-   - Pros and cons, or key trade-offs
-   - Impact on complexity, performance, maintainability
-2. **Recommend one option** — Mark it clearly and explain why.
-3. **Wait for the user's choice** before proceeding.
+   - Pros and cons or key trade-offs in the description
+   - Mark the recommended option with "(Recommended)" in its label
+2. **Wait for the user's choice** before proceeding.
 
 If no design decisions require human input, skip this step and proceed to 1-4.
 
@@ -179,11 +178,10 @@ Run whatever the project defines. **Loop (max 3 attempts):**
 2. If any fail, fix the issue and re-run all checks.
 3. Repeat until all checks pass or 3 attempts are reached.
 
-If a fix requires a design decision (e.g., how to handle an unexpected edge case), present options with a recommendation to the user and wait for their choice.
+If a fix requires a design decision (e.g., how to handle an unexpected edge case), use `AskUserQuestion` to present numbered options with a recommendation and wait for the user's choice.
 
-**If checks still fail after 3 attempts**: Stop and escalate to the user. Present:
-- Which checks are still failing
-- What was tried to fix them
+**If checks still fail after 3 attempts**: Stop and escalate to the user. Use `AskUserQuestion` to present:
+- Which checks are still failing and what was tried
 - Options: continue trying, skip the failing check, or abandon the implementation
 
 If the project has no defined checks, skip this step but note it when creating the PR.
@@ -208,15 +206,23 @@ Check for:
 1. Review the diff.
 2. If issues found:
    - Fix issues that have a clear correct solution.
-   - If a fix requires human judgment (e.g., ambiguous requirements, UX trade-offs, business logic), present the issue with options and a recommendation to the user. Wait for their choice.
+   - If a fix requires human judgment (e.g., ambiguous requirements, UX trade-offs, business logic), use `AskUserQuestion` to present the issue with numbered options and a recommendation. Wait for the user's choice.
 3. After fixes, re-run project checks (Step 2-3) to ensure fixes don't break anything.
 4. Re-review the diff.
 5. Repeat until no issues remain or 3 review rounds are reached.
 
-**If issues remain after 3 rounds**: Stop and present remaining issues to the user. Let the user decide whether to:
+**If issues remain after 3 rounds**: Stop and use `AskUserQuestion` to present remaining issues. Let the user decide whether to:
 - Proceed with known issues
 - Fix manually
 - Abandon the implementation
+
+**After self-review completes**, output a visible summary to the user before proceeding to commit:
+
+```
+Self-review complete: N round(s), N issue(s) found, N fixed, N remaining
+```
+
+This ensures the user can verify that self-review was performed and see the result at a glance.
 
 ### 2-5. Commit
 


### PR DESCRIPTION
## Summary
- Add instruction to output a visible self-review summary (round count, issues found/fixed) before committing
- Replace free-text decision prompts with `AskUserQuestion` tool usage at all decision points

Closes #16

## Changes
- `plugins/aoshimash-skills/skills/implement-issue/SKILL.md` — Updated Phase 0 Step 4, Phase 1 Step 3, Phase 2 Step 4 to reference `AskUserQuestion` and self-review reporting
- `plugins/aoshimash-skills/skills/implement-issue/references/workflow.md` — Updated sections 1-3, 2-3, 2-4 with `AskUserQuestion` instructions and added self-review summary output format

## Test Plan
- [ ] Verify SKILL.md Phase 0 Step 4 mentions `AskUserQuestion` with numbered options
- [ ] Verify SKILL.md Phase 2 Step 4 includes self-review summary output instruction
- [ ] Verify workflow.md 1-3 uses `AskUserQuestion` for design decisions
- [ ] Verify workflow.md 2-3 uses `AskUserQuestion` for check failure escalation
- [ ] Verify workflow.md 2-4 uses `AskUserQuestion` for self-review escalation and includes summary format
- [ ] Run implement-issue skill and confirm choices are presented as numbered options
- [ ] Run implement-issue skill and confirm self-review summary is displayed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)