### PR TITLE
Add auto-bump plugin version workflow on PR merge

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,41 @@
+name: Bump plugin version
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump patch version
+        run: |
+          CURRENT=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          jq --indent 2 \
+            --arg v "$NEW_VERSION" \
+            '.metadata.version = $v | .plugins[0].version = $v' \
+            .claude-plugin/marketplace.json > tmp.json
+          mv tmp.json .claude-plugin/marketplace.json
+
+          echo "NEW_VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+
+      - name: Commit and push
+        run: |
+          git diff --quiet .claude-plugin/marketplace.json && exit 0
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json
+          git commit -m "chore: bump plugin version to $NEW_VERSION"
+          git pull --rebase
+          git push


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-increments the patch version in `marketplace.json` when a PR is merged to `main`
- Updates both `metadata.version` and `plugins[0].version` fields
- Prevents infinite loops: bump commit is a direct push, so it doesn't trigger the `pull_request` event

## Test plan
- [ ] Merge this PR and verify the workflow runs in the Actions tab
- [ ] Confirm `marketplace.json` has both versions incremented (e.g., `1.0.0` → `1.0.1`)
- [ ] Confirm the bump commit appears in git log with message `chore: bump plugin version to X.Y.Z`
- [ ] Confirm no second workflow run is triggered by the bump commit

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/skills/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
