### PR TITLE
Fix bump-version workflow permissions and checkout ref

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
@@ -12,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Bump patch version
         run: |


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to grant `GITHUB_TOKEN` push access to `main`
- Add `ref: main` to `actions/checkout` so the actual `main` branch is checked out (not the merge ref)

## Context
The workflow added in #26 failed with `Permission to aoshimash/skills.git denied to github-actions[bot]` because the default token permissions were read-only.

## Test plan
- [ ] Merge this PR and verify the workflow succeeds in the Actions tab
- [ ] Confirm `marketplace.json` versions are bumped and committed to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/skills/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
