### PR TITLE
Add Pattern Broadening to respond-to-pr-review

### DIFF
--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
@@ -50,7 +50,7 @@ See [references/workflow.md](references/workflow.md) for detailed procedure.
 
 See [references/workflow.md](references/workflow.md) for detailed procedure.
 
-**Summary:** Group comments pointing out the same issue across reviewers/bots/lines. Record metadata (bodies, IDs, reviewers, files). Tag criticality: `critical` (REQUEST_CHANGES or 2+ reviewers) vs `normal`.
+**Summary:** Group comments pointing out the same issue across reviewers/bots/lines. Record metadata (bodies, IDs, reviewers, files). Tag criticality: `critical` (REQUEST_CHANGES or 2+ reviewers) vs `normal`. Tag comment type: `rule-violation-instance` (pattern applies to multiple locations) vs `one-off-bug` (specific defect).
 
 ### Phase 3: Interactive Decision Loop
 
@@ -73,14 +73,21 @@ For each "Implement" decision:
 3. Commit referencing the context (e.g., `fix: address review comment on foo.ts:42`)
 4. Record the commit SHA for use in replies
 
+### Phase 4.5: Pattern Broadening
+
+See [references/workflow.md](references/workflow.md) for detailed procedure.
+
+**Summary:** For each `rule-violation-instance` group just implemented, search the changed files for other instances of the same pattern. Present found instances to the user via `AskUserQuestion` (Apply all / Skip / Pick subset). Apply selected fixes in the same commit, or create a new commit if the previous commit is already pushed.
+
 ### Phase 5: Verification Gate
 
 See [references/verification.md](references/verification.md) for detailed procedure.
 
-**Summary:** Verify that Phase 4 changes match the reviewer's intent.
+**Summary:** Verify that Phase 4 (and 4.5) changes match the reviewer's intent.
 
 - `critical` groups → subagent verification (3 criteria: Intent Match, Scope Guard, Side Effect)
 - `normal` groups → self-review using the same 3 criteria
+- For `rule-violation-instance` groups, same-pattern expansion from Phase 4.5 is considered in-scope for the Scope Guard criterion.
 - NEEDS_FIX → fix loop (max 2 rounds)
 - UNCERTAIN → present to user for decision
 - Still failing → DONE_WITH_CONCERNS (caveat added to reply)
@@ -110,6 +117,7 @@ Draft a reply for every group that requires a response.
 | Decision | Human | Bot |
 |---|---|---|
 | Implement | "Thanks! Fixed in [SHA] — [description]." | "Fixed in [SHA]: [description]." |
+| Implement (broadened) | "Thanks! Fixed in [SHA] — applied to [original location] + [N] other instances of the same pattern." | "Fixed in [SHA]: applied to [original location] + [N] other instances of the same pattern." |
 | Implement (WITH_CONCERNS) | "Thanks! Fixed in [SHA] — [description]. Please verify this matches your intent." | "Fixed in [SHA]: [description]. Verification requested." |
 | Reject | "Thanks for the note. Keeping current approach because [reason]." | "Keeping current approach: [reason]." |
 | Create Issue | "Good point — outside scope. Created #N to track it." | "Out of scope. Tracked in #N." |

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/evals/evals.json
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/evals/evals.json
@@ -14,6 +14,13 @@
       "prompt": "PRコメントに対応してください。現在のブランチは main です（オープンなPRはありません）。",
       "expected_output": "Skill detects no PR on current branch and asks the user to provide a PR number or URL before proceeding.",
       "files": []
+    },
+    {
+      "id": 9,
+      "name": "pattern-broadening-drip-feed",
+      "prompt": "PR のレビューコメントに対応してください。ボット (DeepSource) から1件のコメントがあります: 'Variable `data` in `src/utils.ts:12` does not follow the camelCase convention. Consider renaming to `userData`.' 変更ファイルには同じ命名違反が src/api.ts:34, src/handler.ts:8, src/handler.ts:27 にも存在します。",
+      "expected_output": "1) Group tagged as rule-violation-instance (bot commenter, uses 'convention', pattern grep-findable). 2) Phase 4 fixes only src/utils.ts:12. 3) Phase 4.5 finds 3 additional instances and presents AskUserQuestion with Apply all / Pick subset / Skip. 4) After user approves Apply all, all 4 locations fixed in same commit. 5) Scope Guard passes in verification. 6) Reply uses Implement (broadened) template: 'Fixed in [SHA]: applied to src/utils.ts:12 + 3 other instances of the same pattern.'",
+      "files": []
     }
   ]
 }

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
@@ -171,6 +171,38 @@
 
 ---
 
+## Case 9: Pattern Broadening — drip-feed bot review
+
+**Setup**: PR modifying 4 files. A bot reviewer (e.g., DeepSource) posts one comment:
+- Bot (DeepSource): "Variable `data` in `src/utils.ts:12` does not follow the `camelCase` convention. Consider renaming to `userData`."
+- The same naming violation (`data` instead of a descriptive camelCase name) exists at 3 other locations in the changed files (`src/api.ts:34`, `src/handler.ts:8`, `src/handler.ts:27`).
+
+**Expected behavior**:
+- Phase 2: Group tagged `normal` (single bot commenter, no REQUEST_CHANGES). Type tagged `rule-violation-instance` (bot commenter, uses "convention", grep-findable pattern).
+- Phase 3: User decides Implement.
+- Phase 4: Fix `src/utils.ts:12` only (as specifically requested).
+- Phase 4.5:
+  - Skill searches changed files for similar naming violations.
+  - Finds 3 additional instances.
+  - Presents them to the user via `AskUserQuestion` with Apply all / Pick subset / Skip.
+  - User selects Apply all.
+  - All 3 additional locations fixed and included in the same commit (or a new commit if pushed).
+  - Group marked `broadened` (3 additional instances).
+- Phase 5: Scope Guard passes (`broadened` + `rule-violation-instance` + user approved).
+- Phase 7: Reply uses `Implement (broadened)` template — "Fixed in [SHA]: applied to `src/utils.ts:12` + 3 other instances of the same pattern."
+
+**Verification**:
+- [ ] Group type correctly classified as `rule-violation-instance`
+- [ ] Phase 4 fixes only the originally flagged location
+- [ ] Phase 4.5 finds exactly the 3 additional instances in changed files
+- [ ] `AskUserQuestion` presented with Apply all / Pick subset / Skip options
+- [ ] All 4 locations fixed after user chooses Apply all
+- [ ] Scope Guard criterion passes (not FAIL) in Phase 5 verification
+- [ ] Reply uses `Implement (broadened)` template with correct count and locations
+- [ ] A single bot reply posted (not 4 separate replies)
+
+---
+
 ## Evaluation Log
 
 | Date | Case | Result | Notes |

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
@@ -44,7 +44,8 @@ Check these 3 criteria:
 
 2. **Scope Guard**: Does the diff contain changes NOT requested by the comment?
    - PASS: All changes are directly related to the comment
-   - FAIL: The diff includes unrelated refactoring, formatting, or feature changes
+   - PASS (broadened): The diff includes same-pattern fixes at additional locations, AND the group is tagged `rule-violation-instance`, AND the user approved the broadening in Phase 4.5
+   - FAIL: The diff includes unrelated refactoring, formatting, or feature changes not covered by the above PASS conditions
 
 3. **Side Effect**: Could the change break existing behavior?
    - PASS: The change is safe and localized
@@ -129,5 +130,5 @@ If "Re-implement": apply user guidance, re-verify once more (no round limit for 
 | Criterion | Checks | Common failures |
 |---|---|---|
 | Intent Match | Change addresses the reviewer's request | Partial fix, misinterpreted request, wrong file |
-| Scope Guard | No unrelated changes in the diff | Drive-by refactoring, formatting changes, bonus features |
+| Scope Guard | No unrelated changes in the diff (same-pattern expansion approved in Phase 4.5 is allowed for `rule-violation-instance` groups) | Drive-by refactoring, formatting changes, bonus features |
 | Side Effect | Change doesn't break existing behavior | Modified shared interface, removed used code, changed return type |

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/workflow.md
@@ -67,6 +67,19 @@ Assign a criticality tag to each group:
 
 Criticality determines verification routing in Phase 5 (Verification Gate).
 
+### 2-4: Tag comment type
+
+Assign a type tag to each group:
+
+| Tag | Condition |
+|---|---|
+| `rule-violation-instance` | Comment references a rule, convention, or policy that could apply to multiple locations; OR uses words like "rule", "convention", "pattern", "policy", "violates", "should always", "consistent"; OR similar instances are grep-findable in the changed files; OR the commenter is a bot |
+| `one-off-bug` | Specific defect at a specific location with no indication of a broader pattern |
+
+When in doubt, prefer `one-off-bug` — broadening only applies to `rule-violation-instance` groups.
+
+The type tag drives Pattern Broadening in Phase 4.5.
+
 ## Phase 3: Interactive Decision Loop
 
 ### 3-1: Present groups one at a time
@@ -106,3 +119,52 @@ Decisions summary:
 ```
 
 Proceed to Phase 4 with "Implement" groups, Phase 6 with "Create Issue" groups.
+
+## Phase 4.5: Pattern Broadening
+
+Runs after Phase 4 implementation, before Phase 5 verification. Applies only to groups tagged `rule-violation-instance` with an "Implement" decision.
+
+### 4.5-1: Search for additional instances
+
+For each `rule-violation-instance` group just implemented:
+
+1. Identify the pattern that was fixed (e.g., variable naming convention, error handling style, import ordering).
+2. Search the **changed files** (files in the current PR diff) for other instances of the same pattern that were not addressed in Phase 4.
+   - Use `grep` or structural search on the changed files only (not the whole repo).
+   - Default scope: files changed in this PR. If the reviewer specified a broader scope (e.g., "this directory"), use that.
+3. Exclude lines already fixed in Phase 4.
+
+### 4.5-2: Present findings to user
+
+If additional instances are found, present them via `AskUserQuestion`:
+
+```
+Pattern Broadening — Group N [rule-violation-instance]
+Rule: {short description of the pattern}
+
+Found {K} other instance(s) in the changed files:
+  • src/foo.ts:15  — {snippet}
+  • src/bar.ts:42  — {snippet}
+
+Apply pattern fix to:
+```
+
+Options:
+- **Apply all** — fix all found instances in the same commit
+- **Pick subset** — user selects which instances to fix (follow up with a list)
+- **Skip** — fix only the originally flagged location
+
+If no additional instances are found, skip to Phase 5 silently.
+
+### 4.5-3: Apply selected fixes
+
+For each selected instance:
+
+1. Apply the same fix that was applied in Phase 4 (adapted to the local context).
+2. Run project checks (formatter, linter, tests) until clean.
+3. Amend the Phase 4 commit if it has not been pushed, or create a new commit if it has.
+4. Record the broadened locations for use in the Phase 7 reply template.
+
+### 4.5-4: Mark broadened groups
+
+Tag the group as `broadened` with the count of additional instances fixed. The Phase 7 reply will use the `Implement (broadened)` template variant instead of plain `Implement`.


### PR DESCRIPTION
## Summary

- Adds Phase 4.5 (Pattern Broadening) between Phase 4 and Phase 5 in `respond-to-pr-review`
- Introduces `rule-violation-instance` vs `one-off-bug` comment type classification in Phase 2-4
- For `rule-violation-instance` groups, the skill searches changed files for additional instances and presents them interactively (Apply all / Pick subset / Skip)
- Updates Scope Guard in `verification.md` to treat approved same-pattern expansion as PASS
- Adds `Implement (broadened)` reply template variant for Phase 7
- Adds eval case 9 (drip-feed bot review scenario) to both `evals/evals.json` and `references/eval-cases.md`

## Test plan

- [ ] Verify Phase 2 summary in `SKILL.md` mentions both `criticality` and `type` tags
- [ ] Verify Phase 4.5 section exists in `SKILL.md` and references `workflow.md`
- [ ] Verify `workflow.md` section 2-4 defines `rule-violation-instance` / `one-off-bug` heuristics
- [ ] Verify `workflow.md` Phase 4.5 has all 4 sub-steps (search, present, apply, mark)
- [ ] Verify `verification.md` Scope Guard has `PASS (broadened)` condition with 3 required factors
- [ ] Verify Phase 7 reply table in `SKILL.md` includes `Implement (broadened)` row
- [ ] Verify `evals/evals.json` has id:9 entry with pattern-broadening scenario
- [ ] Verify `eval-cases.md` Case 9 covers drip-feed scenario with 8 verification checkboxes

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/skills/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
