### PR TITLE
Propagate review pattern violations across in-flight PRs

### DIFF
--- a/plugins/aoshimash-skills/skills/run-sprint/SKILL.md
+++ b/plugins/aoshimash-skills/skills/run-sprint/SKILL.md
@@ -17,7 +17,7 @@ Fetch a set of issues, resolve dependencies, implement them in parallel where po
 1. **Issues are the source of truth** — Each issue defines the scope. Do not add unrelated changes. Do not deviate from the issue's acceptance criteria.
 2. **Dependency-driven parallelism** — Issues with no unresolved dependencies run in parallel. Issues with dependencies wait. The dependency graph is the scheduler.
 3. **Worktree isolation** — Each issue gets its own git worktree. No cross-contamination between parallel implementations.
-4. **Two-stage review** — Every completed issue goes through spec compliance review (does the diff match the issue?) then code quality review. Both happen before marking complete.
+4. **Two-stage review with pattern propagation** — Every completed issue goes through spec compliance review (does the diff match the issue?) then code quality review. If a `rule-violation-instance` is found, other in-flight PRs are scanned for the same pattern and the user is offered a fix. All stages happen before marking complete.
 5. **Fail fast, report clearly** — If an issue fails after retries, mark it blocked and continue with independent issues. Never block the entire sprint on one failure.
 
 ## Workflow
@@ -77,6 +77,7 @@ Repeat until all issues are completed or all remaining issues are blocked:
 3. **Two-stage review** — After each issue's PR is created:
    - Stage 1: Dispatch a **spec compliance reviewer** subagent (see [references/review-gates.md](references/review-gates.md))
    - Stage 2: Dispatch a **code quality reviewer** subagent (see [references/review-gates.md](references/review-gates.md))
+   - Stage 2.5: **Pattern Propagation** — If a `rule-violation-instance` is found, scan other in-flight PRs for the same pattern and offer to propagate the fix (see [references/review-gates.md](references/review-gates.md))
    - If issues found → implementer subagent fixes → re-review (max 2 fix rounds)
 4. **Update DAG** — Mark completed issues. Check if new issues are now unblocked.
 5. **Handle failures** — If an issue fails after retries:

--- a/plugins/aoshimash-skills/skills/run-sprint/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/run-sprint/references/review-gates.md
@@ -110,6 +110,36 @@ If code quality review finds Critical or Important issues:
 3. Re-run code quality review.
 4. Max 2 fix rounds. If Critical issues remain, mark issue as `DONE_WITH_CONCERNS`.
 
+## Stage 2.5: Pattern Propagation
+
+### Trigger Condition
+
+Run Stage 2.5 when Stage 1 or Stage 2 finds a violation classified as `rule-violation-instance`.
+
+### Classification Heuristic
+
+Classify a violation as `rule-violation-instance` (rather than a one-off bug) when **any** of the following apply:
+
+- The reviewer uses words like "rule", "convention", "pattern", "policy", "violates", "across", "consistently"
+- The same pattern is grep-findable in other in-flight issues' diffs
+- The severity is Important or Critical **and** the issue is structural (not a one-off typo)
+
+### Propagation Procedure
+
+1. For each other in-flight issue that has a PR branch, run:
+   ```
+   git diff origin/<default-branch>...<branch> | grep -n <pattern>
+   ```
+2. Collect all matches across in-flight branches.
+3. Present findings to the user via `AskUserQuestion`:
+   > "Pattern violation `<pattern>` found in N other in-flight PR(s): <list>. What would you like to do?"
+   > Options: Apply fix to all / Select which PRs / Skip propagation
+4. For each approved PR, dispatch a fix subagent to apply the same fix.
+
+### Non-Blocking Rule
+
+Failures in propagation fix subagents do **not** block the original issue from completing. If a propagation fix fails, record it in the sprint summary under the original issue.
+
 ## Review Flow Diagram
 
 ```
@@ -122,8 +152,14 @@ Stage 1: Spec Compliance
               └─ FAIL → DONE_WITH_CONCERNS
   ↓
 Stage 2: Code Quality
-  ├─ PASS (no Critical/Important) → DONE
+  ├─ PASS (no Critical/Important) → Stage 2.5 check
   └─ NEEDS_FIXES → Implementer fixes → Re-review (max 2 rounds)
-              ├─ PASS → DONE
+              ├─ PASS → Stage 2.5 check
               └─ Still Critical → DONE_WITH_CONCERNS
+  ↓
+Stage 2.5: Pattern Propagation (only if rule-violation-instance found)
+  ├─ No rule violations → DONE
+  └─ rule-violation-instance → Scan other in-flight PRs
+              ├─ No matches / user skips → DONE
+              └─ User approves → Dispatch fix subagents → DONE (failures non-blocking)
 ```

--- a/plugins/aoshimash-skills/skills/run-sprint/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/run-sprint/references/review-gates.md
@@ -90,13 +90,13 @@ Dispatch a reviewer subagent with:
 Code Quality Review: <N> issue(s) found
 
 Critical:
-1. [file:line] <description>
+1. [file:line] <description> | Type: rule-violation-instance | one-off-bug
 
 Important:
-1. [file:line] <description>
+1. [file:line] <description> | Type: rule-violation-instance | one-off-bug
 
 Minor:
-1. [file:line] <description>
+1. [file:line] <description> | Type: rule-violation-instance | one-off-bug
 
 Verdict: PASS / NEEDS_FIXES
 ```
@@ -114,7 +114,7 @@ If code quality review finds Critical or Important issues:
 
 ### Trigger Condition
 
-Run Stage 2.5 when Stage 1 or Stage 2 finds a violation classified as `rule-violation-instance`.
+Run Stage 2.5 when Stage 2's output contains any issue with `Type: rule-violation-instance`.
 
 ### Classification Heuristic
 


### PR DESCRIPTION
## Summary

- Add **Stage 2.5: Pattern Propagation** to `review-gates.md` between Stage 2 and the Review Flow Diagram
- Stage 2.5 triggers when a `rule-violation-instance` violation is found in Stage 1 or Stage 2
- Scans other in-flight PR branches with `git diff origin/<default-branch>...<branch> | grep -n <pattern>` and presents results to the user via `AskUserQuestion`
- Propagation fix failures are non-blocking — original issue completes regardless
- Update `SKILL.md` Core Principle #4 and Phase 2 summary to reference Stage 2.5

## Test plan

- [ ] Verify `review-gates.md` has Stage 2.5 section with trigger condition, classification heuristic, propagation procedure, and non-blocking rule
- [ ] Verify Review Flow Diagram includes Stage 2.5 as optional post-Stage-2 step
- [ ] Verify `SKILL.md` Phase 2 bullet lists Stage 2.5 Pattern Propagation
- [ ] Verify `SKILL.md` Core Principle #4 mentions pattern propagation
- [ ] Verify `SKILL.md` is under 500 lines

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/skills/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
