### PR TITLE
Fix pull-requests permission for claude-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- Changed `pull-requests` permission from `read` to `write` in the Claude Code Review workflow
- This was causing 10 permission denials per run, resulting in zero review comments being posted on PRs despite the job completing successfully

## Root Cause
The `claude-code-action` needs `pull-requests: write` to post inline review comments, but the workflow had `pull-requests: read`, silently blocking all comment attempts.

## Test plan
- [ ] Open a new PR and verify `claude-review` job posts actual review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/aoshimash/skills/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
