### PR TITLE
Add GitHub review approval step before merge in review-dependency-prs

### DIFF
--- a/plugins/aoshimash-skills/skills/review-dependency-prs/SKILL.md
+++ b/plugins/aoshimash-skills/skills/review-dependency-prs/SKILL.md
@@ -70,7 +70,7 @@ For each PR, in order, run the full sequence below before starting the next. See
 6. **Present** a risk summary + required work + rollback plan. **Approval gate: never merge without explicit user approval.**
    - **Downtime is first-class.** If the change causes disruption (node reboot, single-replica restart, DB failover, control-plane disruption), require a **prominent, explicit confirmation** spelling out blast radius + expected downtime — even if the plan was batch-approved in Phase 1. Ask about maintenance-window timing.
 7. **Before any irreversible/disruptive apply, confirm a rollback path exists** (etcd snapshot, revert PR, A/B partition, `helm rollback`, DB backup). See [references/verification.md](references/verification.md).
-8. **Merge** using the repo's merge method. Resolve conflicting sibling PRs (close superseded ones, or let the bot rebase).
+8. **Approve, then merge** — submit a GitHub review approval (`gh pr review {pr} --approve`) before calling `gh pr merge`, so branch-protection rules requiring at least one approved review are satisfied. Resolve conflicting sibling PRs (close superseded ones, or let the bot rebase). See [references/platform-github.md](references/platform-github.md).
 9. **main divergence:** if a clean `gh pr update-branch` (merge commit, or `--rebase`) integrates `main` without conflicts, do it **without asking**; if manual conflict resolution is needed, **ask the user**.
 10. **Run/route the pre/post work** per its A/B/C class.
 11. **Document on the PR:** a comment with the manual steps (for humans too) and a closing "applied & verified" comment — only when real steps/risk exist (no spam), in English.

--- a/plugins/aoshimash-skills/skills/review-dependency-prs/references/platform-github.md
+++ b/plugins/aoshimash-skills/skills/review-dependency-prs/references/platform-github.md
@@ -93,6 +93,19 @@ Decision:
 - Any `FAILURE`/`TIMED_OUT`/`CANCELLED` → **do not merge**; investigate and present as a finding.
 - `PENDING`/`IN_PROGRESS` → wait, then re-check.
 
+## Approve before merge
+
+Submit a GitHub review approval after user approval (step 2-5) and before calling `gh pr merge`. This satisfies branch-protection rules requiring at least one approved review:
+
+```bash
+gh pr review {pr} --approve --body "Dependency update reviewed: release notes read, CI green, risk assessed."
+```
+
+Notes:
+- The `--body` is optional but leaves a human-readable audit trail on the PR.
+- GitHub prevents approving your own PRs — for bot-authored PRs (Renovate, Dependabot) this is never an issue.
+- If the repo requires CODEOWNERS or team-based required reviewers, an agent approval may not satisfy the requirement. Check `mergeStateStatus` after approving; if it still shows `BLOCKED`, surface the gap and ask the user to approve manually.
+
 ## Merge (respect the repo merge method)
 
 Phase 0 determined the merge method. Use the matching flag — do not assume squash:

--- a/plugins/aoshimash-skills/skills/review-dependency-prs/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/review-dependency-prs/references/workflow.md
@@ -128,9 +128,16 @@ Present a concise package for the PR:
 
 **Downtime is first-class.** If the change is disruptive — node reboot, single-replica restart, control-plane disruption, DB failover, anything that interrupts service — do not fold it into a routine approval. Surface a **prominent, explicit confirmation** that spells out the blast radius and expected downtime, and ask about maintenance-window timing. This holds **even if the plan was batch-approved in Phase 1** — batch approval covered *order*, not *"yes, take production down now"*.
 
-### 2-6: Merge and main-divergence
+### 2-6: Approve, merge, and main-divergence
 
-On approval, merge using the repo's merge method (2-6 respects what Phase 0 found; see [platform-github.md](platform-github.md)).
+On approval, first submit a GitHub review approval so branch-protection rules requiring at least one approved review are satisfied, then merge using the repo's merge method (see [platform-github.md](platform-github.md) for both commands).
+
+```bash
+gh pr review {pr} --approve --body "Dependency update reviewed: release notes read, CI green, risk assessed."
+gh pr merge {pr} --<method>
+```
+
+If the repo enforces CODEOWNERS or team-based required reviewers that an agent cannot satisfy, surface this and ask the user to approve instead — never bypass a required check.
 
 Resolve conflicting sibling PRs identified in 1-2: close the superseded PR. The survivor may need updating against `main`; the bot will rebase it on its **own schedule**, so if you need it current now, `gh pr update-branch` is the deterministic path.
 


### PR DESCRIPTION
## Summary

- The `review-dependency-prs` skill was missing a `gh pr review --approve` step before calling `gh pr merge`
- On repos with branch protection requiring at least one approved review, this caused `gh pr merge` to fail silently or be blocked
- Added the approve step to all three layers: SKILL.md summary (step 8), workflow.md (step 2-6), and platform-github.md (new "Approve before merge" section)

## Changes

- **SKILL.md**: Updated Phase 2 step 8 from "Merge" to "Approve, then merge" with inline command reference
- **workflow.md**: Renamed section 2-6 and added the approve → merge command sequence plus a CODEOWNERS edge-case note
- **platform-github.md**: Added a new "Approve before merge" section before "Merge" with the `gh pr review --approve` command and notes on bot-authored PRs and CODEOWNERS constraints

## Test plan

- [ ] Verify the approve command appears before merge in SKILL.md step 8
- [ ] Verify workflow.md 2-6 shows the correct two-command sequence (`gh pr review --approve` then `gh pr merge`)
- [ ] Verify platform-github.md new section explains bot-author and CODEOWNERS edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)