### PR TITLE
fix(create-issue): update Task Overview with real issue numbers after sub-issues are created

### DIFF
--- a/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
@@ -121,6 +121,8 @@ For each test case:
   - [ ] Dependencies form a valid DAG
   - [ ] Split proposed via `AskUserQuestion` before any parent/sub-issue is created — never automatic
   - [ ] Local plan/research files are deleted after issue creation
+  - [ ] Parent issue's Task Overview Dependencies column uses real sub-issue numbers (e.g., #259), not plan-local placeholders (e.g., #1)
+  - [ ] Parent issue's Task Overview Task column is updated to `#<number> — <title>` format
 
 ### Case 10: Complex multi-component feature
 
@@ -239,6 +241,8 @@ For each test case:
   - [ ] Maximum depth of 3 levels is respected
   - [ ] `gh issue edit <child> --add-sub-issue <grandchild>` (or platform equivalent) is used to link grandchildren
   - [ ] Final output tree correctly shows parent → child → grandchild
+  - [ ] Parent issue's Task Overview is updated with real child issue numbers after sub-issues are created
+  - [ ] Child issue's Task Overview is updated with real grandchild issue numbers after grandchildren are created
 
 ---
 

--- a/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
@@ -53,9 +53,46 @@ For each task in the plan, create a sub-issue using the **Sub-Issue** template f
 - Acceptance Criteria — from the task
 - Dependencies — `Blocked by: #<issue-number>` for any blocking sub-issues
 
-Create each sub-issue using the platform CLI.
+Create each sub-issue using the platform CLI. As you create each sub-issue, record the mapping from its plan-local index (the `#` column value in the Task Overview table: 1 for the first task, 2 for the second, etc.) to the real issue number assigned by the platform. You will need this mapping in Step 2.5.
 
-**Grandchild issues**: if the user approved a nested split for a task in Step 0 (that task was itself decomposed further), treat that task as a **child that is also a parent**: create it using the Sub-Issue template (with `Parent: #<parent-issue-number>`) plus its own `## Task Overview` table for its grandchildren, then create each grandchild using the Sub-Issue template with `Parent: #<child-issue-number>`. Link grandchildren to the child the same way children are linked to the parent (see platform guide). Maximum depth is 3 levels (parent → child → grandchild) — if a grandchild would still be Large, return to Task Decomposition and redesign instead of nesting further.
+**Grandchild issues**: if the user approved a nested split for a task in Step 0 (that task was itself decomposed further), treat that task as a **child that is also a parent**: create it using the Sub-Issue template (with `Parent: #<parent-issue-number>`) plus its own `## Task Overview` table for its grandchildren, then create each grandchild using the Sub-Issue template with `Parent: #<child-issue-number>`. Link grandchildren to the child the same way children are linked to the parent (see platform guide). Maximum depth is 3 levels (parent → child → grandchild) — if a grandchild would still be Large, return to Task Decomposition and redesign instead of nesting further. For each child-that-is-also-a-parent, maintain a separate local-to-real mapping for its grandchildren, to be used in Step 2.5.
+
+### 2.5. Update Task Overview Tables
+
+After all sub-issues (and grandchild issues) are created, the plan-local placeholder references in Task Overview tables must be replaced with real issue numbers. Platforms like GitHub auto-link any `#N` in issue bodies — leaving plan-local numbers like `#1` causes them to link to unrelated issues that happen to hold those numbers in the repository.
+
+**Parent issue update:**
+
+Using the local-to-real mapping collected in Step 2:
+
+1. Fetch the current parent issue body (e.g., `gh issue view <number> --json body -q '.body'`).
+2. In the `## Task Overview` table:
+   - **Task column**: prepend the real issue reference to each title — change `<title>` to `#<real-number> — <title>`
+   - **Dependencies column**: replace each plan-local reference (`#1`, `#2`, etc.) with the corresponding real issue number (`#259`, `#260`, etc.)
+   - Replace only within the Task Overview table rows — do not modify other sections of the body (e.g., References, Background).
+3. Update the parent issue body using the platform CLI (e.g., `gh issue edit <parent-number> --body "$(updated body)"`).
+
+Example — before (plan-local numbers):
+
+| # | Task | Dependencies | Size |
+|---|------|--------------|------|
+| 1 | Add pg_trgm index | — | Small |
+| 2 | Create search endpoint | #1 | Medium |
+| 3 | Add search UI | #1 | Small |
+| 4 | Add integration tests | #2, #3 | Medium |
+
+Example — after (real issue numbers #259–#262):
+
+| # | Task | Dependencies | Size |
+|---|------|--------------|------|
+| 1 | #259 — Add pg_trgm index | — | Small |
+| 2 | #260 — Create search endpoint | #259 | Medium |
+| 3 | #261 — Add search UI | #259 | Small |
+| 4 | #262 — Add integration tests | #260, #261 | Medium |
+
+**Grandchild case:**
+
+If any child issue was itself decomposed into grandchild issues and has its own `## Task Overview` table, apply the same update to that child issue's body after all its grandchildren are created, using the grandchild local-to-real mapping collected for that child in Step 2.
 
 ### 3. Link Issues to Their Parent
 

--- a/plugins/aoshimash-skills/skills/create-issue/references/templates.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/templates.md
@@ -231,6 +231,8 @@ Used in the Design Flow to represent an entire feature/initiative that has been 
 <!-- Links to related issues, docs, or external resources -->
 ```
 
+> **Note**: The Task Overview table is written with plan-local numbers at creation time (`#1`, `#2`, etc. in the Dependencies column). Step 2.5 of [issue-creation.md](issue-creation.md) updates the table with real issue numbers after sub-issues are created.
+
 ---
 
 ## Sub-Issue


### PR DESCRIPTION
## Summary

- Add Step 2.5 to `issue-creation.md` that updates the parent issue's Task Overview table after all sub-issues are created, replacing plan-local placeholder references (`#1`, `#2`, etc.) with real issue numbers
- Handle the grandchild case: child issues with their own Task Overview are also updated after their grandchildren are created
- Add a note to the Parent Issue template in `templates.md` pointing to Step 2.5
- Add verification items to eval cases 9 and 17

Closes #55

## Changes

- `references/issue-creation.md`: Added mapping-tracking instruction in Step 2; added new Step 2.5 with before/after examples covering the grandchild case
- `references/templates.md`: Added a note outside the code block explaining that Step 2.5 updates the table with real issue numbers
- `references/eval-cases.md`: Added two verification items to Case 9 (simple feature design) and two to Case 17 (nested split/grandchild)

## Test Plan

- [ ] Design Flow end-to-end produces a parent issue whose Task Overview Dependencies column has real sub-issue numbers (e.g., `#259`), not plan-local placeholders (`#1`, `#2`)
- [ ] Task column in parent issue's Task Overview is updated to `#<number> — <title>` format
- [ ] In the grandchild case, child issue's Task Overview is also updated with real grandchild numbers