### PR TITLE
create-issue: gate issue creation on primary-source verification of external-software claims

### DIFF
--- a/plugins/aoshimash-skills/skills/create-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/create-issue/SKILL.md
@@ -143,6 +143,7 @@ Before showing the draft to the user, evaluate it against all criteria below.
 
 - If a criterion fails due to **missing information from the user** → return to Step L2 and ask a targeted follow-up question. Do not guess or fill in gaps.
 - If a criterion fails due to **draft wording or structure** → revise the draft silently and re-evaluate.
+- If a criterion fails due to an **unverified external-software claim** → fetch the primary source (official docs, or the actual source/config/values file) to verify or correct the claim; if it cannot be cheaply verified, mark it as an assumption (e.g., "TBD", "unverified") instead of stating it as fact. Then re-evaluate.
 - Only present the draft after all checks pass.
 
 | # | Criterion | Pass condition |
@@ -156,6 +157,7 @@ Before showing the draft to the user, evaluate it against all criteria below.
 | 7 | **Proposal is unambiguous** | Two different engineers reading the Proposal would agree on what the desired end state is. If multiple interpretations are possible, the information is insufficient |
 | 8 | **Criteria are independently verifiable** | Each acceptance criterion has a clear binary outcome: it either passes or fails. No criterion requires subjective judgment |
 | 9 | **Self-contained** | A person or AI with zero prior context can read the issue and begin implementation without asking any clarifying questions |
+| 10 | **External facts verified** | Every precise, actionable claim about external/third-party software in the draft (default value, version constraint, config key name, required component/extension, licensing) is either verified against a primary source fetched this session, or explicitly marked as an assumption. Claims already verified against a primary source fetched during this session (e.g., in codebase/dependency research) don't need re-verification |
 
 ### L6: Create the Issue
 
@@ -218,12 +220,13 @@ See [references/issue-creation.md](references/issue-creation.md) for the detaile
 
 **Summary:**
 
-1. Confirm the Split Proposal (see below) — this is a separate, explicit gate even after the plan itself is approved.
-2. Create the **parent issue** from the plan's goal and design decisions section (or a single issue, if the user declined the split).
-3. Create **sub-issues** (and grandchild issues, if a nested split was approved) from each task in the plan.
-4. Link issues to their parent and establish dependency links between siblings.
-5. Clean up: delete the plan file and research file. The issues now hold all information.
-6. Return the parent issue URL and the list of sub-issue (and grandchild) URLs, as an ASCII tree.
+1. Fact-check external-software claims that will appear in the issue bodies against primary sources (or mark unverifiable ones as assumptions) before creating anything.
+2. Confirm the Split Proposal (see below) — this is a separate, explicit gate even after the plan itself is approved.
+3. Create the **parent issue** from the plan's goal and design decisions section (or a single issue, if the user declined the split).
+4. Create **sub-issues** (and grandchild issues, if a nested split was approved) from each task in the plan.
+5. Link issues to their parent and establish dependency links between siblings.
+6. Clean up: delete the plan file and research file. The issues now hold all information.
+7. Return the parent issue URL and the list of sub-issue (and grandchild) URLs, as an ASCII tree.
 
 ## Split Proposal
 

--- a/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
@@ -7,7 +7,7 @@ For each test case:
 2. Trigger the create-issue skill
 3. Provide the user input described in the test case
 4. Respond to follow-up questions as described in the persona
-5. Evaluate the generated issue draft against the 9 quality criteria in Step L5 (Lightweight Flow) or the Split Proposal criteria (Design Flow)
+5. Evaluate the generated issue draft against the 10 quality criteria in Step L5 (Lightweight Flow) or the Split Proposal criteria (Design Flow)
 6. Record which flow (Lightweight/Design) was chosen and whether it matched the expectation
 7. Record results in the Evaluation Log section at the bottom
 
@@ -240,6 +240,35 @@ For each test case:
   - [ ] `gh issue edit <child> --add-sub-issue <grandchild>` (or platform equivalent) is used to link grandchildren
   - [ ] Final output tree correctly shows parent → child → grandchild
 
+## External Fact Verification Cases (new)
+
+### Case 18: Plausible-but-wrong external default (Lightweight Flow)
+
+- **Persona**: DevOps engineer describing a Helm chart deployment
+- **Initial input**: "We want to enable the built-in cache that ships with the `example-chart` Helm chart — it should already be running by default, we just need to configure it."
+- **Setup**: The chart's actual `values.yaml` (available for the tester to check, e.g. a local `values.yaml` with `cache.enabled: false`) shows the cache is disabled by default — the opposite of what the user's phrasing implies.
+- **Expected behavior**:
+  - Skill does not restate "enabled by default" as fact in the Background/Proposal without checking a primary source
+  - Skill fetches/reads the actual `values.yaml` (or equivalent primary source) before finalizing the draft, or — if no primary source is reachable in the test — marks the default-enabled claim as "unverified" instead of asserting it
+  - Step L5 criterion 10 blocks presentation of a draft that states the wrong default as fact
+- **Key criteria to watch**: #10 (External facts verified), #5 (Non-obvious context — must be correct, not just present)
+
+### Case 19: Plan carries unverified facts into Design Flow issue creation
+
+- **Persona**: Platform engineer designing a self-hosted app deployment (mirrors a real incident: aoshimash/homelab-k8s#258–#260)
+- **Setup**: D1 Research and D2 Design produce a plan whose task Background/Approach sections state three external-software claims from memory/search snippets, not from a primary source read this session:
+  1. "The Helm chart bundles the cache dependency by default" (actually `false` in the chart's `values.yaml`)
+  2. An acceptance criterion requiring a component that no longer exists in the current version of the target software
+  3. A "required Postgres extensions" list that is missing one required extension
+- **Expected behavior**:
+  - At D4 Step 0 (Fact-Check External Claims), before any issue is created, the skill identifies these three claims as precise/actionable external-software facts
+  - For each, it fetches a primary source (official docs, actual chart `values.yaml`/source) this session and corrects the claim, or — if unable to verify — marks it explicitly as an assumption ("TBD"/"unverified") rather than stating it as fact
+  - No issue is created until the gate is resolved (verified or explicitly marked)
+- **Verification**:
+  - [ ] All three claims are either corrected against a primary source or marked as assumptions before `gh issue create` (or platform equivalent) runs
+  - [ ] The gate does not re-verify unrelated codebase facts already grounded via direct file reads in D1 Research
+  - [ ] No issue is created with a stated-as-fact external claim that wasn't verified this session
+
 ---
 
 ## Evaluation Log
@@ -255,3 +284,4 @@ Record results here after each evaluation run.
 | 2026-03-05 | 5 | 1,2,3,4,5,6,7,8,9 | — | Clean pass. "Sometimes" narrowed to "6+ items on Chrome" through 5 follow-up questions. | No |
 | 2026-03-05 | 6 | 1,2,3,4,5,6,7,9 | 8 | "Response within 24h" is an operational goal, not an implementation criterion. | Yes — added operational vs implementation criteria separation to Step 3 |
 | 2026-07-05 | — | — | — | Merged design-sprint into create-issue: added adaptive Lightweight/Design flow routing, Split Proposal gate, and cases 9-17 (9-13 renumbered from design-sprint, 14-17 new). Case numbering for 1-8 preserved from the original create-issue log above. | — |
+| 2026-07-08 | — | — | — | Added criterion 10 (External facts verified) to Lightweight Flow L5 and a Fact-Check External Claims gate (D4 Step 0) to Design Flow, per issue #54 (real-world incident: aoshimash/homelab-k8s#258–260). Added Cases 18-19. | — |

--- a/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
@@ -284,4 +284,4 @@ Record results here after each evaluation run.
 | 2026-03-05 | 5 | 1,2,3,4,5,6,7,8,9 | — | Clean pass. "Sometimes" narrowed to "6+ items on Chrome" through 5 follow-up questions. | No |
 | 2026-03-05 | 6 | 1,2,3,4,5,6,7,9 | 8 | "Response within 24h" is an operational goal, not an implementation criterion. | Yes — added operational vs implementation criteria separation to Step 3 |
 | 2026-07-05 | — | — | — | Merged design-sprint into create-issue: added adaptive Lightweight/Design flow routing, Split Proposal gate, and cases 9-17 (9-13 renumbered from design-sprint, 14-17 new). Case numbering for 1-8 preserved from the original create-issue log above. | — |
-| 2026-07-08 | — | — | — | Added criterion 10 (External facts verified) to Lightweight Flow L5 and a Fact-Check External Claims gate (D4 Step 0) to Design Flow, per issue #54 (real-world incident: aoshimash/homelab-k8s#258–260). Added Cases 18-19. | — |
+| 2026-07-08 | — | — | — | Added criterion 10 (External facts verified) to Lightweight Flow L5 and a Fact-Check External Claims gate (D4 Step 0) to Design Flow, per issue #54 (real-world incident: aoshimash/homelab-k8s#258–#260). Added Cases 18-19. | — |

--- a/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
@@ -6,7 +6,19 @@ This procedure is used in the **Design Flow** (see SKILL.md Step 2) to convert t
 
 ## Procedure
 
-### 0. Confirm the Split Proposal
+### 0. Fact-Check External Claims
+
+Scope: only claims about external/third-party software that will actually appear in the parent issue or sub-issue bodies about to be created — not everything read during D1 Research.
+
+Before drafting or creating any issue, scan the plan's content (Background, Approach, and Acceptance Criteria for the parent and every task) for precise, actionable claims about external/third-party software: default values, version constraints, config key names, required components/extensions, licensing. For each such claim:
+
+- If it was already verified against a primary source (official docs, or the actual source/config/values file) fetched during this session, leave it as-is.
+- Otherwise, fetch the primary source and confirm or correct the claim before it goes into an issue body.
+- If it cannot be cheaply verified, state it explicitly as an assumption (e.g., "TBD", "unverified") in the issue body rather than as fact.
+
+General codebase facts already grounded via direct file reads (e.g., in D1 Research) are out of scope — this step targets claims about external/third-party software specifically, since those are the ones most likely to be wrong from memory or search snippets. Do not re-verify the entire research file; check only what will land in an issue body.
+
+### 1. Confirm the Split Proposal
 
 Splitting is always a user-confirmed proposal, never automatic — even after the annotation cycle is approved. Before creating anything, present the plan's `## Split Proposal` section (see SKILL.md "Split Proposal" for the criteria) as an ASCII tree with sizes and dependencies, for example:
 
@@ -22,13 +34,13 @@ Proposed hierarchy:
 ```
 
 Then use `AskUserQuestion`:
-- **Create parent + sub-issues** (mark "(Recommended)" when 2+ tasks are independently implementable and reviewable) — proceed to Step 1.
-- **Create a single issue** — skip the hierarchy. Compose ONE issue using the Feature Request or Technical Task template from [templates.md](templates.md), with the plan's Goal as Motivation/Proposal and the task breakdown included as a `## Task Breakdown` section (titles, files, approach, AC per task, as subsections). Then go directly to Step 4 (Clean Up).
+- **Create parent + sub-issues** (mark "(Recommended)" when 2+ tasks are independently implementable and reviewable) — proceed to Step 2.
+- **Create a single issue** — skip the hierarchy. Compose ONE issue using the Feature Request or Technical Task template from [templates.md](templates.md), with the plan's Goal as Motivation/Proposal and the task breakdown included as a `## Task Breakdown` section (titles, files, approach, AC per task, as subsections). Then go directly to Step 5 (Clean Up).
 - **Adjust the breakdown** — return to the Design phase's Task Decomposition step with the user's feedback, then re-present this gate.
 
 Do NOT create parent/sub-issues, or grandchild issues, without this explicit confirmation.
 
-### 1. Create the Parent Issue
+### 2. Create the Parent Issue
 
 The parent issue represents the entire feature/initiative. Compose it using the **Parent Issue** template from [templates.md](templates.md), filled in from the plan:
 
@@ -41,7 +53,7 @@ The parent issue represents the entire feature/initiative. Compose it using the 
 
 Create the parent issue using the platform CLI. Record the issue number.
 
-### 2. Create Sub-Issues
+### 3. Create Sub-Issues
 
 For each task in the plan, create a sub-issue using the **Sub-Issue** template from [templates.md](templates.md):
 
@@ -55,9 +67,9 @@ For each task in the plan, create a sub-issue using the **Sub-Issue** template f
 
 Create each sub-issue using the platform CLI.
 
-**Grandchild issues**: if the user approved a nested split for a task in Step 0 (that task was itself decomposed further), treat that task as a **child that is also a parent**: create it using the Sub-Issue template (with `Parent: #<parent-issue-number>`) plus its own `## Task Overview` table for its grandchildren, then create each grandchild using the Sub-Issue template with `Parent: #<child-issue-number>`. Link grandchildren to the child the same way children are linked to the parent (see platform guide). Maximum depth is 3 levels (parent → child → grandchild) — if a grandchild would still be Large, return to Task Decomposition and redesign instead of nesting further.
+**Grandchild issues**: if the user approved a nested split for a task in Step 1 (that task was itself decomposed further), treat that task as a **child that is also a parent**: create it using the Sub-Issue template (with `Parent: #<parent-issue-number>`) plus its own `## Task Overview` table for its grandchildren, then create each grandchild using the Sub-Issue template with `Parent: #<child-issue-number>`. Link grandchildren to the child the same way children are linked to the parent (see platform guide). Maximum depth is 3 levels (parent → child → grandchild) — if a grandchild would still be Large, return to Task Decomposition and redesign instead of nesting further.
 
-### 3. Link Issues to Their Parent
+### 4. Link Issues to Their Parent
 
 After all sub-issues (and any grandchild issues) are created, establish the hierarchy:
 
@@ -67,7 +79,7 @@ After all sub-issues (and any grandchild issues) are created, establish the hier
 
 Also establish dependency links between sibling issues where specified.
 
-### 4. Clean Up Local Files
+### 5. Clean Up Local Files
 
 Delete the temporary plan and research files:
 
@@ -78,7 +90,7 @@ rm <plan-dir>/research-<topic-slug>.md
 
 If the plan directory is now empty, delete it too (unless it's a permanent project directory like `docs/plans/`).
 
-### 5. Return Result
+### 6. Return Result
 
 Output:
 - Parent issue URL (or the single issue URL, if the user declined the split)


### PR DESCRIPTION
## Summary
- Add criterion 10 (**External facts verified**) to the Lightweight Flow's L5 self-evaluation checklist: precise, actionable claims about external/third-party software (default values, version constraints, config key names, required components/extensions, licensing) must be verified against a primary source fetched this session, or explicitly marked as an assumption ("TBD"/"unverified") before the draft can be presented.
- Add a new **Step 0: Fact-Check External Claims** to the Design Flow's `issue-creation.md` (D4), gating issue creation on the same check — renumbered the existing steps 0-5 to 1-6 accordingly and fixed all internal cross-references (`Step 4 (Clean Up)` → `Step 5`, etc.).
- Scoped both checks explicitly: only claims that will actually appear in the issue body, only precise/actionable facts, and only claims not already verified from a primary source this session — general codebase facts already grounded via direct file reads remain out of scope.
- Added `eval-cases.md` Case 18 (Lightweight Flow) and Case 19 (Design Flow), the latter modeled directly on the incident referenced in the issue (a Helm chart default, a nonexistent component, and an incomplete extension list all shipped unverified via the Design Flow).

Closes #54

## Changes
- `plugins/aoshimash-skills/skills/create-issue/SKILL.md`
- `plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md`
- `plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md`

## Test Plan
- [x] Diff self-reviewed for internal consistency (step-number cross-references across all files in `create-issue/`, criteria-table formatting, eval-case format)
- [x] Verified all 4 acceptance criteria of #54 are satisfied by the diff
- [ ] Run eval Cases 18-19 in a live session per `references/eval-cases.md`'s "How to Run" procedure and record results in the Evaluation Log