### PR TITLE
Add agent-portability guidelines (AGENTS.md/CLAUDE.md/README)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+This is the canonical, agent-neutral guide for this repository. It provides
+guidance to coding agents (and humans) working with code here.
+
+## Overview
+
+This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aoshimash-skills`) that bundles skills for Claude Code.
+
+## Architecture
+
+- `.claude-plugin/marketplace.json` — Marketplace manifest (lists available plugins)
+- `plugins/aoshimash-skills/.claude-plugin/plugin.json` — Plugin manifest
+- `plugins/aoshimash-skills/skills/<skill-name>/` — Individual skills, each with a `SKILL.md` and optional `references/`, `scripts/`, `assets/`
+
+## Skill Development
+
+Skills follow the [skill-creator](https://github.com/anthropics/skills) best practices:
+
+- `SKILL.md` is the required entry point. Frontmatter has `name` and `description`; add `compatibility` ONLY when the skill inherently requires a specific product (per the [Agent Skills spec](https://agentskills.io/specification), most skills must not need it).
+- Use imperative/infinitive form in SKILL.md body.
+- Keep SKILL.md under 500 lines. Split detailed content into `references/` files.
+- Each skill should have eval test cases in `references/eval-cases.md`. Run them after changes and record results in the evaluation log.
+
+## Agent Portability
+
+Skills in this repository target any agent implementing the [Agent Skills spec](https://agentskills.io/specification), not only Claude Code.
+
+**Guiding principle: agent-agnostic baseline, tool-native maximum.** Every skill must be fully usable by any compliant agent using only baseline capabilities, while still taking advantage of a specific agent's native tools where they exist.
+
+Rules:
+
+- Never prescribe a product-specific tool name as the only way to do something. Describe the capability the step needs, then map it to a native tool as an example.
+- No `.claude/` paths (or other product-specific paths) inside skill instructions.
+- Product-specific advice goes in "On Claude Code, …" conditional notes, so other agents can skip it.
+- Every capability a skill uses appears in that skill's Environment Adaptation section.
+
+Canonical Environment Adaptation template — instantiate it per skill with only the capabilities that skill actually uses:
+
+```markdown
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark results `SELF-REVIEWED` |
+| **Background execution** — run long commands without blocking | Background shell (e.g. Claude Code's background Bash) | Run commands sequentially |
+```
+
+Neutral vocabulary — use the capability term in skill instructions; reserve product-specific names for the example column above and for "On Claude Code, …" notes:
+
+| Product-specific term | Neutral capability term |
+|---|---|
+| subagent / Task tool | separate agent instance (fresh context) |
+| `AskUserQuestion` | user choice |
+| background Bash | background execution |
+| plan mode | (no neutral equivalent — use only inside "On Claude Code, …" notes) |
+
+## Git Conventions
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`, `chore:`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ guidance to coding agents (and humans) working with code here.
 
 ## Overview
 
-This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aoshimash-skills`) that bundles skills for Claude Code.
+This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aoshimash-skills`) that bundles Agent Skills, distributed as a Claude Code plugin.
 
 ## Architecture
 
@@ -17,7 +17,7 @@ This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aosh
 
 Skills follow the [skill-creator](https://github.com/anthropics/skills) best practices:
 
-- `SKILL.md` is the required entry point. Frontmatter has `name` and `description`; add `compatibility` ONLY when the skill inherently requires a specific product (per the [Agent Skills spec](https://agentskills.io/specification), most skills must not need it).
+- `SKILL.md` is the required entry point. Frontmatter requires `name` and `description`; `compatibility` is allowed to declare a genuine environment requirement — an intended product, required CLIs/system packages, or network access (e.g. `Requires git, docker, jq, and access to the internet`). Add it only when truly needed: per the [Agent Skills spec](https://agentskills.io/specification), most skills do not need it.
 - Use imperative/infinitive form in SKILL.md body.
 - Keep SKILL.md under 500 lines. Split detailed content into `references/` files.
 - Each skill should have eval test cases in `references/eval-cases.md`. Run them after changes and record results in the evaluation log.
@@ -28,14 +28,16 @@ Skills in this repository target any agent implementing the [Agent Skills spec](
 
 **Guiding principle: agent-agnostic baseline, tool-native maximum.** Every skill must be fully usable by any compliant agent using only baseline capabilities, while still taking advantage of a specific agent's native tools where they exist.
 
+**Exemption for product-bound skills.** A skill that declares a product in its `compatibility` frontmatter is exempt from the baseline-usability requirement above and MAY omit the Environment Adaptation section. The remaining rules still apply to it wherever they are meaningful.
+
 Rules:
 
 - Never prescribe a product-specific tool name as the only way to do something. Describe the capability the step needs, then map it to a native tool as an example.
-- No `.claude/` paths (or other product-specific paths) inside skill instructions.
+- No `.claude/` paths (or other product-specific paths) inside skill instructions, except (a) inside "On Claude Code, …" conditional notes, or (b) in a skill that declares that product in its `compatibility` frontmatter.
 - Product-specific advice goes in "On Claude Code, …" conditional notes, so other agents can skip it.
 - Every capability a skill uses appears in that skill's Environment Adaptation section.
 
-Canonical Environment Adaptation template — instantiate it per skill with only the capabilities that skill actually uses:
+Canonical Environment Adaptation template — place it in each `SKILL.md` immediately after the intro/principles and before the workflow sections, instantiated with only the capabilities that skill actually uses:
 
 ```markdown
 ## Environment Adaptation
@@ -46,7 +48,7 @@ below use capability terms; map them to your environment as follows.
 | Capability | With native support (example) | Fallback |
 |---|---|---|
 | **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
-| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark results `SELF-REVIEWED` |
+| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body or reply comment the step produces) |
 | **Background execution** — run long commands without blocking | Background shell (e.g. Claude Code's background Bash) | Run commands sequentially |
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+@AGENTS.md
 
-## Overview
-
-This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aoshimash-skills`) that bundles skills for Claude Code.
-
-## Architecture
-
-- `.claude-plugin/marketplace.json` — Marketplace manifest (lists available plugins)
-- `plugins/aoshimash-skills/.claude-plugin/plugin.json` — Plugin manifest
-- `plugins/aoshimash-skills/skills/<skill-name>/` — Individual skills, each with a `SKILL.md` and optional `references/`, `scripts/`, `assets/`
-
-## Skill Development
-
-Skills follow the [skill-creator](https://github.com/anthropics/skills) best practices:
-
-- `SKILL.md` is the required entry point. Frontmatter has `name` and `description` only.
-- Use imperative/infinitive form in SKILL.md body.
-- Keep SKILL.md under 500 lines. Split detailed content into `references/` files.
-- Each skill should have eval test cases in `references/eval-cases.md`. Run them after changes and record results in the evaluation log.
-
-## Git Conventions
-
-- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`, `chore:`)
+Canonical repository guidance lives in AGENTS.md (agent-neutral). This file
+exists so Claude Code loads it automatically.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aoshimash/skills
 
-Personal Claude Code skills collection, packaged as a Plugin for easy installation.
+Personal [Agent Skills](https://agentskills.io) collection. Distributed as a Claude Code plugin, but each skill under `plugins/aoshimash-skills/skills/` is a plain Agent Skills directory usable by any compliant agent.
 
 ## Installation
 
@@ -15,6 +15,10 @@ Personal Claude Code skills collection, packaged as a Plugin for easy installati
 ```
 /plugin install aoshimash-skills@aoshimash-skills
 ```
+
+### Using with other agents
+
+The plugin is only one distribution channel. Each skill under `plugins/aoshimash-skills/skills/` is a plain [Agent Skills](https://agentskills.io) directory (a `SKILL.md` plus optional `references/`, `scripts/`, `assets/`), so any agent implementing the Agent Skills spec can use one directly — point your agent at, or copy, the skill directory.
 
 ## Issue Workflow
 

--- a/plugins/aoshimash-skills/.claude-plugin/plugin.json
+++ b/plugins/aoshimash-skills/.claude-plugin/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "aoshimash-skills",
-  "description": "Personal Claude Code skills by Shuji Aoshima"
+  "description": "Personal agent skills by Shuji Aoshima"
 }


### PR DESCRIPTION
## Summary
- Create `AGENTS.md` as the canonical agent-neutral repo guide (Overview, Architecture, Skill Development, Agent Portability, Git Conventions).
- Reduce `CLAUDE.md` to an `@AGENTS.md` import so Claude Code still auto-loads guidance.
- Reposition `README.md` and `plugin.json` so the collection reads as agent-neutral, distributed via a Claude Code plugin.

Closes #59

## Changes
- **`AGENTS.md`** (new): Overview + Architecture moved verbatim from `CLAUDE.md`; Skill Development with the frontmatter rule amended to allow the Agent Skills spec's optional `compatibility` field (most skills must not need it); new **Agent Portability** section — guiding principle (agent-agnostic baseline, tool-native maximum), rules, the canonical Environment Adaptation template, and a neutral-vocabulary table; Git Conventions.
- **`CLAUDE.md`**: reduced to the `@AGENTS.md` import plus a one-line explanation.
- **`README.md`**: tagline repositioned as an [Agent Skills](https://agentskills.io) collection distributed as a Claude Code plugin; added a "Using with other agents" subsection pointing at `plugins/aoshimash-skills/skills/` as plain Agent Skills directories.
- **`plugins/aoshimash-skills/.claude-plugin/plugin.json`**: description "Personal Claude Code skills…" → "Personal agent skills by Shuji Aoshima".

## Notes
- The `compatibility` frontmatter claim was verified against the primary source (https://agentskills.io/specification): it is an optional field (max 500 chars) for environment requirements, and the spec explicitly notes "Most skills do not need the `compatibility` field."
- Per the issue's Implementation Approach, Overview & Architecture were moved verbatim; the Overview still describes the repo as a Claude Code Plugin Marketplace repository, which is accurate for the distribution channel.

## Test Plan
- [x] `AGENTS.md` contains Overview, Skill Development (amended frontmatter rule), Agent Portability (principle + template + vocabulary), Git Conventions.
- [x] `CLAUDE.md` contains only the `@AGENTS.md` import and a one-line explanation.
- [x] `README.md` no longer describes the collection as Claude Code-only and documents the plain-directory usage path.
- [x] `plugin.json` description does not name Claude Code.