### PR TITLE
Convert review-dependency-prs user gate to capability wording

### DIFF
--- a/plugins/aoshimash-skills/skills/review-dependency-prs/SKILL.md
+++ b/plugins/aoshimash-skills/skills/review-dependency-prs/SKILL.md
@@ -30,6 +30,15 @@ The hard-won lesson behind the serial rule: on 2026-05-04 a homelab cluster bump
 5. **Minimal autonomy / surface-don't-fix.** Tangential improvements (doc fixes, cleanup, config tidy-ups) are surfaced as proposals, never done unprompted. Doc drift you notice is reported, not silently corrected.
 6. **Document on the PR.** Manual steps and a closing "applied & verified" result go on the PR itself so humans and future agents see them. Comment only when there are real steps or risk — no spam.
 
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+
 ## Workflow
 
 ### Phase 0: Discover repo conventions (once per run)

--- a/plugins/aoshimash-skills/skills/review-dependency-prs/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/review-dependency-prs/references/workflow.md
@@ -71,7 +71,7 @@ Optionally offer to scope the set: security-only, skip majors, only a subset of 
 
 ### 1-4: Hard Gate — approve the plan
 
-Present the triaged plan + order and ask (via `AskUserQuestion`): **Approve / Reorder / Scope down / Abort**.
+Present the triaged plan + order and ask the user to choose (see Environment Adaptation in SKILL.md): **Approve / Reorder / Scope down / Abort**.
 
 Approving the *plan* is a batch approval of *what* will be processed and in *what order*. It does **not** authorize any merge — each PR still hits its own approval gate at step 2-5. This is how the skill honors minimal-autonomy without forcing a separate conversation for every trivial digest bump.
 


### PR DESCRIPTION
## Summary
- Converts review-dependency-prs's single `AskUserQuestion` site to capability-based wording so the skill is usable by any agent implementing the Agent Skills spec.
- Adds a minimal Environment Adaptation section (User choice only) instantiated from the canonical AGENTS.md template.

Closes #63

## Changes
- `plugins/aoshimash-skills/skills/review-dependency-prs/SKILL.md` — add an Environment Adaptation section with only the **User choice** capability row, placed after Core Principles and before the Workflow sections.
- `plugins/aoshimash-skills/skills/review-dependency-prs/references/workflow.md` — rewrite the Phase 1-4 Hard Gate (L74) to use capability wording ("ask the user to choose (see Environment Adaptation in SKILL.md)") instead of naming `AskUserQuestion`.

## Test Plan
- [x] `grep -r AskUserQuestion plugins/aoshimash-skills/skills/review-dependency-prs` returns only the Environment Adaptation example row (SKILL.md).
- [x] Gate at workflow.md L74 uses capability wording and points to the Environment Adaptation section.
- [x] No other product-specific tool references remain in the skill (checked for `EnterPlanMode`, `Task tool`, `subagent`, background Bash, `.claude/` paths).