### PR TITLE
Convert create-issue user gates to capability-based wording

### DIFF
--- a/plugins/aoshimash-skills/skills/create-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/create-issue/SKILL.md
@@ -30,6 +30,15 @@ Create issues on any issue tracking platform, always grounded in codebase analys
 - **Hard gates** (Design Flow): Do not proceed to the next phase without explicit user approval.
 - **Splitting is a proposal, never automatic**: Whether to create a parent + sub-issues (or nested grandchild issues) is always confirmed with the user. Default to a single issue when in doubt.
 
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+
 ## Step 1: Detect Platform
 
 Determine the issue tracking platform in this order:
@@ -54,11 +63,11 @@ Default to the **Lightweight Flow**. Escalate to the **Design Flow** when ANY of
 4. **Not one-PR-sized** — the work clearly cannot land as a single reviewable PR (heuristic: multiple deliverables that could ship independently, or more than roughly 1-2 days of work).
 5. **Diverging scope** — during information gathering (Lightweight Step L2), scope questions keep multiplying instead of converging.
 
-If the signals are weak or conflicting, ask the user directly via `AskUserQuestion`:
+If the signals are weak or conflicting, ask the user to choose (see Environment Adaptation):
 - "Quick single issue" → Lightweight Flow
 - "Full design flow (research → design → annotation cycle → issue hierarchy)" → Design Flow
 
-**Mid-flight escalation**: if Lightweight Flow's codebase analysis (Step L3) reveals criteria 2-4, stop and state what was found, then propose switching to the Design Flow via `AskUserQuestion`. Never escalate silently.
+**Mid-flight escalation**: if Lightweight Flow's codebase analysis (Step L3) reveals criteria 2-4, stop and state what was found, then propose switching to the Design Flow as a user choice (see Environment Adaptation). Never escalate silently.
 
 **De-escalation**: if the Design Flow's research (Step D1) shows the work fits comfortably in one issue, say so and finish via the Lightweight Flow's draft/self-eval/create steps (L4-L6) instead of forcing a hierarchy. Never force a hierarchy the work doesn't need.
 
@@ -83,7 +92,7 @@ Include platform-specific types (e.g., Operation for Backlog) in the options whe
 
 ### L2: Gather Information
 
-Collect information through conversation using natural, plain-language questions. Use AskUserQuestion when presenting choices.
+Collect information through conversation using natural, plain-language questions. When presenting choices, ask the user to choose (see Environment Adaptation).
 
 **Fast path**: If the user's initial message already provides clear motivation, desired outcome, and enough detail to generate verifiable acceptance criteria, skip the step-by-step questions below and proceed directly to generating AC (without confirming it yet — see Step L3).
 
@@ -113,7 +122,7 @@ If, during this step, the scope keeps expanding rather than converging (criterio
 
 **Assignees**: Check CLAUDE.md for default assignee configuration (e.g., "always self-assign"). If defaults are configured, apply them without asking. If not, ask the user: assign to yourself, someone else, or no one. If someone else, fetch the available assignees (e.g., `gh api repos/{owner}/{repo}/assignees`) and let the user choose.
 
-When both labels and assignees need user input (no defaults configured for either), combine them into a single AskUserQuestion call instead of asking separately.
+When both labels and assignees need user input, present them as a single combined choice instead of asking separately.
 
 ### L3: Analyze Codebase
 
@@ -182,7 +191,7 @@ See [references/research.md](references/research.md) for the detailed procedure.
 1. Investigate the codebase deeply — related files, architecture patterns, conventions, dependencies, test patterns, CLAUDE.md rules, recent git history.
 2. Write findings to `<plan-dir>/research-<topic-slug>.md`. Include: relevant file paths, current architecture, conventions, constraints, dependencies, and potential risks.
 3. Present the research file to the user.
-4. **Hard Gate:** Use `AskUserQuestion` — "Review the research file and confirm it captures the relevant context" with options: Approve / Add notes / Abort. If the user adds notes, update the research file and re-present.
+4. **Hard Gate:** Ask the user to choose (see Environment Adaptation): "Review the research file and confirm it captures the relevant context" — Approve / Add notes / Abort. If the user adds notes, update the research file and re-present.
 
 If research reveals the work fits comfortably in one issue, apply the "De-escalation" rule from Step 2 and finish via the Lightweight Flow instead of continuing to D2.
 
@@ -193,7 +202,7 @@ See [references/design.md](references/design.md) for the detailed procedure.
 **Summary:**
 
 1. Ask clarifying questions **one at a time** to understand the feature's goals, constraints, and scope. Use the research findings to ask informed questions.
-2. When 2+ valid approaches exist, propose each with trade-offs and a recommendation. Use `AskUserQuestion` with numbered options. Wait for the user's choice.
+2. When 2+ valid approaches exist, propose each with trade-offs and a recommendation. Ask the user to choose (see Environment Adaptation) with numbered options. Wait for the user's choice.
 3. Break the work into tasks (title, purpose, files, approach with code examples, acceptance criteria, dependencies, estimated size).
 4. Each task must pass the **"boring implementation" test**: can someone implement it by following the instructions mechanically, with zero design judgment?
 5. Draft the Split Proposal (see below) into the plan's `## Split Proposal` section, and write the plan to `<plan-dir>/YYYY-MM-DD-<topic-slug>.md`.
@@ -212,7 +221,7 @@ See [references/annotation-cycle.md](references/annotation-cycle.md) for the det
 3. After addressing all notes, re-run the "boring implementation" test on each task.
 4. Write the updated plan and present changes.
 5. **Repeat** until the user approves with no remaining notes.
-6. **Hard Gate:** Use `AskUserQuestion` — "Is the plan ready to be converted to issues?" with options: Approve / Another annotation round / Abort.
+6. **Hard Gate:** Ask the user to choose (see Environment Adaptation): "Is the plan ready to be converted to issues?" — Approve / Another annotation round / Abort.
 
 ### D4: Issue Creation
 
@@ -234,7 +243,7 @@ Splitting is always a user-confirmed proposal, never automatic. After task decom
 
 - **Propose a parent + sub-issues** when the plan yields 2+ tasks that are independently implementable and reviewable.
 - **Propose a nested split (grandchild issues)** when a single task remains Large (roughly 2+ hours) after refinement — on platforms with nested sub-issues (GitHub), its parts become sub-issues of that child. Maximum depth is 3 levels (parent → child → grandchild); if a grandchild would still be Large, redesign the decomposition instead of nesting deeper.
-- Present the proposed hierarchy as an ASCII tree with sizes and dependencies, then confirm via `AskUserQuestion`:
+- Present the proposed hierarchy as an ASCII tree with sizes and dependencies, then ask the user to choose (see Environment Adaptation):
   - "Create parent + sub-issues" (mark "(Recommended)" when the criteria above are met)
   - "Create a single issue"
   - "Adjust the breakdown"

--- a/plugins/aoshimash-skills/skills/create-issue/references/annotation-cycle.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/annotation-cycle.md
@@ -60,7 +60,7 @@ When the user signals readiness:
    - **NOTE / correction**: Incorporate the change directly. Remove the annotation.
    - **REMOVE**: Delete the indicated section. Remove the annotation.
    - **TODO**: Flesh out the indicated section. Remove the annotation.
-   - **QUESTION**: Answer inline (briefly) or ask a clarifying question via `AskUserQuestion`. Remove the annotation after resolution.
+   - **QUESTION**: Answer inline (briefly) or ask a clarifying question (see Environment Adaptation in SKILL.md). Remove the annotation after resolution.
 4. After addressing all annotations, re-run the "boring implementation" test on all tasks.
 5. Update the plan file with changes.
 
@@ -77,7 +77,7 @@ Summarize what changed:
 
 ### 4. Gate
 
-Use `AskUserQuestion` with options:
+Ask the user to choose (see Environment Adaptation in SKILL.md):
 - **Approve** — Plan is ready to convert to issues.
 - **Another round** — User will add more annotations.
 - **Abort** — Stop.

--- a/plugins/aoshimash-skills/skills/create-issue/references/design.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/design.md
@@ -27,7 +27,7 @@ When multiple valid approaches exist:
    - How it works (1-2 sentences)
    - Pros and cons
    - Mark the recommended approach with "(Recommended)"
-2. Use `AskUserQuestion` with numbered options.
+2. Ask the user to choose (see Environment Adaptation in SKILL.md) with numbered options.
 3. Wait for the user's choice.
 4. If the user selects "Other" and provides free text, incorporate it directly — do NOT re-present new options.
 

--- a/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
@@ -113,13 +113,13 @@ For each test case:
   - D1 Research: investigates existing user model, API patterns, search infrastructure. Writes research file.
   - D2 Design: asks clarifying questions (search fields, pagination, performance). Proposes approaches. Writes plan with task breakdown and Split Proposal.
   - D3 Annotation: prompts user to annotate plan. Addresses annotations. Each task passes boring implementation test.
-  - D4 Issue Creation: confirms the Split Proposal via `AskUserQuestion` BEFORE creating anything, then creates parent issue + sub-issues with dependencies. Cleans up local files.
+  - D4 Issue Creation: confirms the Split Proposal as a user choice BEFORE creating anything, then creates parent issue + sub-issues with dependencies. Cleans up local files.
 - **Verification**:
   - [ ] Research file contains relevant file paths and architecture analysis
   - [ ] Plan has concrete code examples, not placeholders
   - [ ] Each sub-issue is independently implementable
   - [ ] Dependencies form a valid DAG
-  - [ ] Split proposed via `AskUserQuestion` before any parent/sub-issue is created — never automatic
+  - [ ] Split proposed as a user choice before any parent/sub-issue is created — never automatic
   - [ ] Local plan/research files are deleted after issue creation
   - [ ] Parent issue's Task Overview Dependencies column uses real sub-issue numbers (e.g., #259), not plan-local placeholders (e.g., #1)
   - [ ] Parent issue's Task Overview Task column is updated to `#<number> — <title>` format
@@ -133,14 +133,14 @@ For each test case:
   - D1 Research: investigates current auth, session management, middleware, all auth-dependent routes.
   - D2 Design: multiple approach options (gradual migration vs big bang, library choices). Task breakdown includes migration steps, backward compatibility.
   - D3 Annotation: multiple rounds expected for a complex feature.
-  - D4 Issue Creation: split confirmed via `AskUserQuestion`, then parent + sub-issues with careful dependency ordering (infra first, then migration, then cleanup).
+  - D4 Issue Creation: split confirmed as a user choice, then parent + sub-issues with careful dependency ordering (infra first, then migration, then cleanup).
 - **Verification**:
   - [ ] Research identifies ALL files touching authentication
   - [ ] Design presents migration strategy options with trade-offs
   - [ ] Tasks have correct dependency ordering (no circular deps)
   - [ ] Sub-issues include rollback considerations where appropriate
   - [ ] No sub-issue requires design judgment to implement
-  - [ ] Split proposed via `AskUserQuestion` before any parent/sub-issue is created — never automatic
+  - [ ] Split proposed as a user choice before any parent/sub-issue is created — never automatic
 
 ### Case 11: Bug-driven design
 
@@ -193,7 +193,7 @@ For each test case:
 - **Persona**: Backend engineer
 - **Initial input**: "Add rate limiting to the API and an admin toggle for it"
 - **Expected behavior**:
-  - Signals are weak/mixed (2 areas: API + admin UI, but modest scope) — the skill either justifies staying in the Lightweight Flow, justifies escalating with a clear reason, or asks the user directly via `AskUserQuestion`
+  - Signals are weak/mixed (2 areas: API + admin UI, but modest scope) — the skill either justifies staying in the Lightweight Flow, justifies escalating with a clear reason, or asks the user directly (user choice)
   - Silently guessing on weak signals without any justification or question is a failure
 - **Verification**:
   - [ ] A flow decision is made with an explicit, stated reason, OR the user is asked
@@ -206,7 +206,7 @@ For each test case:
 - **Setup**: Codebase analysis (Step L3) reveals the change actually requires touching the frontend form, a new backend validation service, and a schema migration (3+ areas)
 - **Expected behavior**:
   - Skill announces the findings from codebase analysis
-  - Proposes switching to the Design Flow via `AskUserQuestion` rather than continuing to draft an oversized single issue
+  - Proposes switching to the Design Flow as a user choice rather than continuing to draft an oversized single issue
   - Does NOT silently continue in the Lightweight Flow once the escalation criteria are clearly met
 - **Verification**:
   - [ ] Findings are stated before proposing escalation
@@ -233,7 +233,7 @@ For each test case:
 - **Setup**: Design Flow decomposition yields 3 tasks; after refinement, one task remains Large (~2+ hours) and cannot be shrunk further without becoming multiple deliverables
 - **Expected behavior**:
   - Skill proposes a nested split for that task specifically (grandchild issues under it) as part of the Step D4 Split Proposal, shown in the ASCII tree with a 3rd level
-  - User confirms via `AskUserQuestion`
+  - User confirms via a user choice
   - GitHub nested sub-issue links are created (child issue linked to parent; grandchild issues linked to the child)
   - Output hierarchy tree shows all 3 levels
 - **Verification**:

--- a/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
@@ -33,7 +33,7 @@ Proposed hierarchy:
   └─ Add search integration tests (Small, blocked by 2, 3)
 ```
 
-Then use `AskUserQuestion`:
+Then ask the user to choose (see Environment Adaptation in SKILL.md):
 - **Create parent + sub-issues** (mark "(Recommended)" when 2+ tasks are independently implementable and reviewable) — proceed to Step 2.
 - **Create a single issue** — skip the hierarchy. Compose ONE issue using the Feature Request or Technical Task template from [templates.md](templates.md), with the plan's Goal as Motivation/Proposal and the task breakdown included as a `## Task Breakdown` section (titles, files, approach, AC per task, as subsections). Then go directly to Step 5 (Clean Up).
 - **Adjust the breakdown** — return to the Design phase's Task Decomposition step with the user's feedback, then re-present this gate.

--- a/plugins/aoshimash-skills/skills/create-issue/references/research.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/research.md
@@ -79,7 +79,7 @@ Present the research file path to the user:
 
 > "Research is written to `<path>`. Review it and let me know if it captures the relevant context, or if there are areas I should investigate further."
 
-Use `AskUserQuestion` with options:
+Ask the user to choose (see Environment Adaptation in SKILL.md):
 - **Approve** — Proceed to design.
 - **Add notes** — User will annotate the research file or provide verbal feedback. Address feedback, update the file, and re-present.
 - **Abort** — Stop.


### PR DESCRIPTION
## Summary
- Convert all 13 bare `AskUserQuestion` prescriptions in the create-issue skill to capability-based wording
- Add an Environment Adaptation section (User choice row only) to `SKILL.md`, per the canonical template in AGENTS.md
- The skill's flow-selection, hard gates, and split proposal now execute on any Agent Skills-compliant agent, not only Claude Code

Closes #60

## Changes
- `SKILL.md`: add Environment Adaptation section after `## Principles`; rewrite 8 gate sites to "Ask the user to choose (see Environment Adaptation)"
- `references/research.md`, `references/design.md`, `references/issue-creation.md`: 1 gate site each, pointing to "Environment Adaptation in SKILL.md"
- `references/annotation-cycle.md`: 2 gate sites
- `references/eval-cases.md`: align 7 expected-behavior references with the capability wording (no more `AskUserQuestion`)
- The combined labels/assignees note now reads "present them as a single combined choice instead of asking separately"

## Test Plan
- [x] `grep -r AskUserQuestion plugins/aoshimash-skills/skills/create-issue` returns only the Environment Adaptation example row (nothing in `references/`)
- [x] Environment Adaptation section present in `SKILL.md` with only the capabilities the skill uses (User choice)
- [x] `SKILL.md` remains under 500 lines (268 lines)
- [x] eval-cases.md expectations match the new wording