### PR TITLE
Declare Claude Code compatibility for analyze-sessions

### DIFF
--- a/plugins/aoshimash-skills/skills/analyze-sessions/SKILL.md
+++ b/plugins/aoshimash-skills/skills/analyze-sessions/SKILL.md
@@ -6,9 +6,12 @@ description: >
   "analyze sessions", "improve skills", "analyze skill logs",
   "セッションを分析", "スキルを改善", "ログを分析", "設定を提案",
   or wants to review skill usage patterns and environment configuration.
+compatibility: Designed for Claude Code — reads ~/.claude/projects session JSONL and proposes Claude Code settings.json/hooks changes
 ---
 
 # Analyze Sessions
+
+This skill is Claude Code-specific by design (see `compatibility`); it deliberately uses Claude Code-native data and configuration to the fullest.
 
 Analyze Claude Code's built-in conversation history to detect recurring patterns in skill executions and propose concrete improvements to skill definitions and `settings.json` configuration.
 


### PR DESCRIPTION
## Summary
- Add the Agent Skills spec's optional `compatibility` frontmatter field to `analyze-sessions/SKILL.md`, declaring the skill as Claude Code-specific instead of implying portability.
- Add a one-sentence body note after the H1 pointing to the `compatibility` field.

analyze-sessions is Claude Code-specific end to end by design: it reads `~/.claude/projects` session JSONL, detects Claude Code skill-invocation markers, and proposes Claude Code `settings.json`/hooks changes. The spec's `compatibility` field exists for exactly this case. The repo frontmatter rule was amended to allow this (see AGENTS.md; product-bound skills are also exempt from the Environment Adaptation section, which this skill already omits).

Verified against the primary source (https://agentskills.io/specification): `compatibility` is optional, 1-500 characters, with the documented example `Designed for Claude Code (or similar products)`. The value added here is 118 characters.

Closes #65

## Changes
- `plugins/aoshimash-skills/skills/analyze-sessions/SKILL.md`:
  - Frontmatter: add `compatibility: Designed for Claude Code — reads ~/.claude/projects session JSONL and proposes Claude Code settings.json/hooks changes`
  - Body: add note after the H1 — "This skill is Claude Code-specific by design (see `compatibility`); it deliberately uses Claude Code-native data and configuration to the fullest."

## Test Plan
- [x] `compatibility` field present and under 500 characters (118 chars)
- [x] Body note present; no other behavioral changes (diff is 3 insertions, 0 deletions)
- [x] Frontmatter parses as valid YAML (keys: name, description, compatibility)
- [x] Field name/limit/example verified against the Agent Skills specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)