### PR TITLE
Neutralize multi-agent-review harness wording and config path

### DIFF
--- a/plugins/aoshimash-skills/skills/multi-agent-review/SKILL.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/SKILL.md
@@ -20,21 +20,31 @@ Run multiple AI CLIs in parallel for code review and produce a unified review ou
 3. **Unified output** — Deduplicate, resolve contradictions, and sort by severity into a single review.
 4. **Review only** — This skill produces review output in the conversation. Where to post it (PR comment, file, etc.) is the caller's responsibility.
 
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+| **Background execution** — run long commands without blocking | Background shell (e.g. Claude Code's background Bash) | Run commands sequentially |
+
 ## Workflow
 
 ### Phase 0: Setup — Agent Configuration
 
-1. Check for existing configuration in `.claude/aoshimash-skills.local.md` (YAML frontmatter).
+1. Check for existing configuration in `.aoshimash-skills.local.md` (repo root, YAML frontmatter).
 2. If configuration exists, load it and proceed to Phase 1.
 3. If no configuration exists (first run):
    a. Check which CLIs are installed using `command -v claude`, `command -v codex`, `command -v gemini`.
-   b. Present the list of detected CLIs to the user and ask which ones to use.
-   c. Save the selection to `.claude/aoshimash-skills.local.md`.
+   b. Present the list of detected CLIs and ask which ones to use (user choice — see Environment Adaptation).
+   c. Save the selection to `.aoshimash-skills.local.md`.
 
 #### Configuration format
 
 ```yaml
-# .claude/aoshimash-skills.local.md frontmatter
+# .aoshimash-skills.local.md frontmatter
 multi-agent-review:
   agents:
     - name: claude
@@ -71,7 +81,7 @@ See [references/agent-cli.md](references/agent-cli.md) for diff preparation deta
 
 ### Phase 2: Execute — Parallel CLI Invocation
 
-Run all enabled agents in parallel using Background Bash.
+Run all enabled agents in parallel using background execution (see Environment Adaptation); without it, invoke the CLIs sequentially — results are identical, total wall-clock time increases.
 
 1. Load review perspectives: project custom perspectives (from settings) merged with defaults from [references/default-perspectives.md](references/default-perspectives.md).
 2. Build the review prompt incorporating all perspectives.

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/agent-cli.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/agent-cli.md
@@ -9,10 +9,10 @@ DIFF_FILE=$(mktemp /tmp/multi-review-XXXXXX)
 echo "$DIFF_FILE"
 ```
 
-**Important — Claude Code shell independence:**
-- Each Bash call runs in an independent shell. Shell variables (`$DIFF_FILE`) do not persist across calls.
-- Read the `mktemp` output, remember the actual file path, and embed it as a literal in subsequent commands.
-- Do not rely on `trap` for cleanup — it only works within the same shell. Clean up explicitly.
+**Important — Per-call shell isolation:**
+- Most agents run each shell command in an independent shell; variables (`$DIFF_FILE`) and `trap` do not persist across tool calls.
+- Read the `mktemp` output and embed the literal path in subsequent commands.
+- Because `trap` does not persist, do not rely on it for cleanup — clean up explicitly (see Cleanup).
 
 **Template suffix:** The `mktemp` template must end with `X` characters (macOS BSD `mktemp` constraint). Do not append extensions like `.diff` after the `X`s.
 
@@ -51,7 +51,7 @@ echo "Diff saved to <DIFF_FILE> ($(wc -l < <DIFF_FILE>) lines)"
 
 ## CLI Invocation
 
-All CLIs are run in **Background Bash** for parallel execution. Each CLI runs in read-only / prompt mode to prevent code changes.
+All CLIs are run with **background execution** (see the Environment Adaptation section in SKILL.md) for parallel execution; without it, invoke the CLIs sequentially — results are identical, total wall-clock time increases. Each CLI runs in read-only / prompt mode to prevent code changes.
 
 ### Installation Check
 

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/aggregation.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/aggregation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The central agent (Claude Code itself) combines outputs from all AI CLIs into a single unified review.
+The orchestrating agent (the agent executing this skill) combines outputs from all AI CLIs into a single unified review.
 
 ## Step 1: Parse Agent Outputs
 

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/default-perspectives.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/default-perspectives.md
@@ -1,6 +1,6 @@
 # Default Review Perspectives
 
-These are language-agnostic review perspectives applied to all agents by default. Projects can override or extend these via `.claude/aoshimash-skills.local.md`.
+These are language-agnostic review perspectives applied to all agents by default. Projects can override or extend these via `.aoshimash-skills.local.md`.
 
 ## Perspectives
 
@@ -35,7 +35,7 @@ These are language-agnostic review perspectives applied to all agents by default
 
 ## Custom Perspectives
 
-Projects can define custom perspectives in `.claude/aoshimash-skills.local.md`:
+Projects can define custom perspectives in `.aoshimash-skills.local.md`:
 
 ```yaml
 multi-agent-review:

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
@@ -124,7 +124,7 @@
 
 ### Case 10: Internal use from another skill
 
-**Scenario**: `implement-issue` skill calls `multi-agent-review` as a subagent to review implementation before creating PR.
+**Scenario**: `implement-issue` skill invokes `multi-agent-review` internally (as a separate agent instance) to review implementation before creating PR.
 
 **Expected behavior**:
 - Skill loads config, gets local diff, runs agents, returns unified review

--- a/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/multi-agent-review/references/eval-cases.md
@@ -8,7 +8,7 @@
 | 2 | CLI availability checked | Each agent's CLI verified with `command -v` before invocation |
 | 3 | Uninstalled CLIs skipped | Missing CLIs skipped gracefully, execution proceeds with available agents |
 | 4 | Diff obtained correctly | PR diff via `gh pr diff` or local diff via `git diff`, saved to temp file |
-| 5 | Agents run in parallel | All enabled agents invoked via Background Bash simultaneously |
+| 5 | Agents run in parallel | All enabled agents invoked via background execution simultaneously (or sequentially where background execution is unavailable) |
 | 6 | Perspectives applied | Default perspectives (or custom overrides) included in review prompt |
 | 7 | Results parsed | Agent outputs parsed into structured findings |
 | 8 | Deduplication applied | Same-issue findings from multiple agents merged |
@@ -23,12 +23,12 @@
 
 ### Case 1: First run — no configuration exists
 
-**Scenario**: User invokes `/multi-agent-review` for the first time. No `.claude/aoshimash-skills.local.md` exists. Claude and Gemini CLIs are installed, Codex is not.
+**Scenario**: User invokes `/multi-agent-review` for the first time. No `.aoshimash-skills.local.md` exists. Claude and Gemini CLIs are installed, Codex is not.
 
 **Expected behavior**:
 - Detect installed CLIs (Claude, Gemini found; Codex not found)
 - Present available CLIs and ask user which to enable
-- Save selection to `.claude/aoshimash-skills.local.md`
+- Save selection to `.aoshimash-skills.local.md`
 - Proceed with selected agents
 
 **Criteria to test**: 1, 2, 3


### PR DESCRIPTION
## Summary
- Remove Claude Code-as-harness assumptions from the `multi-agent-review` skill so it is usable by any agent implementing the Agent Skills spec, while keeping the `claude`/`codex`/`gemini` CLIs as reviewer engines (out of scope, unchanged).
- Add the canonical Environment Adaptation section and migrate the config path to `.aoshimash-skills.local.md` (repo root, hard cutover — no legacy `.claude/` fallback, per parent #58).

Closes #64

## Changes
- **SKILL.md** — Add Environment Adaptation section (User choice, Background execution rows from the canonical AGENTS.md template); Phase 0 config path -> `.aoshimash-skills.local.md`; Phase 2 wording -> "background execution" with sequential fallback stated.
- **references/agent-cli.md** — Rename "Claude Code shell independence" -> "Per-call shell isolation" with neutral wording; replace "Background Bash" with "background execution" + sequential fallback.
- **references/aggregation.md** — "The central agent (Claude Code itself)" -> "The orchestrating agent (the agent executing this skill)".
- **references/default-perspectives.md** — Config path refs -> `.aoshimash-skills.local.md`.
- **references/eval-cases.md** — Align "Background Bash" wording and config path refs.

## Test Plan
- [x] `grep -ri 'claude code\|background bash\|\.claude/' plugins/aoshimash-skills/skills/multi-agent-review` returns only the two Environment Adaptation example rows in SKILL.md.
- [x] Config path is `.aoshimash-skills.local.md` in all references; no `.claude/aoshimash-skills` remains.
- [x] Sequential fallback for CLI invocation is stated (SKILL.md Phase 2, agent-cli.md CLI Invocation, eval-cases criterion 5).

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)