### PR TITLE
respond-to-pr-review: capability gates and verification fallback

### DIFF
--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
@@ -27,6 +27,16 @@ Process PR/MR review comments interactively: explain each one, confirm what to d
 6. **Scope guard** — Only implement what a specific comment requests.
 7. **Match the comment's language** — Reply in the same language as the comment. Japanese comment → Japanese reply. English comment → English reply. Mixed group → majority language.
 
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (here, the reply comment the step produces) |
+
 ## Workflow
 
 ### Phase 0: Identify the PR
@@ -34,7 +44,7 @@ Process PR/MR review comments interactively: explain each one, confirm what to d
 1. Detect platform:
    - Check CLAUDE.md for `## Code Hosting` config
    - If not configured, detect from `git remote -v`: `github.com` → GitHub, `gitlab.com` → GitLab
-   - If ambiguous, ask user via `AskUserQuestion`
+   - If ambiguous, ask the user to choose (user choice — see [Environment Adaptation](#environment-adaptation))
 2. Load platform guide: [references/platform-github.md](references/platform-github.md) or [references/platform-gitlab.md](references/platform-gitlab.md)
 3. Get PR/MR info for current branch
 4. If no PR/MR found, ask user for number or URL
@@ -56,7 +66,7 @@ See [references/workflow.md](references/workflow.md) for detailed procedure.
 
 See [references/workflow.md](references/workflow.md) for detailed procedure.
 
-**Summary:** For each group: show comment, explain it, ask for decision via `AskUserQuestion`.
+**Summary:** For each group: show comment, explain it, ask for a decision via a user choice (see Environment Adaptation).
 
 **Hard Gate** per group — options:
 - **Implement** — address the feedback
@@ -77,7 +87,7 @@ For each "Implement" decision:
 
 See [references/workflow.md](references/workflow.md) for detailed procedure.
 
-**Summary:** For each `rule-violation-instance` group just implemented, search the changed files for other instances of the same pattern. Present found instances to the user via `AskUserQuestion` (Apply all / Skip / Pick subset). Apply selected fixes in the same commit, or create a new commit if the previous commit is already pushed.
+**Summary:** For each `rule-violation-instance` group just implemented, search the changed files for other instances of the same pattern. Present found instances to the user via a user choice (Apply all / Skip / Pick subset). Apply selected fixes in the same commit, or create a new commit if the previous commit is already pushed.
 
 ### Phase 5: Verification Gate
 
@@ -85,7 +95,7 @@ See [references/verification.md](references/verification.md) for detailed proced
 
 **Summary:** Verify that Phase 4 (and 4.5) changes match the reviewer's intent.
 
-- `critical` groups → subagent verification (3 criteria: Intent Match, Scope Guard, Side Effect)
+- `critical` groups → verification by a **separate agent instance** with fresh context (3 criteria: Intent Match, Scope Guard, Side Effect). If the environment cannot provide one, self-review against the same criteria and flag the verdict `SELF-REVIEWED` in the reply (see Environment Adaptation).
 - `normal` groups → self-review using the same 3 criteria
 - For `rule-violation-instance` groups, same-pattern expansion from Phase 4.5 is considered in-scope for the Scope Guard criterion.
 - NEEDS_FIX → fix loop (max 2 rounds)

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/SKILL.md
@@ -95,7 +95,7 @@ See [references/verification.md](references/verification.md) for detailed proced
 
 **Summary:** Verify that Phase 4 (and 4.5) changes match the reviewer's intent.
 
-- `critical` groups → verification by a **separate agent instance** with fresh context (3 criteria: Intent Match, Scope Guard, Side Effect). If the environment cannot provide one, self-review against the same criteria and flag the verdict `SELF-REVIEWED` in the reply (see Environment Adaptation).
+- `critical` groups → verification by a **separate agent instance** with fresh context (3 criteria: Intent Match, Scope Guard, Side Effect). If the environment cannot provide one, self-review against the same criteria, mark the resulting verdict `SELF-REVIEWED`, and carry that flag into the reply (see Environment Adaptation).
 - `normal` groups → self-review using the same 3 criteria
 - For `rule-violation-instance` groups, same-pattern expansion from Phase 4.5 is considered in-scope for the Scope Guard criterion.
 - NEEDS_FIX → fix loop (max 2 rounds)

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/evals/evals.json
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/evals/evals.json
@@ -19,7 +19,7 @@
       "id": 9,
       "name": "pattern-broadening-drip-feed",
       "prompt": "PR のレビューコメントに対応してください。ボット (DeepSource) から1件のコメントがあります: 'Variable `data` in `src/utils.ts:12` does not follow the camelCase convention. Consider renaming to `userData`.' 変更ファイルには同じ命名違反が src/api.ts:34, src/handler.ts:8, src/handler.ts:27 にも存在します。",
-      "expected_output": "1) Group tagged as rule-violation-instance (bot commenter, uses 'convention', pattern grep-findable). 2) Phase 4 fixes only src/utils.ts:12. 3) Phase 4.5 finds 3 additional instances and presents AskUserQuestion with Apply all / Pick subset / Skip. 4) After user approves Apply all, all 4 locations fixed in same commit. 5) Scope Guard passes in verification. 6) Reply uses Implement (broadened) template: 'Fixed in [SHA]: applied to src/utils.ts:12 + 3 other instances of the same pattern.'",
+      "expected_output": "1) Group tagged as rule-violation-instance (bot commenter, uses 'convention', pattern grep-findable). 2) Phase 4 fixes only src/utils.ts:12. 3) Phase 4.5 finds 3 additional instances and presents a user choice with Apply all / Pick subset / Skip. 4) After user approves Apply all, all 4 locations fixed in same commit. 5) Scope Guard passes in verification. 6) Reply uses Implement (broadened) template: 'Fixed in [SHA]: applied to src/utils.ts:12 + 3 other instances of the same pattern.'",
       "files": []
     }
   ]

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
@@ -14,14 +14,14 @@
 - Phase 2: Comments 3a and 3b grouped (same issue). Group 3 tagged `critical` (2 reviewers)
 - Phase 3: User decides — Group 1: Reject, Group 2: Implement, Group 3: Implement
 - Phase 4: Two commits made (rename + error propagation)
-- Phase 5: Group 3 verified by subagent (critical), Group 2 self-reviewed (normal)
+- Phase 5: Group 3 verified by a separate agent instance (critical), Group 2 self-reviewed (normal)
 - Phase 7: Bot reply (no thanks, factual), Human replies (brief thanks + commit link)
 
 **Verification**:
 - [ ] Bot comment reply has no opening thanks and is factual
 - [ ] Human comment replies include brief thanks and commit SHA link
 - [ ] Group 3 (2 reviewers) presented as one group, tagged `critical`
-- [ ] Verification Gate executed: subagent for critical, self-review for normal
+- [ ] Verification Gate executed: separate agent instance for critical, self-review for normal (or SELF-REVIEWED flag if unavailable)
 - [ ] Reject group (Group 1) reply uses factual bot format ("Keeping current approach: [reason].")
 - [ ] Reply batch shown for approval before posting
 
@@ -70,11 +70,11 @@
 
 **Expected behavior**:
 - Skill detects no PR for current branch
-- Asks user for PR number or URL via `AskUserQuestion`
+- Asks user for PR number or URL via a user choice
 - Continues normally after user provides it
 
 **Verification**:
-- [ ] `AskUserQuestion` used (not just a text prompt)
+- [ ] User choice presented (not just a text prompt)
 - [ ] Workflow continues normally after user provides PR info
 
 ---
@@ -87,7 +87,7 @@
 
 **Expected behavior**:
 - Phase 2: Tagged `critical` (REQUEST_CHANGES)
-- Phase 5: Subagent verification detects:
+- Phase 5: Verification by a separate agent instance detects:
   - Intent Match: PASS (function renamed)
   - Scope Guard: FAIL (helper extraction not requested)
   - Side Effect: PASS
@@ -97,7 +97,7 @@
 - Reply includes only the rename commit
 
 **Verification**:
-- [ ] Subagent dispatched for this critical group
+- [ ] Separate agent instance dispatched for this critical group
 - [ ] Scope Guard failure correctly identified
 - [ ] Fix loop executed (max 1 round in this case)
 - [ ] Final diff contains only the rename, no extra refactoring
@@ -138,12 +138,12 @@
 **Expected behavior**:
 - Phase 2: Groups 1 and 2 tagged `critical`, Group 3 tagged `normal`
 - Phase 5:
-  - Groups 1 and 2: subagent verification (separate subagent per group)
+  - Groups 1 and 2: verification by a separate agent instance (one per group)
   - Group 3: self-review (3-criteria checklist)
 
 **Verification**:
 - [ ] Criticality tags correctly assigned based on REQUEST_CHANGES and multi-reviewer
-- [ ] Subagents dispatched for groups 1 and 2
+- [ ] Separate agent instances dispatched for groups 1 and 2
 - [ ] Self-review used for group 3
 - [ ] All 3 criteria checked for every group regardless of method
 
@@ -184,7 +184,7 @@
 - Phase 4.5:
   - Skill searches changed files for similar naming violations.
   - Finds 3 additional instances.
-  - Presents them to the user via `AskUserQuestion` with Apply all / Pick subset / Skip.
+  - Presents them to the user via a user choice with Apply all / Pick subset / Skip.
   - User selects Apply all.
   - All 3 additional locations fixed and included in the same commit (or a new commit if pushed).
   - Group marked `broadened` (3 additional instances).
@@ -195,7 +195,7 @@
 - [ ] Group type correctly classified as `rule-violation-instance`
 - [ ] Phase 4 fixes only the originally flagged location
 - [ ] Phase 4.5 finds exactly the 3 additional instances in changed files
-- [ ] `AskUserQuestion` presented with Apply all / Pick subset / Skip options
+- [ ] User choice presented with Apply all / Pick subset / Skip options
 - [ ] All 4 locations fixed after user chooses Apply all
 - [ ] Scope Guard criterion passes (not FAIL) in Phase 5 verification
 - [ ] Reply uses `Implement (broadened)` template with correct count and locations

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
@@ -21,7 +21,7 @@
 - [ ] Bot comment reply has no opening thanks and is factual
 - [ ] Human comment replies include brief thanks and commit SHA link
 - [ ] Group 3 (2 reviewers) presented as one group, tagged `critical`
-- [ ] Verification Gate executed: separate agent instance for critical, self-review for normal (or SELF-REVIEWED flag if unavailable)
+- [ ] Verification Gate executed: separate agent instance for critical (or SELF-REVIEWED flag if unavailable), self-review for normal
 - [ ] Reject group (Group 1) reply uses factual bot format ("Keeping current approach: [reason].")
 - [ ] Reply batch shown for approval before posting
 
@@ -70,11 +70,11 @@
 
 **Expected behavior**:
 - Skill detects no PR for current branch
-- Asks user for PR number or URL via a user choice
+- Asks user for PR number or URL (a plain question — free-form input, no enumerable options)
 - Continues normally after user provides it
 
 **Verification**:
-- [ ] User choice presented (not just a text prompt)
+- [ ] User is asked to provide a PR number or URL before proceeding
 - [ ] Workflow continues normally after user provides PR info
 
 ---

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
@@ -23,7 +23,7 @@ For each `critical` group with an "Implement" decision:
    - **Diff**: `git diff <commit-before>..<commit-after>` for the commit(s) that addressed this group
    - **Context**: 30 lines before and after the changed area in each modified file
 
-2. Dispatch a **separate agent instance with fresh context** (see Environment Adaptation in SKILL.md) — the point is a verifier that has not seen the implementation. If the environment cannot provide one, verify against the same three criteria yourself and record the verdict as `SELF-REVIEWED (no independent verification available)`; critical comments verified this way MUST be flagged as such in the reply comment (see below). Use this prompt for the verifier (or as your own checklist when self-reviewing):
+2. Dispatch a **separate agent instance with fresh context** (see Environment Adaptation in SKILL.md) — the point is a verifier that has not seen the implementation. If the environment cannot provide one, verify against the same three criteria yourself, record the resulting verdict (PASS / NEEDS_FIX / UNCERTAIN), and mark it `SELF-REVIEWED (no independent verification available)` — the marker rides on the verdict so 5-4/5-5 routing still applies; critical comments verified this way MUST be flagged as such in the reply comment (see below). Use this prompt for the verifier (or as your own checklist when self-reviewing):
 
 ```
 Review Comment: "{comment body}"
@@ -59,10 +59,10 @@ Return one of:
 
 3. Record the verifier's verdict and reasoning.
 
-**`SELF-REVIEWED` reply flag.** When a critical group was verified via the self-review fallback (no separate agent instance available), its Phase 7 reply MUST carry a visible flag so the reviewer knows the independent-verification guarantee did not hold. Append to the reply draft for that group:
+**`SELF-REVIEWED` reply flag.** When a critical group was verified via the self-review fallback (no separate agent instance available), its Phase 7 reply MUST carry a visible flag containing the `SELF-REVIEWED` marker, so the reviewer knows the independent-verification guarantee did not hold. Append to the reply draft for that group:
 
-- Human reviewer: "Note: verified by self-review only — no independent verification available in this environment."
-- Bot: "Self-reviewed; no independent verification available."
+- Human reviewer: "Note: SELF-REVIEWED — verified by self-review only, no independent verification available in this environment."
+- Bot: "SELF-REVIEWED — no independent verification available."
 
 This flag is independent of the DONE_WITH_CONCERNS caveat (5-6); a group can carry both.
 

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/verification.md
@@ -4,7 +4,7 @@ Detailed procedure for Phase 5 of the respond-to-pr-review skill. Verifies that 
 
 ## Purpose
 
-Prevent replying "Fixed in abc1234" when the fix doesn't actually address the comment. Critical comments get third-party (subagent) verification; normal comments get self-review.
+Prevent replying "Fixed in abc1234" when the fix doesn't actually address the comment. Critical comments get third-party verification by a **separate agent instance** that has not seen the implementation; normal comments get self-review. When no separate agent instance is available, critical comments fall back to self-review with an explicit `SELF-REVIEWED` flag (see 5-2) so the missing guarantee stays visible.
 
 ## Procedure
 
@@ -14,7 +14,7 @@ Only groups with an "Implement" decision enter the Verification Gate. Skip group
 
 Within Implement groups, process `critical` first, then `normal`. Within each tier, process in the order they were implemented.
 
-### 5-2: Verify critical groups (subagent)
+### 5-2: Verify critical groups (separate agent instance)
 
 For each `critical` group with an "Implement" decision:
 
@@ -23,7 +23,7 @@ For each `critical` group with an "Implement" decision:
    - **Diff**: `git diff <commit-before>..<commit-after>` for the commit(s) that addressed this group
    - **Context**: 30 lines before and after the changed area in each modified file
 
-2. Dispatch a subagent with this prompt:
+2. Dispatch a **separate agent instance with fresh context** (see Environment Adaptation in SKILL.md) — the point is a verifier that has not seen the implementation. If the environment cannot provide one, verify against the same three criteria yourself and record the verdict as `SELF-REVIEWED (no independent verification available)`; critical comments verified this way MUST be flagged as such in the reply comment (see below). Use this prompt for the verifier (or as your own checklist when self-reviewing):
 
 ```
 Review Comment: "{comment body}"
@@ -57,7 +57,14 @@ Return one of:
 - UNCERTAIN — cannot determine (explain why — e.g., insufficient context, ambiguous comment)
 ```
 
-3. Record the subagent's verdict and reasoning.
+3. Record the verifier's verdict and reasoning.
+
+**`SELF-REVIEWED` reply flag.** When a critical group was verified via the self-review fallback (no separate agent instance available), its Phase 7 reply MUST carry a visible flag so the reviewer knows the independent-verification guarantee did not hold. Append to the reply draft for that group:
+
+- Human reviewer: "Note: verified by self-review only — no independent verification available in this environment."
+- Bot: "Self-reviewed; no independent verification available."
+
+This flag is independent of the DONE_WITH_CONCERNS caveat (5-6); a group can carry both.
 
 ### 5-3: Verify normal groups (self-review)
 
@@ -71,13 +78,13 @@ If any criterion fails, mark as NEEDS_FIX with explanation.
 
 ### 5-4: Handle UNCERTAIN
 
-When a subagent returns UNCERTAIN:
+When verification returns UNCERTAIN:
 
 1. Present to the user:
    - The original comment
    - The diff
-   - The subagent's reasoning for UNCERTAIN
-2. Use `AskUserQuestion` with options:
+   - The verifier's reasoning for UNCERTAIN
+2. Present a user choice (see Environment Adaptation in SKILL.md) with options:
    - Treat as PASS
    - Treat as NEEDS_FIX
    - Skip verification for this group
@@ -90,7 +97,7 @@ For each NEEDS_FIX result:
 2. Re-implement the change to address the failure
 3. Run project checks (formatter, linter, tests) until clean
 4. Amend or create a new commit
-5. Re-verify (subagent for critical, self-review for normal)
+5. Re-verify (separate agent instance for critical, self-review for normal)
 
 **Maximum 2 fix rounds.** If still NEEDS_FIX after round 2, proceed to 5-6.
 
@@ -108,7 +115,7 @@ When a group remains NEEDS_FIX after 2 fix rounds:
 
 **Only triggered if any group is DONE_WITH_CONCERNS.**
 
-Present verification results to the user via `AskUserQuestion`:
+Present verification results to the user via a user choice (see Environment Adaptation in SKILL.md):
 
 ```
 Verification complete. N groups with concerns:

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/workflow.md
@@ -100,7 +100,7 @@ Describe what the reviewer is pointing out, why it might matter, and what the cu
 
 ### 3-3: Ask for a decision
 
-**Hard Gate:** Use `AskUserQuestion` with options:
+**Hard Gate:** Present a user choice (see Environment Adaptation in SKILL.md) with options:
 
 - **Implement** — address the feedback in this PR
 - **Reject** — decline with an explanation (when chosen, ask the user for the reason)
@@ -136,7 +136,7 @@ For each `rule-violation-instance` group just implemented:
 
 ### 4.5-2: Present findings to user
 
-If additional instances are found, present them via `AskUserQuestion`:
+If additional instances are found, present them via a user choice (see Environment Adaptation in SKILL.md):
 
 ```
 Pattern Broadening — Group N [rule-violation-instance]


### PR DESCRIPTION
## Summary
- Convert respond-to-pr-review's user gates and third-party verification to capability-based wording, per the AGENTS.md Environment Adaptation template (added by #59).
- Add an Environment Adaptation section to SKILL.md declaring the **User choice** and **Separate agent instance** capabilities.
- Define an honest self-verification fallback so the core guarantee's absence stays visible instead of silently weakening.

Closes #62

## Changes
- `SKILL.md` — Add Environment Adaptation section; rewrite Phase 0/3/4.5/5 summary lines to capability terms.
- `references/workflow.md` — Rewrite the two decision gates (3-3, 4.5-2) to "user choice".
- `references/verification.md` — 5-2 now dispatches a **separate agent instance with fresh context**; when unavailable, self-review is recorded `SELF-REVIEWED (no independent verification available)` and MUST be flagged in the Phase 7 reply comment (human/bot wording defined). Purpose, 5-4, 5-5, 5-7 rewritten to neutral vocabulary.
- `references/eval-cases.md` — Align 10 references to the new wording.
- `evals/evals.json` — Align 1 reference.

## Test Plan
- [x] No bare `AskUserQuestion`/`subagent` instruction remains outside the Environment Adaptation example column (grep-verified).
- [x] verification.md defines the `SELF-REVIEWED` fallback including the reply-comment flag.
- [x] eval-cases.md and evals.json match the new wording.
- [x] evals.json is valid JSON (`jq empty`).