### PR TITLE
Capability-based gates and plan-mode notes for implement-issue

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -29,6 +29,17 @@ Read an issue (or a set of issues), plan the implementation, get approval, imple
 7. **Worktree isolation** (Batch mode) — Each issue gets its own git worktree. No cross-contamination between parallel implementations.
 8. **Fail fast, report clearly** (Batch mode) — If an issue fails after retries, mark it blocked and continue with independent issues. Never block the entire batch on one failure.
 
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body or reply comment the step produces) |
+| **Background execution** — run long commands without blocking | Background shell (e.g. Claude Code's background Bash) | Run commands sequentially |
+
 ## Phase 0: Setup and Mode Selection
 
 1. Detect the **issue tracker** platform (check CLAUDE.md `## Issue Tracker` → git remote → ask user). Note: the issue tracker and code hosting platform may differ (e.g., Backlog for issues + GitHub for PRs). Read the platform-specific guide:
@@ -37,20 +48,20 @@ Read an issue (or a set of issues), plan the implementation, get approval, imple
    - Backlog: [references/platform-backlog.md](references/platform-backlog.md)
 2. Obtain the issue identifier(s). If none are provided, list open issues from the platform (when supported) and ask the user to select.
 3. **Mode routing:**
-   - **Multiple issues referenced** — a list of numbers, "these issues", a milestone, a label, or "run sprint" / "スプリント実行" phrasing → **Batch mode**. If the source is ambiguous, ask via `AskUserQuestion`: Parent issue / Milestone / Label / Manual list.
+   - **Multiple issues referenced** — a list of numbers, "these issues", a milestone, a label, or "run sprint" / "スプリント実行" phrasing → **Batch mode**. If the source is ambiguous, ask the user to choose (see Environment Adaptation): Parent issue / Milestone / Label / Manual list.
    - **Single issue referenced** — fetch it, then **check whether it is a parent issue** with open sub-issues (GitHub: sub-issues API; GitLab: issue links/task list; Backlog: `--parent` search — see the platform guide's "Detect Sub-Issues / Child Items" section).
-     - If it has open sub-issues, ask via `AskUserQuestion`: "Issue #N has M open sub-issue(s). How do you want to proceed?" with options:
+     - If it has open sub-issues, ask the user to choose (see Environment Adaptation): "Issue #N has M open sub-issue(s). How do you want to proceed?" with options:
        - **Implement all sub-issues (batch)** — mark "(Recommended)" when 2+ children are open. Proceeds to Batch mode with those sub-issues as the source set.
        - **Implement only this issue** — treat #N itself as a normal single issue, ignore its children.
        - **Pick one sub-issue** — list the children, let the user select one, continue in Single mode with that child.
      - If it has no open sub-issues → **Single mode** on #N.
 4. **Single mode only** — check issue state: if the issue is already closed or merged:
    - Inform the user: "Issue #N is already \<state\>."
-   - Use `AskUserQuestion`: "Reopen and implement" / "Pick another issue" / "Abort"
+   - Ask the user to choose (see Environment Adaptation): "Reopen and implement" / "Pick another issue" / "Abort"
    - If "Reopen and implement": reopen the issue, then continue. If "Pick another issue": return to step 2. If "Abort": stop.
 
    **Batch mode**: closed/merged issues in the source set are filtered out silently. If all issues are closed, inform the user and stop.
-5. **Single mode only** — ask the user where to implement using `AskUserQuestion` with numbered options:
+5. **Single mode only** — ask the user where to implement (see Environment Adaptation) with numbered options:
    - **Worktree** (default) — Create a git worktree for isolated work. Keeps current branch untouched.
    - **New branch** — Create a new branch in the current working tree.
    - **Current branch** — Work directly on the current branch (useful if already on a feature branch).
@@ -68,12 +79,12 @@ See [references/workflow.md](references/workflow.md) (Interactive columns) for t
 **Summary:**
 1. Parse the issue — extract motivation, background, proposal, acceptance criteria.
 2. Analyze the codebase — identify files, patterns, dependencies relevant to the issue.
-3. Resolve design decisions — if multiple valid approaches exist, use `AskUserQuestion` to present numbered options with pros/cons and a recommendation. Wait for the user's choice.
+3. Resolve design decisions — if multiple valid approaches exist, ask the user to choose (see Environment Adaptation) from numbered options with pros/cons and a recommendation. Wait for the user's choice.
 4. Draft implementation plan — list files to create/modify, approach for each, edge cases.
 5. Self-evaluate — verify plan addresses all acceptance criteria and stays in scope.
-6. Present the plan as text output, then use `AskUserQuestion` to ask for approval with options: Approve / Request changes / Abort. If the user requests changes, revise and re-present. Do not proceed without approval.
+6. Present the plan as text output, then ask the user to choose (see Environment Adaptation) for approval with options: Approve / Request changes / Abort. If the user requests changes, revise and re-present. Do not proceed without approval.
 
-**Important:** Do NOT use `EnterPlanMode`/`ExitPlanMode` for plan approval. Present the plan directly as text and use `AskUserQuestion` for the approval step.
+**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — present the plan directly as text and collect approval via a user choice. Its approval UI can cause accidental rejections with no way to provide feedback.
 
 ### Phase 2: Implement
 
@@ -83,7 +94,7 @@ See [references/workflow.md](references/workflow.md) for the detailed procedure.
 1. Prepare working environment (worktree / new branch / current branch, per Phase 0 Step 5).
 2. Implement changes following the approved plan. Regenerate derived files if source files that drive code generation were modified.
 3. Run auto-fix commands (formatters, linters with `--fix`) once, then run project checks (tests, lint, type-check, build) — loop until all pass (max 3 attempts).
-4. AI self-review of the full diff — loop until clean (max 3 rounds). Escalate to user (via `AskUserQuestion`) when human judgment is needed. After completion, output a visible self-review summary (e.g., "Self-review: N round(s), N issue(s) found, N fixed").
+4. AI self-review of the full diff — loop until clean (max 3 rounds). Escalate to the user (via a user choice, see Environment Adaptation) when human judgment is needed. After completion, output a visible self-review summary (e.g., "Self-review: N round(s), N issue(s) found, N fixed").
 5. Commit with a message referencing the issue (`Refs #N`).
 
 **Continuous flow**: After user approves the plan, proceed through Phase 2 and Phase 3 without stopping — do not pause between steps unless user input is needed (e.g., escalation).
@@ -94,7 +105,7 @@ See [references/workflow.md](references/workflow.md) for the PR/MR body format a
 
 1. Detect the **code hosting** platform from the git remote URL (this may differ from the issue tracker).
 2. Push the branch and create a PR/MR (title under 70 chars; body with Closes #N / Relates to #N and a test plan).
-3. **Review gates**: run Stage 1 (spec compliance) then Stage 2 (code quality) against the PR diff. Fix findings and push; max 2 fix rounds per stage. If a stage still fails after 2 rounds, escalate to the user via `AskUserQuestion` (Proceed as-is / Keep fixing / Abandon) rather than silently marking anything — Stage 2.5 (pattern propagation) is always skipped in Single mode, since there are no other in-flight PRs to propagate a fix to.
+3. **Review gates**: run Stage 1 (spec compliance) then Stage 2 (code quality) against the PR diff. Fix findings and push; max 2 fix rounds per stage. If a stage still fails after 2 rounds, escalate to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon rather than silently marking anything — Stage 2.5 (pattern propagation) is always skipped in Single mode, since there are no other in-flight PRs to propagate a fix to.
 4. Monitor CI — run `gh pr checks --watch` (GitHub) or `glab mr checks` (GitLab) and verify all checks pass. If CI fails and is fixable, push a fix commit and re-monitor.
 5. If the issue tracker supports comments (e.g., Backlog), post a comment on the issue with the PR/MR link.
 6. Return the PR/MR URL to the user, along with a summary of the review gate results.
@@ -105,7 +116,7 @@ Used for a parent issue's sub-issues, a milestone, a label, or a manual list of 
 
 **Summary:**
 
-1. **Dependency graph** — parse `Blocked by` / `Depends on` / `After` declarations and platform-specific links from each issue body; build a DAG; detect cycles and ask the user how to resolve them; compute parallel execution groups (topological levels); visualize the plan; get approval via `AskUserQuestion` (Approve / Reorder / Abort).
+1. **Dependency graph** — parse `Blocked by` / `Depends on` / `After` declarations and platform-specific links from each issue body; build a DAG; detect cycles and ask the user how to resolve them; compute parallel execution groups (topological levels); visualize the plan; get approval via a user choice (see Environment Adaptation) with options Approve / Reorder / Abort.
 2. **Execution loop** — for each group, dispatch one implementer subagent per issue in parallel, each working in its own git worktree and executing [references/workflow.md](references/workflow.md) in **Autonomous mode** (see that file's Execution Modes table). After each PR is created, the orchestrator runs the two-stage review gates ([references/review-gates.md](references/review-gates.md)), including **Stage 2.5 pattern propagation** across other in-flight PRs when a rule-violation is found. Update the DAG as issues complete; on failure, mark the issue `BLOCKED` and cascade `SKIPPED` to its transitive dependents, then continue with independent issues.
 3. **Summary** — present a status table (issue, title, status, PR) covering DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED / SKIPPED, explain any blockers, and optionally post a summary comment on the parent issue.
 

--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -84,7 +84,7 @@ See [references/workflow.md](references/workflow.md) (Interactive columns) for t
 5. Self-evaluate — verify plan addresses all acceptance criteria and stays in scope.
 6. Present the plan as text output, then ask the user to choose (see Environment Adaptation) for approval with options: Approve / Request changes / Abort. If the user requests changes, revise and re-present. Do not proceed without approval.
 
-**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — present the plan directly as text and collect approval via a user choice. Its approval UI can cause accidental rejections with no way to provide feedback.
+**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — present the plan directly as text and collect approval via a user choice. Plan mode's approval UI can cause accidental rejections with no way to provide feedback.
 
 ### Phase 2: Implement
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -493,10 +493,11 @@ Merged run-sprint's batch execution model (dependency graph, worktree-per-issue 
 
 Converted the interactive surface to agent-neutral capability terms so any
 spec-compliant agent can follow it. Every `AskUserQuestion` gate site (Phase 0
-routing, design decisions, plan approval, check/self-review escalations, Single-
-mode review-gate escalations, the batch dependency-graph approval) now asks the
-user to choose via the **User choice** capability, referencing the new
-Environment Adaptation section in SKILL.md. Plan-mode instructions
+routing, design decisions, plan approval, check/self-review escalations,
+Single-mode review-gate escalations, the Stage 2.5 pattern-propagation prompt,
+and the batch dependency-graph approval) now asks the user to choose via the
+**User choice** capability, referencing the new Environment Adaptation section
+in SKILL.md. Plan-mode instructions
 (`EnterPlanMode`/`ExitPlanMode`) became "On Claude Code specifically" conditional
 notes. The Execution Modes table's Interactive column now names a "user choice
 gate" instead of `AskUserQuestion`. Subagent/batch wording is intentionally

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -164,7 +164,7 @@
 **Expected behavior**:
 - Fetch the issue and detect that it is closed/merged in Phase 0 (before Phase 1)
 - Inform the user: "Issue #15 is already closed."
-- Present options via AskUserQuestion: "Reopen and implement" / "Pick another issue" / "Abort"
+- Present options via a user choice: "Reopen and implement" / "Pick another issue" / "Abort"
 - If "Reopen and implement": reopen the issue and proceed with normal flow
 - If "Pick another issue": return to issue selection
 - If "Abort": stop without entering Phase 1
@@ -338,7 +338,7 @@
 
 **Expected behavior**:
 - Phase 0 detects that #40 has open sub-issues (via the platform guide's sub-issue/child detection)
-- Presents `AskUserQuestion`: "Implement all sub-issues (batch)" (Recommended, since 2+ children are open) / "Implement only this issue" / "Pick one sub-issue"
+- Presents a user choice: "Implement all sub-issues (batch)" (Recommended, since 2+ children are open) / "Implement only this issue" / "Pick one sub-issue"
 - If the user picks batch: proceeds to Batch mode (Phase B1 dependency graph) using #41-#43 as the source set
 - If the user picks "only this issue": treats #40 as a normal single issue, does not touch #41-#43
 - If the user picks "pick one": lists #41-#43 and continues in Single mode with the selected child
@@ -488,3 +488,31 @@ No issues found. Changes are additive and localized to §2-2, §2-3, and §3-x o
 ### 2026-07-05 — Merged run-sprint into implement-issue
 
 Merged run-sprint's batch execution model (dependency graph, worktree-per-issue parallel dispatch, two-stage review with pattern propagation) into implement-issue as "Batch mode". Added criteria 19-23 and cases 16-24 (16-21 renumbered from run-sprint's 6 cases, 22-24 new for parent-issue detection and mode routing). Case numbering for 1-15 preserved from the original implement-issue log above.
+
+### 2026-07-10 — Capability-based gates and plan-mode notes (Refs #61)
+
+Converted the interactive surface to agent-neutral capability terms so any
+spec-compliant agent can follow it. Every `AskUserQuestion` gate site (Phase 0
+routing, design decisions, plan approval, check/self-review escalations, Single-
+mode review-gate escalations, the batch dependency-graph approval) now asks the
+user to choose via the **User choice** capability, referencing the new
+Environment Adaptation section in SKILL.md. Plan-mode instructions
+(`EnterPlanMode`/`ExitPlanMode`) became "On Claude Code specifically" conditional
+notes. The Execution Modes table's Interactive column now names a "user choice
+gate" instead of `AskUserQuestion`. Subagent/batch wording is intentionally
+unchanged (follow-up #66), so `references/batch.md` still has 2 bare user-choice
+sites. Earlier Evaluation Log entries keep their original tool names as a
+historical record, not as instructions.
+
+| Case | Result | Notes |
+|------|--------|-------|
+| 1 | Pass (9/9) | Location choice and plan approval now via the user-choice capability; questions and options unchanged |
+| 11 | Pass (1/1) | Closed-issue options presented via a user choice; wording aligned |
+| 22 | Pass (2/2) | Parent-issue routing question presented via a user choice; wording aligned |
+| 23 | Pass (1/1) | Single-mode gate escalations reference the user-choice capability |
+
+No behavioral change: each gate asks the same question with the same options;
+only the mechanism is now described as a capability. Verified by grep that no
+bare `AskUserQuestion`/`EnterPlanMode`/`ExitPlanMode` instruction remains in the
+four modified files outside the Environment Adaptation section, the "On Claude
+Code specifically" notes, and the historical Evaluation Log entries above.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -62,7 +62,7 @@ If spec compliance fails:
 2. Re-run spec compliance review.
 3. Max 2 fix rounds. If still failing:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS` and include the review output in the batch summary.
-   - **Single mode**: present the remaining findings to the user via `AskUserQuestion` (Proceed as-is / Keep fixing / Abandon) instead of silently marking anything — there is a user present to decide.
+   - **Single mode**: present the remaining findings to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon instead of silently marking anything — there is a user present to decide.
 
 ## Stage 2: Code Quality Review
 
@@ -118,7 +118,7 @@ If code quality review finds Critical or Important issues:
 2. Re-run code quality review.
 3. Max 2 fix rounds. If Critical issues remain:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS`.
-   - **Single mode**: present the remaining Critical findings to the user via `AskUserQuestion` (Proceed as-is / Keep fixing / Abandon).
+   - **Single mode**: present the remaining Critical findings to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon.
 
 ## Stage 2.5: Pattern Propagation (Batch Mode Only)
 
@@ -139,7 +139,7 @@ Classify a violation as `rule-violation-instance` (rather than a one-off bug) wh
    git diff origin/<default-branch>...<branch> | grep -n <pattern>
    ```
 2. Collect all matches across in-flight branches.
-3. Present findings to the user via `AskUserQuestion`:
+3. Present findings to the user via a user choice (see Environment Adaptation):
    > "Pattern violation `<pattern>` found in N other in-flight PR(s): <list>. What would you like to do?"
    > Options: Apply fix to all / Select which PRs / Skip propagation
 4. For each approved PR, dispatch a fix subagent to apply the same fix.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -10,11 +10,11 @@ This pipeline runs in one of two modes:
 | Step | Interactive | Autonomous |
 |---|---|---|
 | 1-1 missing/vague issue fields | Ask the user, or propose criteria and confirm | Stop and report status `NEEDS_CONTEXT` with what is missing |
-| 1-3 design decisions | `AskUserQuestion` with numbered options | Use the issue's Implementation Approach section if present; otherwise choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
-| 1-6 plan approval | Present as text + `AskUserQuestion` gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the subagent and is not presented for approval |
+| 1-3 design decisions | User choice gate with numbered options | Use the issue's Implementation Approach section if present; otherwise choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
+| 1-6 plan approval | Present as text + user choice gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the subagent and is not presented for approval |
 | 2-1 working environment | The choice made in Phase 0 Setup (Worktree / New branch / Current branch) | Always the worktree the orchestrator already created before dispatch |
-| 2-3 checks fail after 3 attempts | Escalate via `AskUserQuestion` (continue / skip / abandon) | Stop and report status `BLOCKED` with the error |
-| 2-4 self-review needs human judgment | Escalate via `AskUserQuestion` | Note the concern in the PR description, continue, and report status `DONE_WITH_CONCERNS` |
+| 2-3 checks fail after 3 attempts | Escalate via user choice gate (continue / skip / abandon) | Stop and report status `BLOCKED` with the error |
+| 2-4 self-review needs human judgment | Escalate via user choice gate | Note the concern in the PR description, continue, and report status `DONE_WITH_CONCERNS` |
 | 3-2 unfixable CI failure | Note in the PR description, tell the user | Note in the PR description and report status `DONE_WITH_CONCERNS` |
 
 Every step below is written from the Interactive perspective by default; where behavior diverges, an "Autonomous mode" note follows the step, keyed to the table above.
@@ -63,7 +63,7 @@ Before drafting the plan, identify any decisions that require human judgment. Ex
 - Technology or library choices not dictated by CLAUDE.md
 - Scope boundaries (what's "good enough" for this issue)
 
-For each decision point, use `AskUserQuestion` with numbered options:
+For each decision point, ask the user to choose (see Environment Adaptation) from numbered options:
 
 1. **Present options** (2–4 choices) with:
    - A short label for each option
@@ -77,7 +77,7 @@ When the user selects "Other" and provides free-text input, treat their text as 
 
 If no design decisions require human input, skip this step and proceed to 1-4.
 
-**Autonomous mode**: do not use `AskUserQuestion`. If the issue includes an Implementation Approach section, follow it. Otherwise choose the option most consistent with existing project conventions, and note the choice and its rationale in the PR body so a human reviewer can revisit it. If the decision is genuinely undecidable (no convention to lean on, and the outcome materially changes the result), stop and return status `NEEDS_CONTEXT`.
+**Autonomous mode**: do not present a user choice. If the issue includes an Implementation Approach section, follow it. Otherwise choose the option most consistent with existing project conventions, and note the choice and its rationale in the PR body so a human reviewer can revisit it. If the decision is genuinely undecidable (no convention to lean on, and the outcome materially changes the result), stop and return status `NEEDS_CONTEXT`.
 
 ### 1-4. Draft Implementation Plan
 
@@ -126,16 +126,16 @@ If any check fails, revise the plan before presenting.
 
 ### 1-6. Present and Get Approval
 
-Present the plan as **text output** (not via `EnterPlanMode`). Clearly state:
+Present the plan as regular **text output**. Clearly state:
 
 - What will change and why
 - Any assumptions or decisions made
 - Questions or trade-offs requiring user input
 
-Then use `AskUserQuestion` to request approval:
+Then collect approval via a user choice (see Environment Adaptation):
 
 ```
-AskUserQuestion with options:
+User choice with options:
 - "Approve" — Proceed with implementation.
 - "Request changes" — Revise the plan based on feedback.
 - "Abort" — Cancel the implementation.
@@ -145,12 +145,12 @@ AskUserQuestion with options:
 1. Read the user's feedback carefully.
 2. Treat the feedback as specific change requests — incorporate them directly into the revised plan. Do NOT re-present new multiple-choice options based on the feedback. If the user wrote "do X instead of Y", revise the plan to do X.
 3. Re-present the revised plan.
-4. Ask for approval again using `AskUserQuestion` with the same options.
+4. Ask for approval again via a user choice with the same options.
 5. Repeat until the user approves or aborts.
 
 Only re-ask for clarification if the feedback is genuinely ambiguous (e.g., contradicts other requirements, or is too vague to act on). If re-asking, quote the user's text and explain specifically what needs clarification.
 
-**Important:** Do NOT use `EnterPlanMode`/`ExitPlanMode` for plan approval. The `ExitPlanMode` UI can cause accidental rejections with no way to provide feedback, leading to abandoned sessions.
+**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — its approval UI can cause accidental rejections with no way to provide feedback, leading to abandoned sessions.
 
 **Autonomous mode**: skip this step entirely. There is no user to present the plan to — the plan drafted in 1-4 is used directly as the internal basis for implementation, without a gate.
 
@@ -243,13 +243,13 @@ Run whatever the project defines. **Loop (max 3 attempts):**
 2. If any fail, fix the issue and re-run all checks.
 3. Repeat until all checks pass or 3 attempts are reached.
 
-If a fix requires a design decision (e.g., how to handle an unexpected edge case), use `AskUserQuestion` to present numbered options with a recommendation and wait for the user's choice.
+If a fix requires a design decision (e.g., how to handle an unexpected edge case), ask the user to choose (see Environment Adaptation) from numbered options with a recommendation and wait for the user's choice.
 
-**If checks still fail after 3 attempts**: Stop and escalate to the user. Use `AskUserQuestion` to present:
+**If checks still fail after 3 attempts**: Stop and escalate to the user via a user choice (see Environment Adaptation) presenting:
 - Which checks are still failing and what was tried
 - Options: continue trying, skip the failing check, or abandon the implementation
 
-**Autonomous mode**: do not use `AskUserQuestion`. Stop and return status `BLOCKED` with which checks are failing and what was tried.
+**Autonomous mode**: do not present a user choice. Stop and return status `BLOCKED` with which checks are failing and what was tried.
 
 If the project has no defined checks, skip this step but note it when creating the PR.
 
@@ -273,17 +273,17 @@ Check for:
 1. Review the diff.
 2. If issues found:
    - Fix issues that have a clear correct solution.
-   - If a fix requires human judgment (e.g., ambiguous requirements, UX trade-offs, business logic), use `AskUserQuestion` to present the issue with numbered options and a recommendation. Wait for the user's choice.
+   - If a fix requires human judgment (e.g., ambiguous requirements, UX trade-offs, business logic), ask the user to choose (see Environment Adaptation) from numbered options with a recommendation. Wait for the user's choice.
 3. After fixes, re-run project checks (Step 2-3) to ensure fixes don't break anything.
 4. Re-review the diff.
 5. Repeat until no issues remain or 3 review rounds are reached.
 
-**If issues remain after 3 rounds**: Stop and use `AskUserQuestion` to present remaining issues. Let the user decide whether to:
+**If issues remain after 3 rounds**: Stop and ask the user to choose (see Environment Adaptation), presenting the remaining issues. Let the user decide whether to:
 - Proceed with known issues
 - Fix manually
 - Abandon the implementation
 
-**Autonomous mode**: do not use `AskUserQuestion`. Note the remaining concerns in the PR description and continue — this issue will be reported as status `DONE_WITH_CONCERNS`.
+**Autonomous mode**: do not present a user choice. Note the remaining concerns in the PR description and continue — this issue will be reported as status `DONE_WITH_CONCERNS`.
 
 **After self-review completes**, output a visible summary before proceeding to commit:
 


### PR DESCRIPTION
## Summary

- Convert implement-issue's interactive surface (30 `AskUserQuestion` gate sites + plan-mode references) to agent-neutral capability wording so any spec-compliant agent can follow the skill, not just Claude Code.
- Add an Environment Adaptation section to `SKILL.md` listing all three capabilities the skill uses (User choice, Separate agent instance, Background execution), instantiated from the canonical AGENTS.md template.
- Turn `EnterPlanMode`/`ExitPlanMode` instructions into "On Claude Code specifically" conditional enhancement notes.

Closes #61

## Changes

- **SKILL.md** — Added the Environment Adaptation section (all three capabilities). Rewrote 9 `AskUserQuestion` gate sites (Phase 0 mode routing, closed-issue handling, location choice, design decisions, plan approval, self-review escalation, Single-mode review-gate escalation, batch dependency-graph approval) to "ask the user to choose (see Environment Adaptation)". Converted the plan-approval plan-mode caveat into an "On Claude Code specifically" note. File is 131 lines (well under 500).
- **references/workflow.md** — Execution Modes table Interactive column now names a "user choice gate" instead of `AskUserQuestion` (rows 1-3, 1-6, 2-3, 2-4). Rewrote the body gate sites in §1-3, §1-6, §2-3, §2-4, including the `User choice with options:` code block. Converted both plan-mode notes (§1-6, L129 + L153 area) into an "On Claude Code specifically" note and plain text output. Rewrote the three `Autonomous mode: do not use AskUserQuestion` lines to `do not present a user choice`.
- **references/review-gates.md** — Rewrote the three Single-mode escalation gate sites (Stage 1 on-failure, Stage 2 on-failure, Stage 2.5 propagation prompt) to the user-choice capability.
- **references/eval-cases.md** — Aligned forward-looking expectations in Case 11 and Case 22 to "user choice" wording; added a 2026-07-10 evaluation log entry documenting the change.

## Scope notes for follow-up #66

- **No mixed-concern sentences were found in the four files.** Per the issue, a sentence mixing user-choice and subagent/background concerns would be converted wholesale and listed here. None of the rewritten sentences also carried `subagent`/background wording, so nothing was converted beyond the user-choice/plan-mode surface. All `subagent`/orchestrator wording is left untouched.
- **`references/batch.md` was intentionally not touched** (not in this issue's file list). It still contains 2 bare user-choice `AskUserQuestion` sites (dependency-graph approval and cycle-resolution) that live inside the batch-orchestration reference; these should be swept when the subagent/batch wording is handled in #66.
- **Historical Evaluation Log entries in eval-cases.md keep their original tool names** (e.g. the 2026-03-08 entry) as a faithful record of past changes — they are records, not instructions, so they are outside the "no bare token" acceptance criterion.

## Test Plan

- [x] No bare `AskUserQuestion`/`EnterPlanMode`/`ExitPlanMode` instruction remains in the four modified files outside the Environment Adaptation section, "On Claude Code specifically" notes, and the Evaluation Log (verified by grep).
- [x] All approval/escalation gates reference the user-choice capability (see Environment Adaptation).
- [x] SKILL.md remains under 500 lines (131).
- [x] eval-cases.md expectations match the new wording; evaluation log entry appended.