### PR TITLE
implement-issue: agent-instance fallback and neutral worktree path

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -6,7 +6,8 @@ description: >
   compliance, then code quality). Implements a single issue interactively by
   default; when given a parent issue, a milestone, a label, or a list of
   issues, offers batch implementation with a dependency graph, git worktrees,
-  and parallel agent instances. Use when the user says "implement issue",
+  and parallel agent instances where the environment supports them (sequential
+  otherwise). Use when the user says "implement issue",
   "issue を実装", "issue #N を対応", "この issue をやって", "implement #N",
   "fix issue #N", "work on issue", "run sprint", "スプリント実行",
   "これらの issue を実装", "implement these issues", "start the sprint",
@@ -16,7 +17,7 @@ description: >
 
 # Implement Issue
 
-Read an issue (or a set of issues), plan the implementation, get approval, implement, and create PR(s)/MR(s) with two-stage review. **Single mode** (one issue, interactive) is the default. **Batch mode** (many issues, dependency-ordered, parallel) is used for parent issues, milestones, labels, or explicit lists.
+Read an issue (or a set of issues), plan the implementation, get approval, implement, and create PR(s)/MR(s) with two-stage review. **Single mode** (one issue, interactive) is the default. **Batch mode** (many issues, dependency-ordered, parallel where the environment supports it) is used for parent issues, milestones, labels, or explicit lists.
 
 ## Core Principles
 
@@ -122,7 +123,7 @@ Used for a parent issue's sub-issues, a milestone, a label, or a manual list of 
 ## References
 
 - [references/workflow.md](references/workflow.md) — Canonical plan/implement/PR procedure, used by both Single mode (Interactive) and Batch mode's implementer agent instances (Autonomous)
-- [references/batch.md](references/batch.md) — Batch mode dependency graph, parallel dispatch, and failure handling
+- [references/batch.md](references/batch.md) — Batch mode dependency graph, dependency-ordered dispatch (parallel where supported), and failure handling
 - [references/review-gates.md](references/review-gates.md) — Two-stage review procedure (Stage 1 spec compliance, Stage 2 code quality, Stage 2.5 pattern propagation)
 - [references/platform-github.md](references/platform-github.md) — GitHub CLI commands
 - [references/platform-gitlab.md](references/platform-gitlab.md) — GitLab CLI commands

--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -6,7 +6,7 @@ description: >
   compliance, then code quality). Implements a single issue interactively by
   default; when given a parent issue, a milestone, a label, or a list of
   issues, offers batch implementation with a dependency graph, git worktrees,
-  and parallel subagents. Use when the user says "implement issue",
+  and parallel agent instances. Use when the user says "implement issue",
   "issue を実装", "issue #N を対応", "この issue をやって", "implement #N",
   "fix issue #N", "work on issue", "run sprint", "スプリント実行",
   "これらの issue を実装", "implement these issues", "start the sprint",
@@ -25,7 +25,7 @@ Read an issue (or a set of issues), plan the implementation, get approval, imple
 3. **Small, reviewable changes** — Prefer focused PRs. If an issue is large, suggest splitting (see the create-issue skill's Split Proposal). If the user insists on a single PR, implement incrementally with clear scope per commit.
 4. **Follow project conventions** — Read CLAUDE.md and existing code patterns before implementing.
 5. **Two-stage review on every PR** — Spec compliance, then code quality, in both modes (see [references/review-gates.md](references/review-gates.md)). They catch different classes of problems; combining them into one review loses signal.
-6. **Dependency-driven parallelism** (Batch mode) — Issues with no unresolved dependencies run in parallel. The dependency graph is the scheduler.
+6. **Dependency-driven parallelism** (Batch mode) — Issues with no unresolved dependencies can run in parallel where the environment supports it. The dependency graph is the scheduler; parallelism is an optimization on top of it, not a requirement (see [references/batch.md](references/batch.md)).
 7. **Worktree isolation** (Batch mode) — Each issue gets its own git worktree. No cross-contamination between parallel implementations.
 8. **Fail fast, report clearly** (Batch mode) — If an issue fails after retries, mark it blocked and continue with independent issues. Never block the entire batch on one failure.
 
@@ -38,7 +38,6 @@ below use capability terms; map them to your environment as follows.
 |---|---|---|
 | **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
 | **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body or reply comment the step produces) |
-| **Background execution** — run long commands without blocking | Background shell (e.g. Claude Code's background Bash) | Run commands sequentially |
 
 ## Phase 0: Setup and Mode Selection
 
@@ -117,12 +116,12 @@ Used for a parent issue's sub-issues, a milestone, a label, or a manual list of 
 **Summary:**
 
 1. **Dependency graph** — parse `Blocked by` / `Depends on` / `After` declarations and platform-specific links from each issue body; build a DAG; detect cycles and ask the user how to resolve them; compute parallel execution groups (topological levels); visualize the plan; get approval via a user choice (see Environment Adaptation) with options Approve / Reorder / Abort.
-2. **Execution loop** — for each group, dispatch one implementer subagent per issue in parallel, each working in its own git worktree and executing [references/workflow.md](references/workflow.md) in **Autonomous mode** (see that file's Execution Modes table). After each PR is created, the orchestrator runs the two-stage review gates ([references/review-gates.md](references/review-gates.md)), including **Stage 2.5 pattern propagation** across other in-flight PRs when a rule-violation is found. Update the DAG as issues complete; on failure, mark the issue `BLOCKED` and cascade `SKIPPED` to its transitive dependents, then continue with independent issues.
+2. **Execution loop** — for each group, implement its issues, each in its own git worktree and executing [references/workflow.md](references/workflow.md) in **Autonomous mode** (see that file's Execution Modes table). Where the environment supports separate agent instances, dispatch one implementer per issue in parallel; otherwise implement them sequentially in dependency order in the current context (see [references/batch.md](references/batch.md)) — the DAG, review gates, and failure cascade are identical either way, only wall-clock parallelism differs. After each PR is created, the orchestrator runs the two-stage review gates ([references/review-gates.md](references/review-gates.md)), including **Stage 2.5 pattern propagation** across other in-flight PRs when a rule-violation is found. Update the DAG as issues complete; on failure, mark the issue `BLOCKED` and cascade `SKIPPED` to its transitive dependents, then continue with independent issues.
 3. **Summary** — present a status table (issue, title, status, PR) covering DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED / SKIPPED, explain any blockers, and optionally post a summary comment on the parent issue.
 
 ## References
 
-- [references/workflow.md](references/workflow.md) — Canonical plan/implement/PR procedure, used by both Single mode (Interactive) and Batch mode's implementer subagents (Autonomous)
+- [references/workflow.md](references/workflow.md) — Canonical plan/implement/PR procedure, used by both Single mode (Interactive) and Batch mode's implementer agent instances (Autonomous)
 - [references/batch.md](references/batch.md) — Batch mode dependency graph, parallel dispatch, and failure handling
 - [references/review-gates.md](references/review-gates.md) — Two-stage review procedure (Stage 1 spec compliance, Stage 2 code quality, Stage 2.5 pattern propagation)
 - [references/platform-github.md](references/platform-github.md) — GitHub CLI commands

--- a/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
@@ -1,8 +1,10 @@
-# Batch Mode: Dependency Graph and Parallel Execution
+# Batch Mode: Dependency Graph and Dependency-Ordered Execution
 
-This procedure is used in **Batch Mode** (see SKILL.md) to implement a set of issues — from a parent issue's sub-issues, a milestone, a label, or a manual list — in parallel where their dependencies allow, with worktree isolation and two-stage review per issue.
+This procedure is used in **Batch Mode** (see SKILL.md) to implement a set of issues — from a parent issue's sub-issues, a milestone, a label, or a manual list — in dependency order (in parallel where the environment allows), with worktree isolation and two-stage review per issue.
 
-The per-issue implementation itself is NOT duplicated here: each issue is implemented by a subagent executing [workflow.md](workflow.md) in **Autonomous mode** (see workflow.md's Execution Modes table). This file covers only the orchestration around that: building the dependency graph, dispatching subagents, running review gates, and handling failures.
+The per-issue implementation itself is NOT duplicated here: each issue is implemented by running [workflow.md](workflow.md) in **Autonomous mode** (see workflow.md's Execution Modes table). This file covers only the orchestration around that: building the dependency graph, running the implementer for each issue, running review gates, and handling failures.
+
+**Separate agent instances are an optimization, not a requirement.** Where the environment supports separate agent instances (see Environment Adaptation in SKILL.md), the orchestrator runs each issue's implementer and each review gate as its own instance, and dispatches an entire dependency group at once for wall-clock parallelism. Where it does not, the orchestrator runs the same steps sequentially in dependency order in the current context. The dependency DAG, review gates, and failure cascade below are identical either way — only wall-clock parallelism is lost in the sequential case.
 
 ## Phase B1: Dependency Graph
 
@@ -28,7 +30,7 @@ Build a mapping: `{ issueNumber → [blockedByIssueNumbers] }`
 1. Create a directed graph: edge from A → B means "A must complete before B can start".
 2. Detect cycles using topological sort. If a cycle is found:
    - Present the cycle to the user: "Circular dependency detected: #A → #B → #C → #A"
-   - Use `AskUserQuestion` with options:
+   - Ask the user to choose (see Environment Adaptation in SKILL.md) with options:
      - Break the dependency between #X and #Y (for each edge in the cycle)
      - Abort the batch
 3. Compute topological levels (groups of issues that can run in parallel):
@@ -55,47 +57,52 @@ Group 3 (sequential, after Group 2):
   #105 — Integration tests [Medium] ← depends on #103, #104
 ```
 
-Use `AskUserQuestion` — "Proceed with this execution plan?" with options: Approve / Reorder / Abort.
+Ask the user to choose (see Environment Adaptation in SKILL.md) — "Proceed with this execution plan?" with options: Approve / Reorder / Abort.
 
 ## Phase B2: Execution Loop
 
-Repeat until all issues are completed or all remaining issues are blocked:
+Repeat until all issues are completed or all remaining issues are blocked.
+
+**Execution model — parallel or sequential.** When the environment can run separate agent instances in parallel, dispatch a whole group's issues at once and wait for the group to finish before starting the next. When it cannot, implement each group's issues **sequentially in dependency order** in the current context, still using one worktree per issue. The DAG, review gates, and failure cascade are unchanged; only wall-clock parallelism is lost. The steps below are written for the parallel case; in the sequential case, "dispatch"/"run the implementer" means "execute those same instructions yourself, one issue at a time, in group-then-dependency order."
 
 ### B2-1. Per-Group Execution
 
-Process groups in order. Within each group, dispatch all issues in parallel.
+Process groups in dependency order. Within a group the issues are independent of each other, so run them in parallel where the environment supports it, otherwise one after another.
 
 For each issue in the current group:
 
-1. **Create worktree:**
+1. **Create worktree** (keep the worktree directory out of version control with a per-clone git exclude — `.git/info/exclude` is local to the clone, so it never appears in the PR the way editing `.gitignore` would):
    ```bash
    git fetch origin
-   git worktree add .claude/worktrees/<branch-name> -b <branch-name> origin/<default-branch>
+   grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
+   git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branch>
    ```
    Branch naming: `<type>/<issue-number>-<short-description>`
-2. **Dispatch an implementer subagent** using the prompt template below.
-3. **Wait for completion** of all issues in the group before proceeding to the next group.
+2. **Run the implementer** using the instruction template below — as a separate agent instance where available, otherwise by executing those same instructions yourself in the issue's worktree.
+3. **Wait for completion** of all issues in the current group before proceeding to the next group.
 
-### B2-2. Implementer Subagent Prompt Template
+### B2-2. Implementer Instruction Template
 
-Dispatch each implementer subagent with a prompt that includes:
+Run each issue's implementer with an instruction set that includes:
 
 1. The full issue body and issue number.
-2. The absolute path to the worktree already created for it (step B2-1) — the subagent works there, it does not create its own.
+2. The absolute path to the worktree already created for it (step B2-1) — the implementer works there, it does not create its own.
 3. The absolute paths to this skill's [workflow.md](workflow.md) and the relevant `platform-*.md` guide, with the instruction:
    > "Read these files, then execute workflow.md Phases 1–3 in **Autonomous mode** inside the given worktree. Stop after creating the PR/MR and monitoring CI (workflow.md step 3-2) — do not run the review gates yourself, the orchestrator runs them. Return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md's Report Status step."
 4. The project's CLAUDE.md path.
 
-Resolve the absolute paths to `workflow.md` and the platform guide at dispatch time (they live alongside this file in the skill's `references/` directory) — do not rely on the subagent inferring them.
+Resolve the absolute paths to `workflow.md` and the platform guide before starting the implementer (they live alongside this file in the skill's `references/` directory) — do not rely on the implementer inferring them. When running as a separate agent instance, pass this as its dispatch prompt; when running in the current context, follow it directly.
 
 ### B2-3. Review Gates
 
-After each issue's PR/MR is created (and the subagent has reported):
+After each issue's PR/MR is created (and the implementer has reported):
 
-1. Stage 1: Dispatch a **spec compliance reviewer** subagent (see [review-gates.md](review-gates.md)).
-2. Stage 2: Dispatch a **code quality reviewer** subagent (see [review-gates.md](review-gates.md)).
+1. Stage 1: Run a **spec compliance reviewer** (see [review-gates.md](review-gates.md)).
+2. Stage 2: Run a **code quality reviewer** (see [review-gates.md](review-gates.md)).
 3. Stage 2.5: **Pattern Propagation** — if a `rule-violation-instance` is found, scan other in-flight PRs for the same pattern and offer to propagate the fix (see [review-gates.md](review-gates.md)). This stage only runs in Batch mode, when 2+ issues are in flight.
-4. If issues are found at Stage 1 or 2 → re-dispatch the implementer subagent to fix → re-review (max 2 fix rounds per stage).
+4. If issues are found at Stage 1 or 2 → re-run the implementer to fix → re-review (max 2 fix rounds per stage).
+
+Run each reviewer as a separate agent instance with fresh context where the environment supports one; otherwise self-review and mark the gate result `SELF-REVIEWED` — see review-gates.md's "Reviewer Dispatch" note for the exact procedure and marker semantics.
 
 ### B2-4. Failure Handling
 
@@ -121,7 +128,7 @@ After each issue completes (regardless of status):
 
 - If DONE or DONE_WITH_CONCERNS: worktree is no longer needed (branch is pushed). Remove it:
   ```bash
-  git worktree remove .claude/worktrees/<branch-name>
+  git worktree remove .worktrees/<branch-name>
   ```
 - If BLOCKED: keep the worktree for debugging. Inform the user of the path.
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -541,8 +541,9 @@ product-specific `.claude` directory to a neutral `.worktrees/`:
   SKILL.md's unused **Background execution** capability row was removed (nothing in the
   skill runs background commands).
 
-Consistency edits in this file, outside the historical log: Cases 17, 19, and 23 now use
-neutral "agent instance" wording instead of "subagent".
+Consistency edits in this file, outside the historical log: Cases 17 and 23 now use neutral
+"agent instance" wording, and Case 19 drops the stray "subagent" qualifier ("Implementer
+subagent fixes" → "Implementer fixes").
 
 | Case | Result | Notes |
 |------|--------|-------|

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -252,7 +252,7 @@
 4. All 4 PRs created
 
 **Verification:**
-- [ ] #201 and #202 run in parallel (concurrent subagents)
+- [ ] #201 and #202 run in parallel (concurrent agent instances, where the environment supports them)
 - [ ] #203 waits for #201 to complete
 - [ ] #204 waits for #202 to complete
 - [ ] No worktree conflicts between parallel issues
@@ -287,7 +287,7 @@
 **Expected behavior:**
 1. Issue implemented without pagination
 2. Spec compliance review (Stage 1): FAIL — AC "paginated results" not met
-3. Implementer subagent fixes: adds pagination
+3. Implementer fixes: adds pagination
 4. Re-review: PASS
 5. Code quality review (Stage 2): runs on updated code
 6. Final status: DONE (after fix round)
@@ -351,7 +351,7 @@
 
 **Expected behavior**:
 - PR is created
-- Stage 1 spec compliance review (run by the main agent, not a subagent) finds AC "paginated" not met → FAIL
+- Stage 1 spec compliance review (run by the main agent, not a separate agent instance) finds AC "paginated" not met → FAIL
 - Main agent fixes and pushes directly (no orchestrator, no re-dispatch)
 - Re-review: PASS
 - Stage 2 code quality review runs next
@@ -517,3 +517,41 @@ only the mechanism is now described as a capability. Verified by grep that no
 bare `AskUserQuestion`/`EnterPlanMode`/`ExitPlanMode` instruction remains in the
 four modified files outside the Environment Adaptation section, the "On Claude
 Code specifically" notes, and the historical Evaluation Log entries above.
+
+### 2026-07-10 — Agent-instance fallback and neutral worktree path (Refs #66)
+
+Made Batch mode and the review gates runnable — degraded but correct — on agents
+without separate-agent-instance support, and moved the worktree location off the
+product-specific `.claude` directory to a neutral `.worktrees/`:
+
+- `batch.md` states the execution model up front: dispatch a whole dependency group
+  as separate agent instances in parallel where supported, otherwise implement each
+  group's issues **sequentially in dependency order** in the current context. The DAG,
+  review gates, and failure cascade are unchanged; only wall-clock parallelism is lost.
+  The 2 deferred bare user-choice sites (cycle resolution in B1-2, plan approval in
+  B1-3) now reference the User choice capability, closing the gap left by #61.
+- `review-gates.md` adds a "Reviewer Dispatch" note: run each reviewer as a separate
+  agent instance where available, otherwise self-review and mark the gate's real
+  verdict `SELF-REVIEWED (no independent reviewer available)`. The marker rides on the
+  verdict — it does not replace it — so the fix routing is unchanged.
+- All `git worktree` commands (workflow.md, batch.md, platform-github/gitlab/backlog.md)
+  now use `.worktrees/` with a `.git/info/exclude` guard, so the ignore stays local to
+  the clone and never lands in a user PR.
+- Subagent/Task-tool vocabulary replaced with "separate agent instance" per AGENTS.md.
+  SKILL.md's unused **Background execution** capability row was removed (nothing in the
+  skill runs background commands).
+
+Consistency edits in this file, outside the historical log: Cases 17, 19, and 23 now use
+neutral "agent instance" wording instead of "subagent".
+
+| Case | Result | Notes |
+|------|--------|-------|
+| 16 | Pass | Linear batch runs identically whether parallel or sequential; worktree path now `.worktrees/` |
+| 17 | Pass | Parallel path unchanged where separate agent instances are available; sequential fallback preserves group-then-dependency order |
+| 18 | Pass | Failure cascade (BLOCKED → SKIPPED dependents) is identical in both execution models |
+| 19 | Pass | Two-stage review runs per issue; reviewer falls back to the `SELF-REVIEWED` marker when no separate instance is available |
+
+No behavioral change for environments with separate agent instances (e.g. Claude Code):
+parallel dispatch, worktree isolation, and the review gates work exactly as before — only
+the worktree directory moved. Verified by grep that no product-specific `.claude` worktree
+path remains anywhere under the skill directory.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
@@ -72,7 +72,8 @@ git checkout -b <branch-name>
 
 ```bash
 git fetch origin
-git worktree add .claude/worktrees/<branch-name> -b <branch-name> origin/<default-branch>
+grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
+git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branch>
 ```
 
 ## Push Branch

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
@@ -72,7 +72,8 @@ git checkout -b <branch-name>
 
 ```bash
 git fetch origin
-git worktree add .claude/worktrees/<branch-name> -b <branch-name> origin/<default-branch>
+grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
+git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branch>
 ```
 
 ## Push Branch

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
@@ -62,7 +62,8 @@ git checkout -b <branch-name>
 
 ```bash
 git fetch origin
-git worktree add .claude/worktrees/<branch-name> -b <branch-name> origin/<default-branch>
+grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
+git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branch>
 ```
 
 ## Push Branch

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -9,9 +9,15 @@ Every PR/MR goes through two review stages before being marked as done — wheth
 
 These are separate concerns. Spec compliance prevents over-building and under-building. Code quality catches bugs and style issues. Combining them into one review loses signal.
 
-**Single mode note**: with only one issue in flight, the main agent runs both stages itself (there is no separate orchestrator/subagent split). Stage 2.5 (pattern propagation) never runs in Single mode — there are no other in-flight PRs to scan.
+**Single mode note**: with only one issue in flight, the main agent runs both stages itself (there is no separate orchestrator/reviewer split). Stage 2.5 (pattern propagation) never runs in Single mode — there are no other in-flight PRs to scan.
 
-**Batch mode note**: the orchestrator dispatches a fresh reviewer subagent per stage per issue, and Stage 2.5 is active whenever a rule violation is found with 2+ issues in flight.
+**Batch mode note**: the orchestrator runs a fresh reviewer per stage per issue, and Stage 2.5 is active whenever a rule violation is found with 2+ issues in flight.
+
+## Reviewer Dispatch
+
+A review is strongest when run by a **separate agent instance** (see Environment Adaptation in SKILL.md) with fresh context that has not seen the implementation — an independent reviewer is not anchored to the choices the implementer already made. Both stages below assume that ideal.
+
+**Fallback when no separate agent instance is available.** Run the stage's checklist yourself and produce the stage's real verdict exactly as defined below (Stage 1: PASS/FAIL with the issue list; Stage 2: severity-tagged issue counts and PASS/NEEDS_FIXES). Then mark that verdict `SELF-REVIEWED (no independent reviewer available)`. The marker **rides on** the real result — it does not replace it — so the On-Failure fix routing (max 2 rounds, then DONE_WITH_CONCERNS in Batch / escalate in Single) applies unchanged. Record the marker next to the gate outcome in the PR/MR body so a human can see the independent-review guarantee did not hold.
 
 ## Stage 1: Spec Compliance Review
 
@@ -23,7 +29,7 @@ Review with:
 - The PR diff (`git diff origin/<default-branch>...<branch-name>`)
 - Instructions below
 
-**Batch mode**: dispatch a dedicated reviewer subagent with the above context. **Single mode**: the main agent performs this review directly on the diff it just produced.
+**Batch mode**: run a dedicated reviewer with the above context — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent performs this review directly on the diff it just produced.
 
 ### Review Criteria
 
@@ -58,7 +64,7 @@ Issues:
 
 If spec compliance fails:
 
-1. Fix the issues found (in Batch mode: send the review output to the implementer subagent, which fixes and pushes; in Single mode: the main agent fixes and pushes directly).
+1. Fix the issues found (in Batch mode: send the review output to the implementer, which fixes and pushes; in Single mode: the main agent fixes and pushes directly).
 2. Re-run spec compliance review.
 3. Max 2 fix rounds. If still failing:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS` and include the review output in the batch summary.
@@ -74,7 +80,7 @@ Review with:
 - Project conventions (CLAUDE.md path)
 - Instructions below
 
-**Batch mode**: dispatch a dedicated reviewer subagent. **Single mode**: the main agent performs this review directly.
+**Batch mode**: run a dedicated reviewer — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent performs this review directly.
 
 ### Review Criteria
 
@@ -114,7 +120,7 @@ Verdict: PASS / NEEDS_FIXES
 
 If code quality review finds Critical or Important issues:
 
-1. Fix Critical and Important issues (Minor issues are optional). In Batch mode, send the review output to the implementer subagent; in Single mode, the main agent fixes directly.
+1. Fix Critical and Important issues (Minor issues are optional). In Batch mode, send the review output to the implementer; in Single mode, the main agent fixes directly.
 2. Re-run code quality review.
 3. Max 2 fix rounds. If Critical issues remain:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS`.
@@ -142,11 +148,11 @@ Classify a violation as `rule-violation-instance` (rather than a one-off bug) wh
 3. Present findings to the user via a user choice (see Environment Adaptation):
    > "Pattern violation `<pattern>` found in N other in-flight PR(s): <list>. What would you like to do?"
    > Options: Apply fix to all / Select which PRs / Skip propagation
-4. For each approved PR, dispatch a fix subagent to apply the same fix.
+4. For each approved PR, run a fix pass to apply the same fix — a separate agent instance where available, otherwise directly.
 
 ### Non-Blocking Rule
 
-Failures in propagation fix subagents do **not** block the original issue from completing. If a propagation fix fails, record it in the batch summary under the original issue.
+Failures in propagation fixes do **not** block the original issue from completing. If a propagation fix fails, record it in the batch summary under the original issue.
 
 ## Review Flow Diagram
 
@@ -155,7 +161,7 @@ PR Created
   ↓
 Stage 1: Spec Compliance
   ├─ PASS → Stage 2
-  └─ FAIL → Fix (subagent in Batch / main agent in Single) → Re-review (max 2 rounds)
+  └─ FAIL → Fix (implementer in Batch / main agent in Single) → Re-review (max 2 rounds)
               ├─ PASS → Stage 2
               └─ FAIL → Batch: DONE_WITH_CONCERNS | Single: ask user
   ↓
@@ -171,5 +177,5 @@ Mode check
               ├─ No rule violations → DONE
               └─ rule-violation-instance → Scan other in-flight PRs
                           ├─ No matches / user skips → DONE
-                          └─ User approves → Dispatch fix subagents → DONE (failures non-blocking)
+                          └─ User approves → Run fix passes → DONE (failures non-blocking)
 ```

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -5,13 +5,13 @@
 This pipeline runs in one of two modes:
 
 - **Interactive** (Single mode) — the main agent executes this workflow directly, with the user present. This is the default.
-- **Autonomous** (Batch mode) — an implementer subagent executes this workflow with no access to the user, dispatched by the orchestrator described in [batch.md](batch.md). Every point below that normally asks the user has an Autonomous-mode replacement instead.
+- **Autonomous** (Batch mode) — the implementer executes this workflow with no access to the user, coordinated by the orchestrator described in [batch.md](batch.md). The orchestrator runs the implementer as a separate agent instance where the environment supports one, or in the current context sequentially where it does not; either way this workflow is identical. Every point below that normally asks the user has an Autonomous-mode replacement instead.
 
 | Step | Interactive | Autonomous |
 |---|---|---|
 | 1-1 missing/vague issue fields | Ask the user, or propose criteria and confirm | Stop and report status `NEEDS_CONTEXT` with what is missing |
 | 1-3 design decisions | User choice gate with numbered options | Use the issue's Implementation Approach section if present; otherwise choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
-| 1-6 plan approval | Present as text + user choice gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the subagent and is not presented for approval |
+| 1-6 plan approval | Present as text + user choice gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the implementer and is not presented for approval |
 | 2-1 working environment | The choice made in Phase 0 Setup (Worktree / New branch / Current branch) | Always the worktree the orchestrator already created before dispatch |
 | 2-3 checks fail after 3 attempts | Escalate via user choice gate (continue / skip / abandon) | Stop and report status `BLOCKED` with the error |
 | 2-4 self-review needs human judgment | Escalate via user choice gate | Note the concern in the PR description, continue, and report status `DONE_WITH_CONCERNS` |
@@ -160,7 +160,7 @@ Only re-ask for clarification if the feedback is genuinely ambiguous (e.g., cont
 
 Use the implementation location chosen in Phase 0 Setup.
 
-**Autonomous mode**: the working environment is always the worktree the orchestrator created before dispatching this subagent — skip the branching below and `cd` into that worktree path.
+**Autonomous mode**: the working environment is always the worktree the orchestrator created before starting this implementer — skip the branching below and `cd` into that worktree path.
 
 Branch naming convention (for new branch and worktree):
 
@@ -178,11 +178,12 @@ Type is inferred from issue labels or content:
 - Feature → `feat/`
 - Technical task / refactor → `refactor/` or `chore/`
 
-**If "Worktree"** (default): Fetch latest, then create a worktree from the default branch:
+**If "Worktree"** (default): Fetch latest, then create a worktree from the default branch. Keep the worktree directory out of version control with a local git exclude (`.git/info/exclude` is per-clone, so it never appears in the PR the way editing `.gitignore` would):
 ```bash
 git fetch origin
-git worktree add .claude/worktrees/<branch-name> -b <branch-name> origin/<default-branch>
-cd .claude/worktrees/<branch-name>
+grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
+git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branch>
+cd .worktrees/<branch-name>
 ```
 
 **If "New branch"**: Fetch latest and create a branch from the default branch:
@@ -291,7 +292,7 @@ Check for:
 Self-review complete: N round(s), N issue(s) found, N fixed, N remaining
 ```
 
-Interactive mode: this is shown to the user directly. Autonomous mode: this line is included in the subagent's final report to the orchestrator. This ensures self-review is verifiable and the result is visible at a glance either way.
+Interactive mode: this is shown to the user directly. Autonomous mode: this line is included in the implementer's final report to the orchestrator. This ensures self-review is verifiable and the result is visible at a glance either way.
 
 ### 2-5. Commit
 
@@ -355,9 +356,9 @@ Closes #<issue-number>
 
 After the PR/MR is created, every issue — Interactive or Autonomous — goes through the two-stage review described in [review-gates.md](review-gates.md): Stage 1 spec compliance, then Stage 2 code quality.
 
-**Interactive mode**: the main agent runs both stages itself and fixes/pushes directly; there is no separate reviewer subagent to dispatch. See review-gates.md's single-issue notes for the escalation path when fixes don't converge.
+**Interactive mode**: the main agent runs both stages itself and fixes/pushes directly; there is no separate reviewer to dispatch. See review-gates.md's single-issue notes for the escalation path when fixes don't converge.
 
-**Autonomous mode**: this subagent does NOT run the review gates itself. Stop after 3-2 (CI monitoring) and report status back to the orchestrator, which dispatches the reviewer subagents and re-invokes this implementer for fix rounds if needed. Stage 2.5 (pattern propagation) only ever runs in Autonomous/batch mode, coordinated by the orchestrator across all in-flight issues — never in Interactive mode.
+**Autonomous mode**: the implementer does NOT run the review gates itself. Stop after 3-2 (CI monitoring) and report status back to the orchestrator, which runs the reviewer for each stage (as a separate agent instance where available, or self-review with a `SELF-REVIEWED` marker otherwise — see [review-gates.md](review-gates.md)) and re-invokes this implementer for fix rounds if needed. Stage 2.5 (pattern propagation) only ever runs in Autonomous/batch mode, coordinated by the orchestrator across all in-flight issues — never in Interactive mode.
 
 ### 3-2. Monitor CI
 


### PR DESCRIPTION
## Summary
- Make Batch mode and the review gates runnable — degraded but correct — on agents without separate-agent-instance support: where they are unavailable, a group's issues are implemented sequentially in dependency order, and reviewer gates fall back to a `SELF-REVIEWED` self-review. The DAG, review gates, and failure cascade are unchanged; only wall-clock parallelism is lost.
- Migrate worktrees from the product-specific `.claude` location to a neutral `.worktrees/`, guarded by a per-clone `.git/info/exclude` entry so the ignore never lands in a user PR.
- Replace subagent/Task-tool vocabulary with "separate agent instance" per AGENTS.md.

Closes #66

## Changes
- `SKILL.md` — Batch-mode summary now frames separate agent instances as an optimization with a sequential fallback; References line reworded; removed the unused **Background execution** capability row.
- `references/batch.md` — top-of-file + Phase B2 execution-model notes defining the sequential fallback; worktree create/remove use `.worktrees/` + exclude guard; neutral implementer/reviewer wording.
- `references/workflow.md` — Autonomous-mode framing neutralized; worktree block uses `.worktrees/` + exclude guard.
- `references/review-gates.md` — new **Reviewer Dispatch** section defining the `SELF-REVIEWED (no independent reviewer available)` fallback that rides on the real verdict; neutral wording throughout.
- `references/platform-github.md`, `references/platform-gitlab.md`, `references/platform-backlog.md` — worktree block uses `.worktrees/` + exclude guard.
- `references/eval-cases.md` — see orchestrator-authorized additions below.

## Orchestrator-authorized additions
- **A** — Converted the 2 bare user-choice sites in `batch.md` deferred from #61 (cycle resolution in B1-2, plan approval in B1-3) to the standard "Ask the user to choose (see Environment Adaptation)…" wording.
- **B** — Checked the **Background execution** capability: nothing in the skill runs background commands (parallelism uses separate agent instances; CI monitoring blocks with `--watch`), so the row was **removed** from SKILL.md's Environment Adaptation table.
- **C** — `eval-cases.md` (not in the issue's file list): neutralized "subagent" wording in Cases 17, 19, and 23 to stay consistent with the converted batch/review wording, and added a 2026-07-10 Evaluation Log entry. No `.claude/` paths existed in this file; the new log entry avoids the literal string so AC-1's whole-directory grep stays clean.
- **D** — The `SELF-REVIEWED` marker is defined to ride **on** the gate's real result (Stage 1 PASS/FAIL + issue list; Stage 2 severity counts + PASS/NEEDS_FIXES), not replace it, mirroring respond-to-pr-review's `verification.md` pattern. Fix routing (max 2 rounds, then DONE_WITH_CONCERNS / escalate) is unchanged.

## Additional file beyond the issue's table
- `references/platform-github.md` also contained a `.claude/worktrees/` path (not listed in the issue's file table). AC-1's whole-directory grep requires it, so it was migrated too.

## Test Plan
- [x] AC-1: `grep -r '\.claude/' plugins/aoshimash-skills/skills/implement-issue` returns nothing
- [x] AC-2: `batch.md` defines the sequential fallback with unchanged DAG semantics
- [x] AC-3: `review-gates.md` defines the `SELF-REVIEWED` marker fallback
- [x] AC-4: worktree commands use `.worktrees/` and the `.git/info/exclude` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)