### PR TITLE
Bump plugin version to 1.2.0 and run portability sweep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Personal Claude Code skills collection",
-    "version": "1.1.10"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "aoshimash-skills",
       "description": "Collection of personal Claude Code skills by Shuji Aoshima",
       "source": "./plugins/aoshimash-skills",
-      "version": "1.1.10",
+      "version": "1.2.0",
       "author": {
         "name": "Shuji Aoshima"
       },


### PR DESCRIPTION
## Summary
- Final release step of the agent-portability initiative (parent #58): bump the plugin to a minor version reflecting the behavior-affecting wording changes across all 6 skills.
- Ran the repo-wide portability consistency sweep — **zero violations found**, so no content fixes were needed; this PR carries only the version bump.

Closes #67

## Changes
- `.claude-plugin/marketplace.json` — bump `metadata.version` and `plugins[0].version` to `1.2.0`.

## Notes for the reviewer
- **Version field location.** The issue's Files table pointed at `plugins/aoshimash-skills/.claude-plugin/plugin.json`, but that manifest has no `version` field. The actual, authoritative version lives in `.claude-plugin/marketplace.json` (two places: `metadata.version` and `plugins[0].version`). Git history confirms every prior bump edits that file, so this PR follows the real convention.
- **Minor bump is manual, by design.** The `bump-version.yml` workflow only auto-increments the *patch* on merge. The one prior *minor* bump (1.1.0) was likewise a manual `chore:` commit by the maintainer, followed by the bot's patch bump to 1.1.1. This PR mirrors that pattern: it sets 1.2.0; on merge the bot will patch-bump to 1.2.1 as the published release.
- **Rebased onto latest `main`.** After this branch was cut, an unrelated PR's auto-patch-bump advanced `main` to 1.1.10. The branch was rebased onto `origin/main` and the version conflict resolved to `1.2.0` (both fields), so it now merges cleanly.

## Portability sweep result
Ran:
```
grep -rniE 'AskUserQuestion|EnterPlanMode|ExitPlanMode|subagent|background bash|\.claude/|claude code' plugins/aoshimash-skills/skills/
```
All **34** hits fall into the allowed categories from the acceptance rule — **no violations**:
- **(a) Environment Adaptation table rows — 8** (create-issue, implement-issue, multi-agent-review, respond-to-pr-review, review-dependency-prs): capability-to-native-tool mappings, product names confined to the example column.
- **(b) "On Claude Code specifically" conditional notes — 2** (implement-issue `workflow.md` and `SKILL.md`): plan-mode advice other agents can skip.
- **(c) analyze-sessions — 10**: declared Claude Code-specific via `compatibility` frontmatter.
- **(d) Evaluation Log entries — 14** (implement-issue `eval-cases.md`): dated historical records of past changes, not instructions. `subagent` now appears only here, confirming #66's neutral-vocabulary conversion was complete.

## Test Plan
- [x] Sweep grep output contains zero violations per the acceptance rule (34 hits, all in allowed buckets).
- [x] `jq` confirms both version fields are `1.2.0` and the JSON is well-formed.
- [x] Rebased onto `origin/main`; `git merge-tree` reports a clean merge (no version conflict remaining).
- [x] `skills-ref` validator not installed in this environment — validation step skipped (permitted by the issue).