### PR TITLE
Unify issue skills around a reader-agnostic, no-perishable-detail design axis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,16 @@ Skills follow the [skill-creator](https://github.com/anthropics/skills) best pra
 - Keep SKILL.md under 500 lines. Split detailed content into `references/` files.
 - Each skill should have eval test cases in `references/eval-cases.md`. Run them after changes and record results in the evaluation log.
 
+## Issue Skill Design Axis
+
+The issue-lifecycle skills (`create-issue`, `implement-issue`) share one non-negotiable design axis. Changes to either skill must preserve it:
+
+- **Issues are reader-agnostic.** Humans and AI agents read the same issue, and a good issue is the same for both: why (motivation), what (desired end state, binary acceptance criteria), and the design decisions and constraints behind them — never how.
+- **No perishable detail in issues.** Implementation steps, file-edit lists, and code examples rot between issue creation and implementation; design decisions and constraints do not. Issues record decisions, never steps.
+- **Implementation planning happens at implementation time.** Deriving the how is the implementer's job (`implement-issue` or a human), against the codebase as it exists then. Supplementary research findings that help at implementation time (current state, gotchas, related code) belong in the issue's Background.
+
+Rationale and provenance: README.md "Design Philosophy".
+
 ## Agent Portability
 
 Skills in this repository target any agent implementing the [Agent Skills spec](https://agentskills.io/specification), not only Claude Code.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ create-issue                               implement-issue
 **Key properties:**
 
 - **Issue tracker is the interface** — Both skills connect only through the issue tracker (GitHub, GitLab, Backlog). No skill-specific files persist after completion.
-- **Works with humans and AI** — Issues created by `create-issue` are readable and implementable by anyone. Issues written by hand work with `implement-issue`.
+- **Works with humans and AI** — Issues created by `create-issue` are readable and implementable by anyone. Issues written by hand work with `implement-issue`. A good issue is the same for both readers: it explains why and what — never how.
 - **Splitting is always proposed, never automatic** — `create-issue` defaults to a single issue; a parent + sub-issue (or nested grandchild) hierarchy is only created after the user confirms a Split Proposal.
 - **Annotation cycle** — in the Design Flow, plans are refined through inline notes in a local markdown file. The file is deleted after issues are created.
 - **Parallel execution** — in Batch mode, `implement-issue` resolves issue dependencies as a DAG and dispatches independent issues in parallel using git worktrees.
@@ -83,6 +83,12 @@ The issue workflow draws from two sources and combines them with an issue-centri
 - superpowers stores specs and plans in `docs/superpowers/` files. This works for solo use but creates friction in team settings — not everyone uses the same tools, and tool-specific files clutter the repo
 - Instead, the issue tracker is the single shared artifact. `create-issue`'s Design Flow uses local files only temporarily during the annotation cycle, then converts everything to issues and deletes the files
 - This means a team member who doesn't use these skills can still read the issues, pick one up, and implement it — the workflow degrades gracefully
+
+**Reader-agnostic issues (original):**
+- An issue is read by humans and AI agents alike, and a good issue is the same for both: motivation (why), desired end state with binary acceptance criteria (what), and the design decisions and constraints behind them — never implementation steps, file-edit lists, or code examples (how)
+- Time passes between issue creation and implementation. Implementation detail rots in that gap — other changes land, files move, approaches get invalidated; design decisions and constraints do not. Issues record decisions, never steps
+- This deliberately departs from superpowers' "boring implementation" (mechanical instructions with code examples in the plan): here the boringness comes from tight scope, recorded decisions, and binary acceptance criteria — the "boring scope" test. The implementer (human or `implement-issue`) plans the how at implementation time, against the codebase as it exists then
+- Findings from research that will help at implementation time (current state, gotchas, related code) still belong in the issue as supplementary background — they help humans and AI alike
 
 ## Skills
 

--- a/plugins/aoshimash-skills/skills/create-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/create-issue/SKILL.md
@@ -15,18 +15,19 @@ description: >
 
 # Create Issue
 
-Create issues on any issue tracking platform, always grounded in codebase analysis. This skill has two flows: a **Lightweight Flow** for a single, well-scoped issue, and a **Design Flow** for research-driven decomposition into an issue hierarchy. Every issue is structured to be solvable by both humans and AI agents with zero prior context.
+Create issues on any issue tracking platform, always grounded in codebase analysis. This skill has two flows: a **Lightweight Flow** for a single, well-scoped issue, and a **Design Flow** for research-driven decomposition into an issue hierarchy. Every issue is structured to be solvable by both humans and AI agents with zero prior context. A good issue is the same regardless of who implements it — it explains why and what, and leaves how to implementation time.
 
 ## Principles
 
-- **Motivation & Proposal, never How**: Describe why it matters and what the desired outcome is. Never prescribe implementation.
-- **Background from code**: Always analyze the codebase to ground the issue in reality. Include file paths and current state as background, not as implementation guidance. Background should capture what is NOT obvious from reading the code: decisions, constraints, business rules.
+- **Motivation & Proposal, never How**: Describe why it matters and what the desired outcome is. Never prescribe implementation — no implementation steps, no lists of files to edit, no code examples. Whoever picks up the issue (human or AI) plans the implementation at implementation time.
+- **No perishable detail**: Time passes between issue creation and implementation. File lists, code snippets, and step-by-step approaches rot in that gap; design decisions and constraints do not. Record decisions, never steps.
+- **Background from code**: Always analyze the codebase to ground the issue in reality. Include file paths and current state as background, not as implementation guidance. Background should capture what is NOT obvious from reading the code: decisions, constraints, business rules. Findings from analysis that will help at implementation time (current state, gotchas, related modules) are welcome as supplementary background — they help humans and AI alike. Known pitfalls are not optional context: if analysis reveals a trap an implementer could plausibly fall into (hidden coupling, caching, ordering requirements, API quirks), record it as a constraint — never as code.
 - **Actionable by anyone**: Include enough information for a human or AI agent with no prior context to understand and resolve the issue. An incomplete issue creates back-and-forth communication that costs more than asking thorough questions upfront.
 - **Accessible to everyone**: Use plain language in all interactions. Avoid jargon. The skill should be equally usable by engineers and non-engineers.
 - **Never settle for vague**: If the user's response is ambiguous, incomplete, or leaves room for multiple interpretations, ask follow-up questions until the intent is clear. It is better to ask too many questions than to create an issue that requires clarification later.
 - **Research before design** (Design Flow): Never design without deeply understanding the codebase first. Produce a written research artifact, not a verbal summary.
 - **Plan as shared mutable state** (Design Flow): The plan lives in a local markdown file that the user can annotate inline. Chat-based steering is imprecise; document-based iteration is not.
-- **Implementation must be boring** (Design Flow): Each task must be implementable without creative decisions. If a task requires design judgment, it is not decomposed enough.
+- **Tasks must be boringly scoped** (Design Flow): Each task must be scoped so narrowly and unambiguously that the implementer — human or AI — faces no open design decisions. Achieve this through precise scope, recorded design decisions, and binary acceptance criteria, not by prescribing the implementation. If a task requires design judgment, decompose further or record the decision.
 - **Hard gates** (Design Flow): Do not proceed to the next phase without explicit user approval.
 - **Splitting is a proposal, never automatic**: Whether to create a parent + sub-issues (or nested grandchild issues) is always confirmed with the user. Default to a single issue when in doubt.
 
@@ -203,8 +204,8 @@ See [references/design.md](references/design.md) for the detailed procedure.
 
 1. Ask clarifying questions **one at a time** to understand the feature's goals, constraints, and scope. Use the research findings to ask informed questions.
 2. When 2+ valid approaches exist, propose each with trade-offs and a recommendation. Ask the user to choose (see Environment Adaptation) with numbered options. Wait for the user's choice.
-3. Break the work into tasks (title, purpose, files, approach with code examples, acceptance criteria, dependencies, estimated size).
-4. Each task must pass the **"boring implementation" test**: can someone implement it by following the instructions mechanically, with zero design judgment?
+3. Break the work into tasks (title, purpose, scope, acceptance criteria, dependencies, estimated size).
+4. Each task must pass the **"boring scope" test**: is the task scoped so tightly — with every design decision recorded — that implementing it requires zero design judgment?
 5. Draft the Split Proposal (see below) into the plan's `## Split Proposal` section, and write the plan to `<plan-dir>/YYYY-MM-DD-<topic-slug>.md`.
 
 ### D3: Annotation Cycle
@@ -218,7 +219,7 @@ See [references/annotation-cycle.md](references/annotation-cycle.md) for the det
    - If a note rejects an approach → replace with the user's direction
    - If a note adds a constraint → incorporate it
    - If a note asks a question → answer inline or ask a clarifying question
-3. After addressing all notes, re-run the "boring implementation" test on each task.
+3. After addressing all notes, re-run the "boring scope" test on each task.
 4. Write the updated plan and present changes.
 5. **Repeat** until the user approves with no remaining notes.
 6. **Hard Gate:** Ask the user to choose (see Environment Adaptation): "Is the plan ready to be converted to issues?" — Approve / Another annotation round / Abort.

--- a/plugins/aoshimash-skills/skills/create-issue/references/annotation-cycle.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/annotation-cycle.md
@@ -27,13 +27,13 @@ The user adds HTML comments anywhere in the plan file:
 ```markdown
 ### Task 3: Add search endpoint
 
-**Approach:**
-Use a full-text search query against the users table.
-<!-- NOTE: use pg_trgm index, not full-text search. We already have it set up. -->
+**Scope:**
+Users can be searched by name and email via a new API endpoint.
+<!-- NOTE: search by name only for now — email search has privacy implications, keep it out of scope. -->
 
-**Files:**
-- `src/api/users.ts` — Modify: add search handler
-<!-- NOTE: this should be in src/api/routes/users.ts, not src/api/users.ts -->
+**Acceptance Criteria:**
+- [ ] Search results return within 500ms
+<!-- NOTE: 500ms is unrealistic for the current dataset; make it 1s -->
 ```
 
 Annotations may also appear as:
@@ -61,7 +61,7 @@ When the user signals readiness:
    - **REMOVE**: Delete the indicated section. Remove the annotation.
    - **TODO**: Flesh out the indicated section. Remove the annotation.
    - **QUESTION**: Answer inline (briefly) or ask a clarifying question (see Environment Adaptation in SKILL.md). Remove the annotation after resolution.
-4. After addressing all annotations, re-run the "boring implementation" test on all tasks.
+4. After addressing all annotations, re-run the "boring scope" test on all tasks.
 5. Update the plan file with changes.
 
 ### 3. Present Changes
@@ -69,8 +69,8 @@ When the user signals readiness:
 Summarize what changed:
 
 > "Addressed N annotations:
-> - Task 3: switched to pg_trgm index per your note
-> - Task 3: corrected file path to src/api/routes/users.ts
+> - Task 3: narrowed scope to name-only search per your note
+> - Task 3: relaxed the response-time criterion to 1s
 > - Task 5: removed caching section as requested
 >
 > Updated plan is at `<path>`. Review and add more notes if needed, or approve to proceed."
@@ -93,9 +93,9 @@ Before presenting the final gate, verify:
 | # | Check | Pass condition |
 |---|-------|----------------|
 | 1 | All annotations resolved | No `<!-- ... -->` notes remain in the file |
-| 2 | Boring implementation test | Every task passes all 6 criteria from the design phase |
+| 2 | Boring scope test | Every task passes all 6 criteria from the design phase |
 | 3 | Dependency graph consistent | All referenced task dependencies exist and form a DAG |
 | 4 | No scope creep | Tasks match the agreed design decisions |
-| 5 | Code examples up to date | Annotations that changed approach are reflected in code examples |
+| 5 | Design Decisions up to date | Annotations that changed an approach or constraint are reflected in the Design Decisions table and affected task scopes |
 
 If any check fails, fix it before presenting the gate.

--- a/plugins/aoshimash-skills/skills/create-issue/references/design.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/design.md
@@ -39,28 +39,30 @@ Break the design into tasks where each task = one potential sub-issue. For each 
 |-------|-------------|
 | **Title** | Imperative form, concise (e.g., "Add user search endpoint") |
 | **Purpose** | Why this task exists, in context of the whole feature |
-| **Files** | Exact file paths to create or modify |
-| **Approach** | Concrete implementation with code examples. No placeholders, no "add validation here" |
+| **Scope** | The desired end state and explicit boundaries (what is NOT included). Two engineers reading it would agree on what to build |
+| **Notes** | Optional: non-obvious constraints, relevant design decisions, useful findings from research (current state, gotchas). No implementation steps, file-edit lists, or code examples |
 | **Acceptance Criteria** | Binary pass/fail conditions |
 | **Dependencies** | Which other tasks must complete first |
 | **Estimated size** | Small (< 30 min) / Medium (30-60 min) / Large (1-2 hours). If Large, consider splitting further |
 
+**Notes is optional in form but mandatory in substance**: any pitfall discovered during research that an implementer could plausibly fall into (hidden coupling, caching behavior, ordering requirements, API quirks) MUST be recorded there — as a constraint, never as implementation code. With implementation detail excluded from issues, recorded constraints are the channel that carries design-time knowledge to implementation time; an unrecorded pitfall is a trap left armed for whoever implements the task.
+
 If decomposition yields **exactly one task** at Small or Medium size, do not force a hierarchy — note this to the user and fall back to a single issue: skip to the Split Proposal step, which will recommend a single issue in this case, then finish via the Lightweight Flow's draft/self-eval/create steps (SKILL.md Steps L4–L6) using that one task as the issue content.
 
-### 4. The "Boring Implementation" Test
+### 4. The "Boring Scope" Test
 
-Before writing the plan, verify each task against:
+Implementation must be boring — but the boringness comes from tight scope and recorded decisions, not from prescribing the implementation. Before writing the plan, verify each task against:
 
 | # | Check | Pass condition |
 |---|-------|----------------|
-| 1 | No design decisions | Someone can implement by following instructions mechanically |
-| 2 | Code examples present | Key implementation shown with actual code, not descriptions |
-| 3 | Files are specific | Exact paths listed, not "relevant files" |
+| 1 | No open design decisions | Every choice the task depends on is recorded in Design Decisions — nothing is left to the implementer's judgment |
+| 2 | Scope is unambiguous | Two engineers reading the task would agree on what to build and what not to build |
+| 3 | No implementation prescription | The task contains no implementation steps, file-edit lists, or code examples — the implementer plans those at implementation time |
 | 4 | AC is testable | Each criterion has a clear binary outcome |
 | 5 | Dependencies are explicit | Blocking relationships are stated, not implied |
 | 6 | Size is appropriate | No task is larger than ~2 hours of work |
 
-If any task fails, split or refine it until it passes.
+If any task fails, split it, tighten its scope, or record the missing decision until it passes.
 
 ### 5. Write the Plan File
 
@@ -90,11 +92,11 @@ Status: Draft
 **Dependencies:** None | Task N
 **Size:** Small / Medium / Large
 
-**Files:**
-- `path/to/file.ts` — Create / Modify: <what changes>
+**Scope:**
+<desired end state and explicit boundaries — what is included and what is not>
 
-**Approach:**
-<concrete implementation with code examples>
+**Notes:** (optional)
+<non-obvious constraints, relevant design decisions, useful findings from research>
 
 **Acceptance Criteria:**
 - [ ] <criterion 1>

--- a/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/eval-cases.md
@@ -7,7 +7,7 @@ For each test case:
 2. Trigger the create-issue skill
 3. Provide the user input described in the test case
 4. Respond to follow-up questions as described in the persona
-5. Evaluate the generated issue draft against the 10 quality criteria in Step L5 (Lightweight Flow) or the Split Proposal criteria (Design Flow)
+5. Evaluate the generated issue draft against the 10 quality criteria in Step L5 (these apply to every issue, in both flows; for Design Flow also check the Split Proposal criteria)
 6. Record which flow (Lightweight/Design) was chosen and whether it matched the expectation
 7. Record results in the Evaluation Log section at the bottom
 
@@ -112,11 +112,12 @@ For each test case:
   - Explicit request triggers escalation to Design Flow (Step 2 criterion 1)
   - D1 Research: investigates existing user model, API patterns, search infrastructure. Writes research file.
   - D2 Design: asks clarifying questions (search fields, pagination, performance). Proposes approaches. Writes plan with task breakdown and Split Proposal.
-  - D3 Annotation: prompts user to annotate plan. Addresses annotations. Each task passes boring implementation test.
+  - D3 Annotation: prompts user to annotate plan. Addresses annotations. Each task passes the boring scope test.
   - D4 Issue Creation: confirms the Split Proposal as a user choice BEFORE creating anything, then creates parent issue + sub-issues with dependencies. Cleans up local files.
 - **Verification**:
   - [ ] Research file contains relevant file paths and architecture analysis
-  - [ ] Plan has concrete code examples, not placeholders
+  - [ ] Plan tasks have unambiguous scope and binary acceptance criteria; open design decisions are recorded in Design Decisions
+  - [ ] No issue body contains implementation steps, file-edit lists, or code examples
   - [ ] Each sub-issue is independently implementable
   - [ ] Dependencies form a valid DAG
   - [ ] Split proposed as a user choice before any parent/sub-issue is created — never automatic
@@ -177,12 +178,12 @@ For each test case:
 - **Setup**: After plan is written, user annotates with `<!-- NOTE: completely different approach, use X instead of Y -->`
 - **Expected behavior**:
   - Claude reads the annotation and rewrites the affected tasks.
-  - Code examples are updated to reflect the new approach.
+  - The Design Decisions table and affected task scopes are updated to reflect the new approach.
   - Dependencies are rechecked (approach change may alter dependency graph).
-  - Boring implementation test is re-run on all affected tasks.
+  - Boring scope test is re-run on all affected tasks.
 - **Verification**:
   - [ ] Annotation is fully addressed (not partially)
-  - [ ] Code examples match the new approach
+  - [ ] Design Decisions and task scopes match the new approach
   - [ ] Dependency graph is updated if needed
   - [ ] No stale references to the old approach remain
 
@@ -289,3 +290,4 @@ Record results here after each evaluation run.
 | 2026-03-05 | 6 | 1,2,3,4,5,6,7,9 | 8 | "Response within 24h" is an operational goal, not an implementation criterion. | Yes — added operational vs implementation criteria separation to Step 3 |
 | 2026-07-05 | — | — | — | Merged design-sprint into create-issue: added adaptive Lightweight/Design flow routing, Split Proposal gate, and cases 9-17 (9-13 renumbered from design-sprint, 14-17 new). Case numbering for 1-8 preserved from the original create-issue log above. | — |
 | 2026-07-08 | — | — | — | Added criterion 10 (External facts verified) to Lightweight Flow L5 and a Fact-Check External Claims gate (D4 Step 0) to Design Flow, per issue #54 (real-world incident: aoshimash/homelab-k8s#258–#260). Added Cases 18-19. | — |
+| 2026-07-16 | — | — | — | Unified design philosophy: issues are reader-agnostic (human or AI) and never contain perishable implementation detail (implementation steps, file-edit lists, code examples) — implementation is planned at implementation time. Sub-Issue template rewritten (Files table and Implementation Approach removed; Proposal and Related Code added); "boring implementation" test reframed as "boring scope" test; plan task fields changed (Files/Approach → Scope/Notes). Pitfall recording made mandatory: traps discovered during research MUST land in task Notes / issue Background as constraints (SKILL.md Background principle, design.md Task Decomposition) — with implementation detail excluded from issues, recorded constraints are the channel that carries design-time knowledge to implementation time. Cases 9 and 13 updated. Full eval re-run pending. | — |

--- a/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/issue-creation.md
@@ -4,6 +4,8 @@
 
 This procedure is used in the **Design Flow** (see SKILL.md Step 2) to convert the approved plan into issues on the tracker. After this phase, the plan and research files are deleted — the issues hold all information needed for implementation.
 
+Every issue body created here (parent, sub, grandchild, or single) must satisfy the same quality criteria as Lightweight Flow issues (SKILL.md Step L5, adapted to each template's sections) — a good issue is the same regardless of flow or reader. In particular: no implementation steps, file-edit lists, or code examples in any issue body. Implementation is planned at implementation time by whoever picks up the issue.
+
 ## Procedure
 
 ### 0. Fact-Check External Claims
@@ -35,7 +37,7 @@ Proposed hierarchy:
 
 Then ask the user to choose (see Environment Adaptation in SKILL.md):
 - **Create parent + sub-issues** (mark "(Recommended)" when 2+ tasks are independently implementable and reviewable) — proceed to Step 2.
-- **Create a single issue** — skip the hierarchy. Compose ONE issue using the Feature Request or Technical Task template from [templates.md](templates.md), with the plan's Goal as Motivation/Proposal and the task breakdown included as a `## Task Breakdown` section (titles, files, approach, AC per task, as subsections). Then go directly to Step 5 (Clean Up).
+- **Create a single issue** — skip the hierarchy. Compose ONE issue using the Feature Request or Technical Task template from [templates.md](templates.md), with the plan's Goal as Motivation/Proposal and the task breakdown included as a `## Task Breakdown` section (title, purpose, scope, and AC per task, as subsections). Then go directly to Step 5 (Clean Up).
 - **Adjust the breakdown** — return to the Design phase's Task Decomposition step with the user's feedback, then re-present this gate.
 
 Do NOT create parent/sub-issues, or grandchild issues, without this explicit confirmation.
@@ -60,8 +62,8 @@ For each task in the plan, create a sub-issue using the **Sub-Issue** template f
 - Title — the task title (imperative form, under 70 chars)
 - `Parent: #<parent-issue-number>`
 - Motivation — why this task exists, in context of the parent feature
-- Background / Files — task-specific context and exact file paths
-- Implementation Approach — the plan's concrete approach with code examples
+- Background — task-specific context from the plan's Notes: non-obvious constraints, relevant design decisions, useful research findings; Related Code as factual current state
+- Proposal — the task's desired end state and boundaries, from the plan's Scope
 - Acceptance Criteria — from the task
 - Dependencies — `Blocked by: #<issue-number>` for any blocking sub-issues
 

--- a/plugins/aoshimash-skills/skills/create-issue/references/templates.md
+++ b/plugins/aoshimash-skills/skills/create-issue/references/templates.md
@@ -237,7 +237,7 @@ Used in the Design Flow to represent an entire feature/initiative that has been 
 
 ## Sub-Issue
 
-Used in the Design Flow for each task in the plan. A sub-issue may itself be a **parent** when a task was further split into grandchild issues (nested sub-issues) — in that case its body also includes a Task Overview table for its own children, following the Parent Issue template above.
+Used in the Design Flow for each task in the plan. Sub-issues follow the same reader-agnostic structure as every other issue this skill creates: motivation, background, proposal, acceptance criteria — never implementation steps, file-edit lists, or code examples. A sub-issue may itself be a **parent** when a task was further split into grandchild issues (nested sub-issues) — in that case its body also includes a Task Overview table for its own children, following the Parent Issue template above.
 
 ```markdown
 <!-- 1-2 sentence summary of what this task accomplishes -->
@@ -250,21 +250,17 @@ Parent: #<parent-issue-number>
 
 ## Background
 
-<!-- Task-specific context from the plan -->
+<!-- Task-specific context from the plan: non-obvious constraints, -->
+<!-- relevant design decisions, useful findings from research -->
 
-### Files
+### Related Code
 
-<!-- Exact file paths to create or modify -->
+<!-- File paths as factual current state, not a list of files to edit -->
 
-| File | Action | Changes |
-|------|--------|---------|
-| `path/to/file` | Create / Modify | What changes and why |
+## Proposal
 
-## Implementation Approach
-
-<!-- From the plan: concrete approach with code examples -->
-<!-- This is NOT "how to implement" as imperative instructions -->
-<!-- It IS "what the implementation looks like" as reference code -->
+<!-- The task's desired end state and explicit scope boundaries -->
+<!-- WHAT the result should be, never HOW to implement it -->
 
 ## Acceptance Criteria
 

--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -39,6 +39,7 @@ below use capability terms; map them to your environment as follows.
 |---|---|---|
 | **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
 | **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body or reply comment the step produces) |
+| **Model selection** — run a separate agent instance on a chosen model | Per-instance model override (e.g. Claude Code's Task tool `model` parameter, or an agent definition's `model` frontmatter) | Run every instance on the session's default model — the workflow is unchanged, only the reviewer-stronger-than-implementer recommendation (see [references/review-gates.md](references/review-gates.md)) is unavailable |
 
 ## Phase 0: Setup and Mode Selection
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
@@ -85,7 +85,7 @@ For each issue in the current group:
 
 Run each issue's implementer with an instruction set that includes:
 
-1. The full issue body and issue number.
+1. The full issue body and issue number. When the batch source is a parent issue, also include the parent issue's body — its Background, Design Decisions, and Task Overview are shared context for every sub-issue.
 2. The absolute path to the worktree already created for it (step B2-1) — the implementer works there, it does not create its own.
 3. The absolute paths to this skill's [workflow.md](workflow.md) and the relevant `platform-*.md` guide, with the instruction:
    > "Read these files, then execute workflow.md Phases 1–3 in **Autonomous mode** inside the given worktree. Stop after creating the PR/MR and monitoring CI (workflow.md step 3-2) — do not run the review gates yourself, the orchestrator runs them. Return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md's Report Status step."
@@ -99,6 +99,8 @@ After each issue's PR/MR is created (and the implementer has reported):
 
 1. Stage 1: Run a **spec compliance reviewer** (see [review-gates.md](review-gates.md)).
 2. Stage 2: Run a **code quality reviewer** (see [review-gates.md](review-gates.md)).
+
+   Where the environment supports model selection, run reviewers on a model at least as capable as the implementer's — see review-gates.md "Reviewer model".
 3. Stage 2.5: **Pattern Propagation** — if a `rule-violation-instance` is found, scan other in-flight PRs for the same pattern and offer to propagate the fix (see [review-gates.md](review-gates.md)). This stage only runs in Batch mode, when 2+ issues are in flight.
 4. If issues are found at Stage 1 or 2 → re-run the implementer to fix → re-review (max 2 fix rounds per stage).
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -556,3 +556,41 @@ No behavioral change for environments with separate agent instances (e.g. Claude
 parallel dispatch, worktree isolation, and the review gates work exactly as before — only
 the worktree directory moved. Verified by grep that no product-specific `.claude` worktree
 path remains anywhere under the skill directory.
+
+### 2026-07-16 — Align with the reader-agnostic issue axis (AGENTS.md "Issue Skill Design Axis")
+
+create-issue no longer emits Implementation Approach sections or Files tables in
+issue bodies — issues now carry why/what plus recorded design decisions, and
+implementation planning is this skill's job at implementation time. Aligned the
+references that assumed the old sub-issue format:
+
+- `workflow.md` 1-1 adds a **Parent context** step: when the issue references a
+  parent (`Parent: #N` or platform link), fetch the parent and read its
+  Background, Design Decisions, and Task Overview as shared context. Under the
+  old format each sub-issue was self-contained via Implementation Approach;
+  under the new one, shared decisions live in the parent.
+- `workflow.md` 1-3 (both modes): decisions already recorded in the issue or its
+  parent are settled — Interactive mode does not re-ask the user; Autonomous
+  mode follows them and only falls back to project conventions for decisions
+  not recorded. The "Implementation Approach section if present" fallback is
+  replaced accordingly (Execution Modes table row 1-3 and the 1-3 Autonomous
+  note).
+- `batch.md` B2-2: the implementer instruction set now includes the parent
+  issue's body when the batch source is a parent issue.
+- `review-gates.md` Stage 1: reviewer context includes the parent issue's body
+  when one exists; criterion 5 reworded from "Approach matches" to "Decisions
+  honored" (recorded design decisions/constraints are followed).
+
+No changes to the plan/implement/PR pipeline itself — drafting the
+implementation plan (Files to Change, approach, edge cases) at implementation
+time is exactly the division of responsibility the axis prescribes.
+
+Also added a **Model selection** capability (SKILL.md Environment Adaptation)
+and a "Reviewer model" recommendation (review-gates.md Reviewer Dispatch,
+referenced from batch.md B2-3): where the environment supports per-instance
+model selection, run reviewers on a model at least as capable as — ideally more
+capable than — the implementer's. Since issues carry no implementation detail,
+the implementer derives the plan itself; a stronger reviewer is the cheapest
+guard against derivation errors when implementers run on a faster model. The
+fallback (no model selection) runs everything on the session default with the
+workflow unchanged. Full eval re-run pending.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -17,6 +17,8 @@ These are separate concerns. Spec compliance prevents over-building and under-bu
 
 A review is strongest when run by a **separate agent instance** (see Environment Adaptation in SKILL.md) with fresh context that has not seen the implementation — an independent reviewer is not anchored to the choices the implementer already made. Both stages below assume that ideal.
 
+**Reviewer model.** Where the environment supports **model selection** (see Environment Adaptation in SKILL.md), run each reviewer on a model at least as capable as — ideally more capable than — the implementer's. Well-formed issues deliberately carry no implementation detail (they record decisions and constraints, never steps), so the implementer derives the implementation plan itself; a stronger reviewer is the cheapest guard against derivation errors, especially when implementers run on a faster/cheaper model. On Claude Code, pass a `model` override when dispatching the reviewer as a subagent (e.g. an `opus`-class reviewer over `sonnet`-class implementers). Where model selection is unavailable, run reviewers on the default model — the two-stage structure and fix routing are unchanged.
+
 **Fallback when no separate agent instance is available.** Run the stage's checklist yourself and produce the stage's real verdict exactly as defined below (Stage 1: PASS/FAIL with the issue list; Stage 2: severity-tagged issue counts and PASS/NEEDS_FIXES). Then mark that verdict `SELF-REVIEWED (no independent reviewer available)`. The marker **rides on** the real result — it does not replace it — so the On-Failure fix routing (max 2 rounds, then DONE_WITH_CONCERNS in Batch / escalate in Single) applies unchanged. Record the marker next to the gate outcome in the PR/MR body so a human can see the independent-review guarantee did not hold.
 
 ## Stage 1: Spec Compliance Review
@@ -25,7 +27,7 @@ A review is strongest when run by a **separate agent instance** (see Environment
 
 Review with:
 
-- The issue body (the "spec")
+- The issue body (the "spec"), plus the parent issue's body when the issue has one (its Design Decisions and Background apply to the sub-issue)
 - The PR diff (`git diff origin/<default-branch>...<branch-name>`)
 - Instructions below
 
@@ -39,7 +41,7 @@ Review with:
 | 2 | No scope creep | No changes unrelated to the issue's scope |
 | 3 | Files match | Files changed match those listed in the issue (if specified) |
 | 4 | No missing pieces | No acceptance criterion is only partially addressed |
-| 5 | Approach matches | If the issue specifies an implementation approach, the code follows it |
+| 5 | Decisions honored | If the issue (or its parent) records design decisions or constraints, the implementation follows them |
 
 ### Output Format
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -10,7 +10,7 @@ This pipeline runs in one of two modes:
 | Step | Interactive | Autonomous |
 |---|---|---|
 | 1-1 missing/vague issue fields | Ask the user, or propose criteria and confirm | Stop and report status `NEEDS_CONTEXT` with what is missing |
-| 1-3 design decisions | User choice gate with numbered options | Use the issue's Implementation Approach section if present; otherwise choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
+| 1-3 design decisions | User choice gate with numbered options (decisions already recorded in the issue or its parent are settled — do not re-ask) | Follow design decisions recorded in the issue or its parent (Background, Design Decisions); for decisions not recorded, choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
 | 1-6 plan approval | Present as text + user choice gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the implementer and is not presented for approval |
 | 2-1 working environment | The choice made in Phase 0 Setup (Worktree / New branch / Current branch) | Always the worktree the orchestrator already created before dispatch |
 | 2-3 checks fail after 3 attempts | Escalate via user choice gate (continue / skip / abandon) | Stop and report status `BLOCKED` with the error |
@@ -34,6 +34,8 @@ Extract and organize the following from the issue body:
 | **Acceptance Criteria** | Binary pass/fail conditions for completion |
 | **References** | Links, screenshots, related issues |
 
+**Parent context**: If the issue references a parent (a `Parent: #N` line in the body, or a platform-level parent link), fetch the parent issue and read its Background, Design Decisions, and Task Overview — they are shared context for every sub-issue. Design decisions recorded there apply to this task.
+
 If any critical field is missing or ambiguous:
 - **Missing**: Ask the user to provide it.
 - **Vague** (e.g., "it should work well"): Propose 2–3 concrete, binary-testable criteria and ask the user to confirm or adjust. Do not proceed until acceptance criteria are specific enough to verify.
@@ -55,7 +57,9 @@ Record findings as structured notes for use in the plan.
 
 ### 1-3. Resolve Design Decisions
 
-Before drafting the plan, identify any decisions that require human judgment. Examples:
+Decisions already recorded in the issue or its parent (e.g., a Design Decisions table, constraints in Background) are settled — follow them, do not re-ask. They were typically resolved with the user when the issue was designed.
+
+Before drafting the plan, identify any remaining decisions that require human judgment. Examples:
 
 - Multiple valid architectural approaches (e.g., REST vs GraphQL, new table vs extend existing)
 - Trade-offs between simplicity and extensibility
@@ -77,7 +81,7 @@ When the user selects "Other" and provides free-text input, treat their text as 
 
 If no design decisions require human input, skip this step and proceed to 1-4.
 
-**Autonomous mode**: do not present a user choice. If the issue includes an Implementation Approach section, follow it. Otherwise choose the option most consistent with existing project conventions, and note the choice and its rationale in the PR body so a human reviewer can revisit it. If the decision is genuinely undecidable (no convention to lean on, and the outcome materially changes the result), stop and return status `NEEDS_CONTEXT`.
+**Autonomous mode**: do not present a user choice. Follow design decisions recorded in the issue or its parent (Background, Design Decisions). For decisions not recorded there, choose the option most consistent with existing project conventions, and note the choice and its rationale in the PR body so a human reviewer can revisit it. If the decision is genuinely undecidable (no recorded decision, no convention to lean on, and the outcome materially changes the result), stop and return status `NEEDS_CONTEXT`.
 
 ### 1-4. Draft Implementation Plan
 


### PR DESCRIPTION
## Summary

- Establish one design axis for the issue-lifecycle skills: issues are read by humans and AI alike, and a good issue is the same for both — it explains **why** and **what** (plus the design decisions and constraints behind them), never **how**. Implementation detail (steps, file-edit lists, code examples) rots between issue creation and implementation, so it is excluded from issue bodies and derived at implementation time.
- **create-issue**: the Design Flow's Sub-Issue template previously mandated a Files table and an Implementation Approach section with code examples, contradicting the Lightweight Flow's own "No How" self-eval criterion. Sub-issues now use the same reader-agnostic structure as every other issue (Motivation / Background / Related Code / Proposal / AC). The "boring implementation" test is reframed as a "boring scope" test — boringness comes from tight scope, recorded design decisions, and binary acceptance criteria, not from prescriptive instructions. Known pitfalls discovered during research MUST be recorded as constraints (never as code): with implementation detail excluded, recorded constraints are the channel that carries design-time knowledge to implementation time.
- **implement-issue**: aligned with the new sub-issue format. Implementers now fetch the parent issue's Background / Design Decisions / Task Overview as shared context (previously each sub-issue was self-contained via Implementation Approach). Recorded decisions are settled — Interactive mode doesn't re-ask the user; Autonomous mode follows them before falling back to project conventions. Added an agent-neutral **Model selection** capability and a recommendation to run review-gate reviewers on a model at least as capable as the implementer's — the cheapest guard against derivation errors when implementers run on a faster model (e.g. strong-model issue design, fast-model implementation).
- Documented the axis in AGENTS.md ("Issue Skill Design Axis") as a development guardrail and in README ("Reader-agnostic issues"), explicitly noting the deliberate departure from superpowers' boring-implementation approach.

## Test plan

- [x] Grep: no runtime skill instruction still references the removed Files table / Implementation Approach section (remaining mentions are historical evaluation-log entries only)
- [x] Grep: no runtime skill instruction references repo-level docs (AGENTS.md) that don't ship with a standalone skill; product-specific model syntax is confined to the Environment Adaptation example column and "On Claude Code, …" notes
- [x] Self-review of the full diff (2 rounds; 1 finding — a portability-breaking AGENTS.md reference in review-gates.md — fixed)
- [ ] Full eval re-run of both skills' eval-cases (logged as pending in both evaluation logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)