### PR TITLE
Add sync-agent-rules skill to distribute shared conventions into a repository's AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This is a Claude Code Plugin Marketplace repository. It contains a plugin (`aosh
 - `.claude-plugin/marketplace.json` — Marketplace manifest (lists available plugins)
 - `plugins/aoshimash-skills/.claude-plugin/plugin.json` — Plugin manifest
 - `plugins/aoshimash-skills/skills/<skill-name>/` — Individual skills, each with a `SKILL.md` and optional `references/`, `scripts/`, `assets/`
+- `plugins/aoshimash-skills/rules/agent-rules.md` — Shared conventions corpus, deliberately outside every skill. A running skill resolves to a version-pinned copy rather than the git checkout, so this file is addressed as a repository path and fetched over the GitHub API at runtime. Its "Contract" and "Format" sections are authoritative for the rule format and the managed-block delimiters
 
 ## Skill Development
 

--- a/README.md
+++ b/README.md
@@ -100,18 +100,27 @@ The issue workflow draws from two sources and combines them with an issue-centri
 | [multi-agent-review](plugins/aoshimash-skills/skills/multi-agent-review/) | Run multiple AI CLIs (Claude, Codex, Gemini) in parallel for code review and produce a unified review output |
 | [respond-to-pr-review](plugins/aoshimash-skills/skills/respond-to-pr-review/) | Process PR review comments one by one — explain, confirm actions, implement fixes, and post reply comments |
 | [merge-renovate-prs](plugins/aoshimash-skills/skills/merge-renovate-prs/) | Merge Renovate PRs one at a time, autonomously by default — verify monitoring/revert preconditions, LLM pre-check, merge, post-merge verification, and auto-revert on failure; interactive per-PR-approval mode available |
+| [sync-agent-rules](plugins/aoshimash-skills/skills/sync-agent-rules/) | Write the shared conventions from [the rule corpus](plugins/aoshimash-skills/rules/agent-rules.md) into the current repository's `AGENTS.md` — detect which rules apply from the files actually present, write only those into a delimited managed block, and open a PR; additive, so nothing is removed without confirmation |
 
 ## Structure
 
 ```
 plugins/aoshimash-skills/
 ├── .claude-plugin/plugin.json    # Plugin manifest
+├── rules/
+│   └── agent-rules.md            # Shared conventions corpus (read by sync-agent-rules)
 └── skills/
     └── <skill-name>/
         ├── SKILL.md              # Skill definition (required)
         ├── scripts/              # Helper scripts (optional)
         └── references/           # Reference docs (optional)
 ```
+
+`rules/agent-rules.md` sits outside every skill on purpose: a running skill
+resolves to a version-pinned copy rather than the git checkout, so the corpus is
+addressed as a repository path and fetched over the GitHub API at runtime. That
+also means a rule added there is distributable immediately, without waiting for
+an installed plugin to update.
 
 ## License
 

--- a/plugins/aoshimash-skills/rules/agent-rules.md
+++ b/plugins/aoshimash-skills/rules/agent-rules.md
@@ -16,13 +16,14 @@ repository's instruction file.
 
 ## Contract
 
-Three things are fixed. Both skills depend on them, so do not change them
-without updating both.
+These are fixed. Both skills depend on them, so do not change them without
+updating both.
 
 | Thing | Value |
 |---|---|
 | This file's path | `plugins/aoshimash-skills/rules/agent-rules.md`, relative to the repository root of `aoshimash/skills` |
-| Managed-block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->` |
+| Managed-block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->`, each alone on its own line |
+| Block preamble | Immediately inside `BEGIN`: the heading `## Shared Conventions`, then an HTML comment beginning `<!-- Managed by the sync-agent-rules skill`. Both are generated, not content — a reader strips them, a writer re-emits them |
 | Per-rule marker inside a block | `<!-- rule: <id> -->`, on the line after the rule's `###` heading |
 
 The delimiters are HTML comments, so they are invisible in rendered markdown and
@@ -56,14 +57,17 @@ markdown. Skip fenced regions when enumerating rules.
 
 - **Detect** is a comma-separated list of backticked glob patterns. Each is
   matched against the target repository's file list; **any** match makes the
-  rule relevant. Use `**/` prefixes so a pattern matches at the repository root
-  and at any depth. Patterns name the *files that indicate the tool is in use*,
-  not files that prove compliance — a repository that violates a rule still
-  needs to carry it.
-- **Rule** body runs from the `**Rule:**` line to the next `## rule:` heading or
-  end of file, with leading and trailing blank lines trimmed. It is copied
-  byte-for-byte, so it must read correctly standing alone in someone else's
-  `AGENTS.md`.
+  rule relevant. Prefix a pattern with `**/` so it matches at the repository root
+  and at any depth — unless the tool only ever works at a fixed path, in which
+  case anchor the pattern there instead (as `github-actions-pinning` does with
+  `.github/workflows/*.yaml`). Patterns name the *files that indicate the tool is
+  in use*, not files that prove compliance — a repository that violates a rule
+  still needs to carry it.
+- **Rule** body starts on the line **after** the `**Rule:**` line and runs to the
+  next `## rule:` heading or end of file, with leading and trailing blank lines
+  trimmed. The `**Rule:**` marker line itself is never part of the body. It is
+  copied byte-for-byte, so it must read correctly standing alone in someone
+  else's `AGENTS.md`.
 - A body may use bullets, tables, code fences, and links, but **no markdown
   headings** — it is emitted under a `###` heading and any heading inside it
   would break the target file's outline.

--- a/plugins/aoshimash-skills/rules/agent-rules.md
+++ b/plugins/aoshimash-skills/rules/agent-rules.md
@@ -1,0 +1,161 @@
+# Shared Agent Rules
+
+The canonical set of the author's personal project conventions. This file is the
+single source; the rules are copied *from* here into individual repositories'
+`AGENTS.md`, and hand-written rules found in owned repositories are promoted
+*into* here.
+
+- `sync-agent-rules` **reads** this file (over the GitHub API, from
+  `aoshimash/skills`) and writes the relevant rules into a target repository.
+- `collect-agent-rules` **edits** this file in a local checkout to add newly
+  promoted rules.
+
+This file is data, not instructions to an agent. Nothing here changes how a
+skill behaves; a rule body is text to be copied verbatim into another
+repository's instruction file.
+
+## Contract
+
+Three things are fixed. Both skills depend on them, so do not change them
+without updating both.
+
+| Thing | Value |
+|---|---|
+| This file's path | `plugins/aoshimash-skills/rules/agent-rules.md`, relative to the repository root of `aoshimash/skills` |
+| Managed-block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->` |
+| Per-rule marker inside a block | `<!-- rule: <id> -->`, on the line after the rule's `###` heading |
+
+The delimiters are HTML comments, so they are invisible in rendered markdown and
+greppable in source. They serve two purposes: they tell `sync-agent-rules` what
+it owns and may refresh, and they tell `collect-agent-rules` what to **ignore**
+when scanning a repository for rules worth promoting — without that boundary,
+already-distributed rules would be rediscovered as candidates on every scan.
+
+## Format
+
+Every rule is one `## rule: <id>` section appearing under the "Rules" heading
+below. The id is stable, lowercase, hyphen-separated, and is what a managed block
+references — never rename an id without accepting that repositories carrying it
+will treat the old one as orphaned.
+
+A `## rule:` line **inside a fenced code block is not a rule** — the template
+immediately below is an example, and a rule body may legitimately contain fenced
+markdown. Skip fenced regions when enumerating rules.
+
+```markdown
+## rule: <id>
+
+**Title:** <heading text used in the target repository>
+
+**Detect:** `<glob>`, `<glob>`, …
+
+**Rule:**
+
+<body — copied verbatim into the target repository>
+```
+
+- **Detect** is a comma-separated list of backticked glob patterns. Each is
+  matched against the target repository's file list; **any** match makes the
+  rule relevant. Use `**/` prefixes so a pattern matches at the repository root
+  and at any depth. Patterns name the *files that indicate the tool is in use*,
+  not files that prove compliance — a repository that violates a rule still
+  needs to carry it.
+- **Rule** body runs from the `**Rule:**` line to the next `## rule:` heading or
+  end of file, with leading and trailing blank lines trimmed. It is copied
+  byte-for-byte, so it must read correctly standing alone in someone else's
+  `AGENTS.md`.
+- A body may use bullets, tables, code fences, and links, but **no markdown
+  headings** — it is emitted under a `###` heading and any heading inside it
+  would break the target file's outline.
+- Bodies are written in English, matching this repository and the author's newer
+  `AGENTS.md` files.
+- Avoid version numbers and image tags that rot, except where naming one is the
+  point of the rule.
+
+**Adding a rule requires no change to any `SKILL.md`.** Append a new
+`## rule:` section below and it is distributable immediately — the skills
+enumerate these sections generically and nothing about a rule (id, title,
+pattern, or body) is hard-coded in a skill. Keep sections in a stable order;
+that order determines the order rules are appended in a target repository.
+
+## Rules
+
+## rule: container-base-image
+
+**Title:** Container image policy
+
+**Detect:** `**/Dockerfile`, `**/Dockerfile.*`, `**/*.Dockerfile`, `**/Containerfile`, `**/compose.yaml`, `**/compose.yml`, `**/docker-compose.yaml`, `**/docker-compose.yml`
+
+**Rule:**
+
+| Purpose | Base image | Why |
+|---|---|---|
+| Build stage | Debian/Ubuntu-based (e.g. `golang:1.25-bookworm`) | glibc compatibility, full toolchain, debuggable |
+| Production stage | distroless (e.g. `gcr.io/distroless/static-debian12`) | minimal attack surface, no shell, no package manager |
+| Development and tooling | Debian/Ubuntu-based | rich debug tooling, glibc-based compatibility |
+
+- **Do not use Alpine.** musl-vs-glibc incompatibilities, missing debug tooling,
+  and differing DNS behaviour. Exception: when upstream publishes only an
+  Alpine-based image (e.g. `migrate/migrate`), using it is acceptable.
+- Build Go binaries with `CGO_ENABLED=0` so they are static and pair cleanly
+  with distroless.
+- To debug a distroless image, use its `:debug` tag (which includes busybox) or
+  an ephemeral container (`kubectl debug`).
+
+## rule: python-package-management
+
+**Title:** Python package management
+
+**Detect:** `**/pyproject.toml`, `**/uv.lock`, `**/requirements*.txt`, `**/setup.py`, `**/setup.cfg`, `**/Pipfile`, `**/*.py`
+
+**Rule:**
+
+- Manage every Python project with [uv](https://docs.astral.sh/uv/).
+  Dependencies are declared in `pyproject.toml` and locked in `uv.lock`; both
+  are committed.
+- **Never invoke `pip`, `pip install`, `python`, or `python3` directly.** Every
+  Python operation goes through uv — `uv add`, `uv sync`, `uv run`.
+- Give each independently-versioned component its own uv project (its own
+  `pyproject.toml` and virtual environment) and run uv commands from that
+  project's directory rather than from the repository root.
+
+## rule: cli-version-management
+
+**Title:** CLI tool version management
+
+**Detect:** `**/aqua.yaml`, `**/aqua.yml`, `**/.aqua.yaml`, `**/.aqua.yml`, `**/aqua/aqua.yaml`, `**/.aqua/aqua.yaml`, `**/.tool-versions`, `**/.nvmrc`, `**/.node-version`, `**/.terraform-version`, `**/mise.toml`, `**/.mise.toml`
+
+**Rule:**
+
+- Pin every CLI tool the repository needs with [aqua](https://aquaproj.github.io/),
+  configured in `aqua.yaml` at the repository root and committed.
+- **aqua is the single source of tool versions.** Do not add a second version
+  manager (asdf, mise, nvm, pyenv, tfenv), and do not keep parallel version
+  files such as `.nvmrc` or `.terraform-version`.
+  - Exception: when a build host discovers a version only from its own file
+    (for example a hosting platform reading `.node-version`), keep that file,
+    record why, and keep it in sync with `aqua.yaml`. Renovate raises a pull
+    request for both, so following it is enough.
+- Install tools through aqua in CI as well, so local and CI run the same
+  versions.
+
+## rule: github-actions-pinning
+
+**Title:** GitHub Actions pinning
+
+**Detect:** `.github/workflows/*.yaml`, `.github/workflows/*.yml`, `**/action.yaml`, `**/action.yml`
+
+**Rule:**
+
+- Pin every third-party GitHub Action to a full commit SHA, with the
+  human-readable version in a trailing comment:
+
+  ```yaml
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  ```
+
+  A tag or branch reference is mutable and can be repointed at different code
+  after review.
+- Do not maintain the pins by hand. Enable Renovate's
+  [`helpers:pinGitHubActionDigests`](https://docs.renovatebot.com/presets-helpers/)
+  preset so pinning and updating are automatic.

--- a/plugins/aoshimash-skills/rules/agent-rules.md
+++ b/plugins/aoshimash-skills/rules/agent-rules.md
@@ -1,14 +1,14 @@
 # Shared Agent Rules
 
 The canonical set of the author's personal project conventions. This file is the
-single source; the rules are copied *from* here into individual repositories'
-`AGENTS.md`, and hand-written rules found in owned repositories are promoted
-*into* here.
+single source: the rules are copied *from* here into individual repositories'
+`AGENTS.md`.
 
 - `sync-agent-rules` **reads** this file (over the GitHub API, from
   `aoshimash/skills`) and writes the relevant rules into a target repository.
-- `collect-agent-rules` **edits** this file in a local checkout to add newly
-  promoted rules.
+- A future `collect-agent-rules` skill (issue #83, not yet implemented) will
+  **edit** this file in a local checkout to add rules promoted from hand-written
+  `AGENTS.md` files in owned repositories.
 
 This file is data, not instructions to an agent. Nothing here changes how a
 skill behaves; a rule body is text to be copied verbatim into another
@@ -16,8 +16,9 @@ repository's instruction file.
 
 ## Contract
 
-These are fixed. Both skills depend on them, so do not change them without
-updating both.
+These are fixed. `sync-agent-rules` depends on them today and
+`collect-agent-rules` will depend on them, so do not change them without
+updating every skill that reads or writes this format.
 
 | Thing | Value |
 |---|---|
@@ -28,9 +29,11 @@ updating both.
 
 The delimiters are HTML comments, so they are invisible in rendered markdown and
 greppable in source. They serve two purposes: they tell `sync-agent-rules` what
-it owns and may refresh, and they tell `collect-agent-rules` what to **ignore**
-when scanning a repository for rules worth promoting — without that boundary,
-already-distributed rules would be rediscovered as candidates on every scan.
+it owns and may refresh, and they will tell `collect-agent-rules` what to
+**ignore** when scanning a repository for rules worth promoting — without that
+boundary, already-distributed rules would be rediscovered as candidates on every
+scan. That second purpose is why the format is fixed here even though the
+collection skill does not exist yet.
 
 ## Format
 
@@ -64,8 +67,10 @@ markdown. Skip fenced regions when enumerating rules.
   in use*, not files that prove compliance — a repository that violates a rule
   still needs to carry it.
 - **Rule** body starts on the line **after** the `**Rule:**` line and runs to the
-  next `## rule:` heading or end of file, with leading and trailing blank lines
-  trimmed. The `**Rule:**` marker line itself is never part of the body. It is
+  next `##`-level heading or end of file, with leading and trailing blank lines
+  trimmed. The `**Rule:**` marker line itself is never part of the body. Stopping
+  at any `##` heading — not only at the next `## rule:` — keeps a non-rule section
+  appended after the last rule from being swallowed into that rule's body. It is
   copied byte-for-byte, so it must read correctly standing alone in someone
   else's `AGENTS.md`.
 - A body may use bullets, tables, code fences, and links, but **no markdown

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
@@ -41,15 +41,17 @@ file in `aoshimash/skills`.
    Every rule declares the file patterns that indicate its tool is in use.
    Detection is re-evaluated on every run, so a rule appears by itself once its
    tool appears here. **Rules whose patterns do not match are skipped
-   silently** — not written, not offered, not asked about. Never ask the user
-   whether they might use a tool later.
+   silently** — not written, not offered, not asked about — *except* in the
+   bootstrap case (Phase 5), where nothing at all is detected and the full
+   catalog is deliberately offered for selection. Never ask the user whether
+   they might use a tool later.
 3. **Writes are additive.** The managed block may hold rules that detection
    would not produce, because a user selected them explicitly. A later run must
    preserve them. Removal is only ever presented for confirmation and is never
    applied automatically.
 4. **Idempotent.** A second run against an unchanged repository must produce a
    byte-identical file, therefore no commit and no pull request. Render the
-   block by the exact recipe in Phase 6 and compare before writing.
+   block by the exact recipe in Phase 8 and compare before writing.
 5. **No clone, and no new files.** The skill runs inside the target repository,
    so the change is an ordinary edit plus a pull request. Never `git clone`.
    Never create a per-repository state file, config file, cache, or scratch file
@@ -57,6 +59,10 @@ file in `aoshimash/skills`.
 6. **The rule text is copied verbatim.** Do not reword, re-wrap, summarize, or
    "improve" a rule body while writing it. Byte-for-byte copying is what makes
    the block idempotent and what makes a corrected rule propagate cleanly.
+7. **Nothing is written until the decision to write is made.** Every filesystem
+   edit happens in Phase 10. Phases 0–9 read, decide, and ask; a run that ends
+   in "already in sync", a cancelled bootstrap, or a refusal leaves the
+   repository exactly as it was found.
 
 ## Environment Adaptation
 
@@ -69,20 +75,20 @@ below use capability terms; map them to your environment as follows.
 
 User choice is used in four places only, and never as an approval gate on the
 sync itself: Phase 0's confirmation when the target *is* the corpus repository,
-Phase 3's decision when the repository has a `CLAUDE.md` but no `AGENTS.md`,
-Phase 4's catalog selection when nothing is detected, and Phase 5's confirmation
+Phase 5's catalog selection when nothing is detected, Phase 6's decision when
+the repository has a `CLAUDE.md` but no `AGENTS.md`, and Phase 7's confirmation
 before removing anything from an existing managed block.
 
 ## The Contract
 
-These three things are fixed, and other skills depend on them. Do not vary them
-per run.
+These are fixed, and other skills depend on them. Do not vary them per run.
 
 | Thing | Value |
 |---|---|
 | Corpus path | `plugins/aoshimash-skills/rules/agent-rules.md` in `aoshimash/skills` |
 | Rule format | One `## rule: <id>` section per rule, containing a `**Title:**` line, a `**Detect:**` line of backticked glob patterns, and a `**Rule:**` line followed by the verbatim rule body. Specified in full in the corpus file's own "Format" section |
-| Block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->` |
+| Block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->`, each alone on its own line |
+| Block preamble | Immediately inside `BEGIN`: the heading `## Shared Conventions`, then an HTML comment beginning `<!-- Managed by the sync-agent-rules skill`. Both are **generated**, not content — this skill strips them when reading (Phase 4) and re-emits them when writing (Phase 8) |
 | Per-rule marker | `<!-- rule: <id> -->`, on the line after the rule's `###` heading inside the block |
 
 Because a rule is just a section in one file and this skill enumerates the
@@ -101,9 +107,13 @@ failed if any does not hold.
    there is nothing to clone.
 2. **The target instruction files are unmodified.** `git status --porcelain`
    must not list `AGENTS.md` or `CLAUDE.md`, and nothing may be already staged.
-   Refuse to proceed otherwise, so the commit contains only the sync.
+   Refuse to proceed otherwise, so the commit contains only the sync and no
+   in-progress work is swept into it.
 3. **`gh` is authenticated** (`gh auth status`) and the network is reachable.
-4. Note the current branch so Phase 8 can restore it.
+4. **Record the starting position** so the wrap-up can restore it:
+   `git symbolic-ref --quiet --short HEAD` for a branch, or — when that fails
+   because HEAD is detached — `git rev-parse HEAD` for the commit. Restoring by
+   SHA is correct for a detached HEAD; do not assume a branch name exists.
 5. **If the remote is `aoshimash/skills` itself**, the target is the corpus
    repository. Rules there are authored, not distributed, and a managed block in
    its `AGENTS.md` would duplicate the corpus it ships. Say so and ask the user
@@ -128,10 +138,11 @@ curl -fsSL https://raw.githubusercontent.com/aoshimash/skills/main/plugins/aoshi
 
 Hold the fetched text in memory, or write it to a temporary location **outside
 the repository** (e.g. the system temp directory) — never into the working tree.
-Parse every `## rule: <id>` section into `(id, title, detect patterns, body)`;
-the body runs from the `**Rule:**` line to the next `## rule:` heading or end of
-file, with surrounding blank lines trimmed. Preserve the corpus order, which
-determines the order of newly appended rules.
+Parse every `## rule: <id>` section into `(id, title, detect patterns, body)`.
+The body starts on the line **after** the `**Rule:**` line and runs to the next
+`## rule:` heading or end of file, with surrounding blank lines trimmed — the
+`**Rule:**` marker line itself is never part of the body. Preserve the corpus
+order, which determines the order of newly appended rules.
 
 Two things are **not** rules and must be skipped: sections that are not
 `## rule:` headings (the corpus's own "Contract" and "Format" documentation),
@@ -146,49 +157,96 @@ the skill, and never reconstruct rule text from memory.
 
 For each rule, test its `Detect` patterns against the files present in this
 repository. Use git's own file list, so `.gitignore` is honoured and files added
-but not yet committed still count:
+but not yet committed still count. Run **one invocation per pattern**, so you
+know which pattern matched and not merely that something did:
 
 ```bash
-git ls-files --cached --others --exclude-standard -- ':(glob)<pattern>' ':(glob)<pattern2>'
+git ls-files --cached --others --exclude-standard -- ':(glob)<pattern>'
 ```
 
-Non-empty output means the rule's tool is in use → the rule is **detected**.
-Empty output across all of its patterns → not detected, and Principle 2 applies:
-skip it silently.
+Non-empty output means the rule's tool is in use → the rule is **detected**; you
+may stop at its first matching pattern. Empty output across all of its patterns
+→ not detected, and Principle 2 applies: skip it silently.
 
 Notes:
 
 - `--others --exclude-standard` includes untracked-but-not-ignored files, so a
   `Dockerfile` created moments ago is seen, while ignored paths such as
   `node_modules/` and `.venv/` are excluded automatically.
-- `':(glob)**/x'` matches `x` at the repository root as well as at any depth.
+- `':(glob)**/x'` matches `x` at the repository root as well as at any depth. A
+  pathspec that matches nothing exits 0 with empty output, so "non-empty output"
+  is the correct test — do not rely on the exit status.
 - Detection is about the *presence of the tool*, not about compliance. A
   repository that violates a rule still gets the rule.
 
-Record the detected set and the pattern that matched each one, so the pull
-request can explain why every rule is there.
+Record, per detected rule, the pattern that matched and one example file, so the
+pull request can explain why every rule is there.
 
-### Phase 3: Locate and read the target file
+### Phase 3: Establish the working branch
 
-The target is `AGENTS.md` at the repository root. Handle the variants:
+Do this **before** reading the target file, so everything that follows reads,
+renders, compares, and writes against one single branch's copy of the file.
 
-| Situation | Action |
+```bash
+git fetch origin
+```
+
+Determine the default branch (e.g.
+`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`), then:
+
+- **A sync branch already exists** (local `chore/sync-agent-rules` or
+  `origin/chore/sync-agent-rules`) → check it out and fast-forward it to the
+  remote. That branch's `AGENTS.md` already carries the block and may carry
+  hand edits a reviewer made on the open pull request; reading and writing there
+  is what preserves them. If the local branch has diverged and cannot
+  fast-forward, stop and report — do not merge, rebase, or force anything.
+- **No sync branch exists** → create it from the freshly fetched default branch:
+  `git switch -c chore/sync-agent-rules origin/<default-branch>`. **Never base
+  it on the session's current branch** — a feature branch would drag unrelated
+  commits into the pull request, and a stale local default branch would give a
+  stale base.
+
+Remember whether this run created the branch. If the run later ends without a
+commit, the wrap-up deletes it.
+
+### Phase 4: Read the target file
+
+Pick the target file, in this order:
+
+| Situation | Target |
 |---|---|
-| `AGENTS.md` exists | Use it. |
-| Neither `AGENTS.md` nor `CLAUDE.md` exists | Create `AGENTS.md` containing only the managed block. Mention in the pull request that a `CLAUDE.md` importing it (`@AGENTS.md`) is the convention, but do not create one. |
-| `AGENTS.md` absent, `CLAUDE.md` exists and already imports it (contains `@AGENTS.md`) | Create `AGENTS.md`. `CLAUDE.md` needs no change — the import already picks it up. |
-| `AGENTS.md` absent, `CLAUDE.md` exists and does **not** import it | Writing a fresh `AGENTS.md` here would land the rules in a file no agent reads. Do not guess — ask the user to choose (see Environment Adaptation): **(1) Create `AGENTS.md` and add an `@AGENTS.md` import line to `CLAUDE.md`** (recommended; matches the convention) / **(2) Write the managed block into `CLAUDE.md` instead** / **(3) Create `AGENTS.md` only, no import** — warn that nothing will load it until something imports it / **(4) Abort**. |
+| `AGENTS.md` exists | `AGENTS.md` |
+| `AGENTS.md` absent, but `CLAUDE.md` contains a managed block | `CLAUDE.md`. A previous run wrote there on the user's instruction; the block's location *is* that recorded decision, so do not ask again |
+| Otherwise | **Undecided** — resolved in Phase 6, after Phase 5 can still cancel the run |
 
-Option 1 is the only case where a second file is touched; it is a one-line
-addition to a file that already exists, and it happens only on the user's
-explicit selection. No other file in the repository is ever created or modified.
+Then, on the chosen file:
 
-Then read the target file and parse whatever sits between the delimiters into an
-ordered list of entries. An entry carrying a `<!-- rule: <id> -->` marker is a
-**managed entry**; anything else between the delimiters is a **foreign entry**.
-A file with no delimiters yields an empty list.
+1. **Validate the block.** Count the lines whose entire content, ignoring
+   surrounding whitespace, is exactly the `BEGIN` delimiter, and likewise for
+   `END`. Requiring the delimiter to be the whole line is what stops a prose
+   mention of it in the document from being miscounted. Accept only **zero** of
+   each (no block yet) or **exactly one of each, `BEGIN` before `END`**.
+   Anything else — a `BEGIN` with no `END` (truncated file, deleted marker) or
+   two pairs (bad merge) — is a malformed block: **stop and report, write
+   nothing.** Never guess the missing boundary; treating an unterminated block
+   as running to end of file would destroy every hand-written section below it.
+2. **Record the file's line ending** (LF or CRLF, by majority) and whether the
+   file ends with a newline. Phase 9 compares and Phase 10 writes in the file's
+   own line ending, so a CRLF checkout does not diff against an LF render on
+   every run.
+3. **Strip the generated preamble** from the top of the block: the
+   `## Shared Conventions` heading line if present, and the HTML comment
+   beginning `<!-- Managed by the sync-agent-rules skill` if present, together
+   with the blank lines around them. Phase 8 re-emits both verbatim. **Skipping
+   this step is what makes a second run produce a spurious diff**, because the
+   preamble would otherwise be captured as content and then duplicated.
+4. **Parse the remainder into an ordered list of entries.** An entry carrying a
+   `<!-- rule: <id> -->` marker is a **managed entry**; anything else between the
+   delimiters is a **foreign entry** — including a hand-written paragraph that
+   sits before the first `###` heading. A file with no delimiters yields an empty
+   list.
 
-### Phase 4: Bootstrap when nothing is detected
+### Phase 5: Bootstrap when nothing is detected
 
 If the detected set is empty **and** the block has no managed entries — a
 repository with no tooling yet, e.g. one created moments ago — do not finish with
@@ -197,15 +255,34 @@ an empty run and do not write an empty block. Present the full corpus catalog
 Environment Adaptation) which rules to write. Multiple selections are expected;
 offer an option to select all and an option to cancel without changes.
 
-Treat the user's selections exactly as detected rules for the rest of the
-workflow. They are the reason Principle 3 exists: a later run detects nothing
-and must still leave them alone.
+If the user cancels, go straight to the wrap-up: nothing has been written yet
+(Principle 7), so there is nothing to undo beyond restoring the branch.
+
+Otherwise treat the selections exactly as detected rules for the rest of the
+workflow. They are the reason Principle 3 exists: a later run detects nothing and
+must still leave them alone.
 
 If the detected set is empty but the block already carries managed entries, this
-is **not** a bootstrap — the repository is either in sync (Phase 7) or needs only
-the refresh from Phase 5 step 2. Do not present the catalog.
+is **not** a bootstrap — the repository is either in sync (Phase 9) or needs only
+the refresh from Phase 7 step 2. Do not present the catalog.
 
-### Phase 5: Merge into the managed block
+### Phase 6: Resolve an undecided target file
+
+Only reached when Phase 4 left the target undecided and Phase 5 did not cancel —
+that is, only once something is actually going to be written.
+
+| Situation | Action |
+|---|---|
+| Neither `AGENTS.md` nor `CLAUDE.md` exists | Target `AGENTS.md`, to be created in Phase 10 with the block as its entire contents. Mention in the pull request that a `CLAUDE.md` importing it (`@AGENTS.md`) is the convention, but do not create one. |
+| `CLAUDE.md` exists and already imports `AGENTS.md` (contains `@AGENTS.md`) | Target `AGENTS.md`, to be created in Phase 10. `CLAUDE.md` needs no change — the import already picks it up. |
+| `CLAUDE.md` exists and does **not** import `AGENTS.md` | Writing a fresh `AGENTS.md` here would land the rules in a file no agent reads. Do not guess — ask the user to choose (see Environment Adaptation): **(1) Target `AGENTS.md` and add an `@AGENTS.md` import line to `CLAUDE.md`** (recommended; matches the convention) / **(2) Target `CLAUDE.md` instead** / **(3) Target `AGENTS.md` only, no import** — warn that nothing will load it until something imports it / **(4) Abort**. |
+
+Option 1 is the only case where a second file is touched; it is a one-line
+addition to a file that already exists, it happens only on the user's explicit
+selection, and like everything else it is applied in Phase 10. No other file in
+the repository is ever created or modified.
+
+### Phase 7: Merge into the managed block
 
 Build the new entry list from the parsed entries and the detected set:
 
@@ -225,10 +302,10 @@ Build the new entry list from the parsed entries and the detected set:
 A detected rule that is already present is simply refreshed by step 2 — it is
 not duplicated. Match entries on the id, never on the title or body text.
 
-### Phase 6: Render the block
+### Phase 8: Render the block
 
 Render exactly this, with no variation — the byte-level recipe is what makes
-Phase 7's comparison meaningful:
+Phase 9's comparison meaningful:
 
 ```markdown
 <!-- BEGIN aoshimash-agent-rules -->
@@ -252,35 +329,48 @@ Phase 7's comparison meaningful:
 <!-- END aoshimash-agent-rules -->
 ```
 
+- The heading and the managed-by comment are the generated preamble from "The
+  Contract". Emit them exactly as above on every run — Phase 4 step 3 already
+  removed the previous copy, so they are never duplicated.
 - One blank line after each `<!-- rule: ... -->` marker, one blank line between a
   body and the next `###` heading, one blank line before `<!-- END ... -->`.
 - Rule bodies are copied verbatim from the corpus, including their own
   formatting. Do not re-wrap lines.
 - Foreign entries are emitted verbatim at their recorded position, separated from
   their neighbours by a single blank line.
-- When the block is new, append it to the end of the file, preceded by exactly
-  one blank line. The file ends with a single newline.
-- When the block already exists, replace only the text between and including the
-  delimiters. Everything outside them is untouched.
+- Use the target file's recorded line ending (Phase 4 step 2) throughout; LF for
+  a file being created.
 
-### Phase 7: Compare, and stop early if in sync
+Placement:
 
-Compare the rendered file content against the file on disk.
+- **Creating the file** (Phase 6 rows 1–2): the file *is* the block —
+  `<!-- BEGIN … -->` is line 1, with no leading blank line, and the file ends
+  with a single newline after `<!-- END … -->`.
+- **Appending to an existing file with no block**: if the file does not already
+  end with a newline, add one; then one blank line, then the block; then a
+  single trailing newline.
+- **Updating an existing block**: replace only the text between and including
+  the delimiters — which Phase 4 step 1 has already proven to be exactly one
+  well-formed pair. Everything outside them is untouched.
 
-- **Identical** → nothing to do. Make no edit, create no branch, open no pull
-  request. Report which rules are present, which were detected, and that the
-  repository is already in sync. This is the second-run case and it must be a
-  true no-op.
-- **Different** → continue to Phase 8.
+### Phase 9: Compare, and stop if in sync
 
-### Phase 8: Commit and open a pull request
+Compare the rendered file content against the file on disk, both in the file's
+recorded line ending so the comparison reflects real content and not encoding.
 
-1. Create (or reuse) the branch `chore/sync-agent-rules` from the current HEAD.
-   If a branch or open pull request with that head already exists, commit on top
-   of it and update that pull request rather than opening a second one
-   (`gh pr list --head chore/sync-agent-rules`).
-2. Write the file(s) and stage **only** `AGENTS.md` (plus `CLAUDE.md` when the
-   user chose Phase 3 option 1 or 2). Never `git add -A` / `git add .` — that is
+- **Identical** → nothing to do. Make no edit and open no pull request. Report
+  which rules are present, which were detected, and that the repository is
+  already in sync, then go to the wrap-up. This is the second-run case and it
+  must be a true no-op.
+- **Different** → continue to Phase 10.
+
+### Phase 10: Write, commit, and open a pull request
+
+This is the only phase that modifies anything. The branch is already checked out
+and up to date from Phase 3.
+
+1. Write the target file, and `CLAUDE.md` too if the user chose Phase 6 option 1.
+2. Stage **only** those files by name. Never `git add -A` / `git add .` — that is
    the guard that keeps stray files out of the change.
 3. Commit:
 
@@ -292,15 +382,32 @@ Compare the rendered file content against the file on disk.
    Source: aoshimash/skills plugins/aoshimash-skills/rules/agent-rules.md
    ```
 
-4. Push and open the pull request. The body states, per rule, whether it was
-   **added**, **refreshed** (text changed upstream), **kept** (present but not
-   detected), or **removed** (confirmed by the user), plus the pattern that
+4. Push (`git push -u origin chore/sync-agent-rules`). If the push is rejected as
+   non-fast-forward, someone pushed to the sync branch during this run: **stop and
+   report, and do not force-push** — the local commit is preserved, and re-running
+   the skill picks the new remote state up in Phase 3.
+5. Open the pull request, or, when one is already open for this branch
+   (`gh pr list --head chore/sync-agent-rules`), let the push update it instead of
+   opening a second one. The body states, per rule, whether it was **added**,
+   **refreshed** (text changed upstream), **kept** (present but not detected), or
+   **removed** (confirmed by the user), plus the pattern and example file that
    matched for each detected rule. List any foreign entries found inside the
    block.
-5. Return the pull request URL and restore the branch the session started on.
+6. Return the pull request URL.
 
 Never commit directly to the default branch, and never merge the pull request as
 part of this skill.
+
+### Wrap-up
+
+Reached by every exit path — success, "already in sync", a cancelled bootstrap, or
+a refusal.
+
+1. Restore the starting position recorded in Phase 0 step 4 (branch name, or
+   commit SHA for a detached HEAD).
+2. If this run created the sync branch and made no commit on it, delete it
+   (`git branch -d chore/sync-agent-rules`) so a cancelled run leaves nothing
+   behind. Never delete a branch that existed before this run.
 
 ## What This Skill Does Not Do
 
@@ -310,6 +417,8 @@ part of this skill.
   check compliance is a separate concern.
 - Does not touch other repositories, and does not clone anything.
 - Does not remove anything from the managed block without explicit confirmation.
+- Does not repair a malformed managed block, force-push, or resolve a diverged
+  sync branch. Each of those stops the run for a human.
 
 ## References
 

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: sync-agent-rules
+description: >
+  Write the shared personal conventions from the aoshimash/skills rule corpus
+  into the current repository's AGENTS.md — fetch the corpus over the GitHub
+  API, decide which rules are relevant from the files actually present in the
+  repository, write only those into a delimited managed block, and open a pull
+  request. Additive: entries already inside the block are never removed
+  without confirmation, and a repository where nothing is detected gets the
+  full catalog offered for explicit selection. Use when the user says
+  "sync agent rules", "apply my shared conventions to this repo",
+  "add the standard rules to AGENTS.md", "distribute the shared rules here",
+  "共通ルールを同期して", "AGENTS.md に共通の規約を反映して",
+  "このリポジトリに標準ルールを入れて", "エージェントルールを同期",
+  "共通の規約をこのリポジトリに配布して", or otherwise wants this
+  repository's AGENTS.md brought in line with the shared rule set.
+compatibility: Requires git, network access, and the GitHub CLI (gh) authenticated with read access to aoshimash/skills and write access to the target repository
+---
+
+# Sync Agent Rules
+
+Distribute the author's shared conventions into the repository the session is
+running in. The rules live in one corpus file in `aoshimash/skills`; this skill
+reads it, keeps only the rules whose tooling is actually present here, and
+writes them into a delimited managed block in this repository's `AGENTS.md`.
+The result is a pull request.
+
+This skill is the **transport, not the rulebook**. It never invents a rule and
+never edits the corpus — adding or correcting a rule is an edit to the corpus
+file in `aoshimash/skills`.
+
+## Core Principles
+
+1. **The corpus is addressed as a repository path, never relative to this
+   skill.** A running skill may resolve to a read-only, version-pinned copy that
+   is replaced on update and is not the git checkout. Always fetch the corpus
+   from `aoshimash/skills` over the network (Phase 1). This also means a rule
+   added to the corpus today is distributable today, without waiting for an
+   installed copy of this skill to catch up.
+2. **Relevance is decided from the repository's files, not from the user.**
+   Every rule declares the file patterns that indicate its tool is in use.
+   Detection is re-evaluated on every run, so a rule appears by itself once its
+   tool appears here. **Rules whose patterns do not match are skipped
+   silently** — not written, not offered, not asked about. Never ask the user
+   whether they might use a tool later.
+3. **Writes are additive.** The managed block may hold rules that detection
+   would not produce, because a user selected them explicitly. A later run must
+   preserve them. Removal is only ever presented for confirmation and is never
+   applied automatically.
+4. **Idempotent.** A second run against an unchanged repository must produce a
+   byte-identical file, therefore no commit and no pull request. Render the
+   block by the exact recipe in Phase 6 and compare before writing.
+5. **No clone, and no new files.** The skill runs inside the target repository,
+   so the change is an ordinary edit plus a pull request. Never `git clone`.
+   Never create a per-repository state file, config file, cache, or scratch file
+   inside the repository — the managed block *is* the state.
+6. **The rule text is copied verbatim.** Do not reword, re-wrap, summarize, or
+   "improve" a rule body while writing it. Byte-for-byte copying is what makes
+   the block idempotent and what makes a corrected rule propagate cleanly.
+
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+
+User choice is used in four places only, and never as an approval gate on the
+sync itself: Phase 0's confirmation when the target *is* the corpus repository,
+Phase 3's decision when the repository has a `CLAUDE.md` but no `AGENTS.md`,
+Phase 4's catalog selection when nothing is detected, and Phase 5's confirmation
+before removing anything from an existing managed block.
+
+## The Contract
+
+These three things are fixed, and other skills depend on them. Do not vary them
+per run.
+
+| Thing | Value |
+|---|---|
+| Corpus path | `plugins/aoshimash-skills/rules/agent-rules.md` in `aoshimash/skills` |
+| Rule format | One `## rule: <id>` section per rule, containing a `**Title:**` line, a `**Detect:**` line of backticked glob patterns, and a `**Rule:**` line followed by the verbatim rule body. Specified in full in the corpus file's own "Format" section |
+| Block delimiters | `<!-- BEGIN aoshimash-agent-rules -->` … `<!-- END aoshimash-agent-rules -->` |
+| Per-rule marker | `<!-- rule: <id> -->`, on the line after the rule's `###` heading inside the block |
+
+Because a rule is just a section in one file and this skill enumerates the
+sections generically, **adding a rule to the corpus requires no edit to this
+`SKILL.md`** — no rule id, title, pattern, or body is hard-coded here.
+
+## Workflow
+
+### Phase 0: Preconditions
+
+Verify all of the following before touching anything. Stop and say which one
+failed if any does not hold.
+
+1. **Inside a git repository, at its root.** `git rev-parse --show-toplevel`
+   succeeds; run everything from that directory. This repository is the target —
+   there is nothing to clone.
+2. **The target instruction files are unmodified.** `git status --porcelain`
+   must not list `AGENTS.md` or `CLAUDE.md`, and nothing may be already staged.
+   Refuse to proceed otherwise, so the commit contains only the sync.
+3. **`gh` is authenticated** (`gh auth status`) and the network is reachable.
+4. Note the current branch so Phase 8 can restore it.
+5. **If the remote is `aoshimash/skills` itself**, the target is the corpus
+   repository. Rules there are authored, not distributed, and a managed block in
+   its `AGENTS.md` would duplicate the corpus it ships. Say so and ask the user
+   to choose (see Environment Adaptation) whether to continue or stop; default
+   to stopping.
+
+### Phase 1: Fetch the corpus
+
+Read the corpus from `aoshimash/skills` over the API. **Do not read it from this
+skill's own directory** — that copy may be stale or read-only.
+
+```bash
+gh api repos/aoshimash/skills/contents/plugins/aoshimash-skills/rules/agent-rules.md \
+  -H "Accept: application/vnd.github.raw"
+```
+
+Fallback if that read fails (rate limit, transient error):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aoshimash/skills/main/plugins/aoshimash-skills/rules/agent-rules.md
+```
+
+Hold the fetched text in memory, or write it to a temporary location **outside
+the repository** (e.g. the system temp directory) — never into the working tree.
+Parse every `## rule: <id>` section into `(id, title, detect patterns, body)`;
+the body runs from the `**Rule:**` line to the next `## rule:` heading or end of
+file, with surrounding blank lines trimmed. Preserve the corpus order, which
+determines the order of newly appended rules.
+
+Two things are **not** rules and must be skipped: sections that are not
+`## rule:` headings (the corpus's own "Contract" and "Format" documentation),
+and any `## rule:` line **inside a fenced code block** — the Format section
+shows the template inside a fence, and a rule body may itself contain fenced
+markdown.
+
+If both reads fail, stop and report it. Never fall back to a copy bundled with
+the skill, and never reconstruct rule text from memory.
+
+### Phase 2: Detect which rules are relevant
+
+For each rule, test its `Detect` patterns against the files present in this
+repository. Use git's own file list, so `.gitignore` is honoured and files added
+but not yet committed still count:
+
+```bash
+git ls-files --cached --others --exclude-standard -- ':(glob)<pattern>' ':(glob)<pattern2>'
+```
+
+Non-empty output means the rule's tool is in use → the rule is **detected**.
+Empty output across all of its patterns → not detected, and Principle 2 applies:
+skip it silently.
+
+Notes:
+
+- `--others --exclude-standard` includes untracked-but-not-ignored files, so a
+  `Dockerfile` created moments ago is seen, while ignored paths such as
+  `node_modules/` and `.venv/` are excluded automatically.
+- `':(glob)**/x'` matches `x` at the repository root as well as at any depth.
+- Detection is about the *presence of the tool*, not about compliance. A
+  repository that violates a rule still gets the rule.
+
+Record the detected set and the pattern that matched each one, so the pull
+request can explain why every rule is there.
+
+### Phase 3: Locate and read the target file
+
+The target is `AGENTS.md` at the repository root. Handle the variants:
+
+| Situation | Action |
+|---|---|
+| `AGENTS.md` exists | Use it. |
+| Neither `AGENTS.md` nor `CLAUDE.md` exists | Create `AGENTS.md` containing only the managed block. Mention in the pull request that a `CLAUDE.md` importing it (`@AGENTS.md`) is the convention, but do not create one. |
+| `AGENTS.md` absent, `CLAUDE.md` exists and already imports it (contains `@AGENTS.md`) | Create `AGENTS.md`. `CLAUDE.md` needs no change — the import already picks it up. |
+| `AGENTS.md` absent, `CLAUDE.md` exists and does **not** import it | Writing a fresh `AGENTS.md` here would land the rules in a file no agent reads. Do not guess — ask the user to choose (see Environment Adaptation): **(1) Create `AGENTS.md` and add an `@AGENTS.md` import line to `CLAUDE.md`** (recommended; matches the convention) / **(2) Write the managed block into `CLAUDE.md` instead** / **(3) Create `AGENTS.md` only, no import** — warn that nothing will load it until something imports it / **(4) Abort**. |
+
+Option 1 is the only case where a second file is touched; it is a one-line
+addition to a file that already exists, and it happens only on the user's
+explicit selection. No other file in the repository is ever created or modified.
+
+Then read the target file and parse whatever sits between the delimiters into an
+ordered list of entries. An entry carrying a `<!-- rule: <id> -->` marker is a
+**managed entry**; anything else between the delimiters is a **foreign entry**.
+A file with no delimiters yields an empty list.
+
+### Phase 4: Bootstrap when nothing is detected
+
+If the detected set is empty **and** the block has no managed entries — a
+repository with no tooling yet, e.g. one created moments ago — do not finish with
+an empty run and do not write an empty block. Present the full corpus catalog
+(each rule's id, title, and a one-line gist) and ask the user to choose (see
+Environment Adaptation) which rules to write. Multiple selections are expected;
+offer an option to select all and an option to cancel without changes.
+
+Treat the user's selections exactly as detected rules for the rest of the
+workflow. They are the reason Principle 3 exists: a later run detects nothing
+and must still leave them alone.
+
+If the detected set is empty but the block already carries managed entries, this
+is **not** a bootstrap — the repository is either in sync (Phase 7) or needs only
+the refresh from Phase 5 step 2. Do not present the catalog.
+
+### Phase 5: Merge into the managed block
+
+Build the new entry list from the parsed entries and the detected set:
+
+1. **Keep every existing entry, in its existing order.** This is Principle 3.
+2. For each managed entry whose id exists in the corpus: **replace its title and
+   body with the corpus version, in place.** This is how a corrected rule reaches
+   repositories that already carry it.
+3. A managed entry whose id is **no longer in the corpus** is orphaned. Ask the
+   user to choose (see Environment Adaptation) per orphan: **Keep** (default) /
+   **Remove**. Never remove without an explicit selection.
+4. **Foreign entries are kept verbatim, in place.** Do not reformat or relocate
+   them. List them in the pull request body so the user can see what is inside
+   the block but not managed.
+5. **Append detected rules that are not already present**, in corpus order,
+   after the existing entries.
+
+A detected rule that is already present is simply refreshed by step 2 — it is
+not duplicated. Match entries on the id, never on the title or body text.
+
+### Phase 6: Render the block
+
+Render exactly this, with no variation — the byte-level recipe is what makes
+Phase 7's comparison meaningful:
+
+```markdown
+<!-- BEGIN aoshimash-agent-rules -->
+## Shared Conventions
+
+<!-- Managed by the sync-agent-rules skill (aoshimash/skills).
+     Source: plugins/aoshimash-skills/rules/agent-rules.md
+     Managed entries below are refreshed on every sync. Keep
+     repository-specific rules outside this block. -->
+
+### <title>
+<!-- rule: <id> -->
+
+<body>
+
+### <next title>
+<!-- rule: <next id> -->
+
+<body>
+
+<!-- END aoshimash-agent-rules -->
+```
+
+- One blank line after each `<!-- rule: ... -->` marker, one blank line between a
+  body and the next `###` heading, one blank line before `<!-- END ... -->`.
+- Rule bodies are copied verbatim from the corpus, including their own
+  formatting. Do not re-wrap lines.
+- Foreign entries are emitted verbatim at their recorded position, separated from
+  their neighbours by a single blank line.
+- When the block is new, append it to the end of the file, preceded by exactly
+  one blank line. The file ends with a single newline.
+- When the block already exists, replace only the text between and including the
+  delimiters. Everything outside them is untouched.
+
+### Phase 7: Compare, and stop early if in sync
+
+Compare the rendered file content against the file on disk.
+
+- **Identical** → nothing to do. Make no edit, create no branch, open no pull
+  request. Report which rules are present, which were detected, and that the
+  repository is already in sync. This is the second-run case and it must be a
+  true no-op.
+- **Different** → continue to Phase 8.
+
+### Phase 8: Commit and open a pull request
+
+1. Create (or reuse) the branch `chore/sync-agent-rules` from the current HEAD.
+   If a branch or open pull request with that head already exists, commit on top
+   of it and update that pull request rather than opening a second one
+   (`gh pr list --head chore/sync-agent-rules`).
+2. Write the file(s) and stage **only** `AGENTS.md` (plus `CLAUDE.md` when the
+   user chose Phase 3 option 1 or 2). Never `git add -A` / `git add .` — that is
+   the guard that keeps stray files out of the change.
+3. Commit:
+
+   ```
+   chore: sync shared agent rules into AGENTS.md
+
+   <one line per rule added / refreshed / removed>
+
+   Source: aoshimash/skills plugins/aoshimash-skills/rules/agent-rules.md
+   ```
+
+4. Push and open the pull request. The body states, per rule, whether it was
+   **added**, **refreshed** (text changed upstream), **kept** (present but not
+   detected), or **removed** (confirmed by the user), plus the pattern that
+   matched for each detected rule. List any foreign entries found inside the
+   block.
+5. Return the pull request URL and restore the branch the session started on.
+
+Never commit directly to the default branch, and never merge the pull request as
+part of this skill.
+
+## What This Skill Does Not Do
+
+- Does not edit the corpus. New or corrected rules are changes to
+  `aoshimash/skills`.
+- Does not enforce the rules. It writes text into an instruction file; making CI
+  check compliance is a separate concern.
+- Does not touch other repositories, and does not clone anything.
+- Does not remove anything from the managed block without explicit confirmation.
+
+## References
+
+- [../../rules/agent-rules.md](../../rules/agent-rules.md) — the corpus, in this
+  repository. At runtime it is read from `aoshimash/skills` over the API
+  (Phase 1), not from this path.
+- [references/eval-cases.md](references/eval-cases.md) — human-readable index of
+  the eval scenarios; runnable source is [evals/evals.json](evals/evals.json).

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md
@@ -59,10 +59,12 @@ file in `aoshimash/skills`.
 6. **The rule text is copied verbatim.** Do not reword, re-wrap, summarize, or
    "improve" a rule body while writing it. Byte-for-byte copying is what makes
    the block idempotent and what makes a corrected rule propagate cleanly.
-7. **Nothing is written until the decision to write is made.** Every filesystem
-   edit happens in Phase 10. Phases 0–9 read, decide, and ask; a run that ends
-   in "already in sync", a cancelled bootstrap, or a refusal leaves the
-   repository exactly as it was found.
+7. **Nothing is written until the decision to write is made.** No edit to the
+   repository's tracked content happens outside git's own branch operations until
+   Phase 10 — Phase 2 does create/check out a branch, which moves git refs and can
+   swap tracked files, and the wrap-up restores both. Phases 0–9 otherwise read,
+   decide, and ask; a run that ends in "already in sync", a cancelled bootstrap,
+   or a refusal leaves the repository exactly as it was found.
 
 ## Environment Adaptation
 
@@ -110,11 +112,14 @@ failed if any does not hold.
    Refuse to proceed otherwise, so the commit contains only the sync and no
    in-progress work is swept into it.
 3. **`gh` is authenticated** (`gh auth status`) and the network is reachable.
-4. **Record the starting position** so the wrap-up can restore it:
+4. **An `origin` remote exists and points at GitHub** (`git remote get-url
+   origin`). Without it, Phase 2's `git fetch origin` and `gh repo view` fail
+   mid-run; a local-only repository has nowhere to open a pull request.
+5. **Record the starting position** so the wrap-up can restore it:
    `git symbolic-ref --quiet --short HEAD` for a branch, or — when that fails
    because HEAD is detached — `git rev-parse HEAD` for the commit. Restoring by
    SHA is correct for a detached HEAD; do not assume a branch name exists.
-5. **If the remote is `aoshimash/skills` itself**, the target is the corpus
+6. **If the remote is `aoshimash/skills` itself**, the target is the corpus
    repository. Rules there are authored, not distributed, and a managed block in
    its `AGENTS.md` would duplicate the corpus it ships. Say so and ask the user
    to choose (see Environment Adaptation) whether to continue or stop; default
@@ -140,9 +145,13 @@ Hold the fetched text in memory, or write it to a temporary location **outside
 the repository** (e.g. the system temp directory) — never into the working tree.
 Parse every `## rule: <id>` section into `(id, title, detect patterns, body)`.
 The body starts on the line **after** the `**Rule:**` line and runs to the next
-`## rule:` heading or end of file, with surrounding blank lines trimmed — the
-`**Rule:**` marker line itself is never part of the body. Preserve the corpus
-order, which determines the order of newly appended rules.
+`##`-level heading or end of file, with surrounding blank lines trimmed — the
+`**Rule:**` marker line itself is never part of the body. Stopping at any `##`
+heading, not only at the next `## rule:`, is what keeps a non-rule section
+appended after the last rule from being absorbed into that rule's body and
+copied into every target repository — which would inject a `##` heading that the
+corpus format forbids in bodies. Preserve the corpus order, which determines the
+order of newly appended rules.
 
 Two things are **not** rules and must be skipped: sections that are not
 `## rule:` headings (the corpus's own "Contract" and "Format" documentation),
@@ -153,9 +162,72 @@ markdown.
 If both reads fail, stop and report it. Never fall back to a copy bundled with
 the skill, and never reconstruct rule text from memory.
 
-### Phase 2: Detect which rules are relevant
+### Phase 2: Establish the working branch
 
-For each rule, test its `Detect` patterns against the files present in this
+Do this **before** detecting anything and before reading the target file, so
+every step that follows — detection, read, render, compare, write — sees one
+single branch's copy of the repository.
+
+```bash
+git fetch origin
+```
+
+Determine the default branch (e.g.
+`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`), then check
+whether a sync pull request is actually open:
+
+```bash
+gh pr list --head chore/sync-agent-rules --state open
+```
+
+- **An open pull request exists for `chore/sync-agent-rules`** → reuse that
+  branch. Its target file already carries the block and may carry hand edits a
+  reviewer made on the pull request; reading and writing there is what preserves
+  them.
+
+  ```bash
+  git switch chore/sync-agent-rules
+  git merge --ff-only origin/chore/sync-agent-rules
+  ```
+
+  If the fast-forward fails, stop and report — **never** `git reset --hard`,
+  merge, rebase, or force. A local branch that is merely *ahead* of the remote is
+  the expected state after Phase 10 step 4 preserved an unpushed commit, and a
+  hard reset would silently destroy it.
+- **No open pull request** → do not reuse the branch even if a local
+  `chore/sync-agent-rules` exists. Nothing deletes local branches when a pull
+  request merges, so a leftover branch is behind the default branch; after a
+  squash merge its merge base is the pre-sync commit, and the next pull request
+  would re-add the whole block and conflict with the already-merged version.
+  Recreate it from the freshly fetched default branch:
+
+  ```bash
+  git switch -c chore/sync-agent-rules origin/<default-branch>   # -C to replace a leftover branch
+  ```
+
+  **Never base it on the session's current branch** — a feature branch would drag
+  unrelated commits into the pull request, and a stale local default branch would
+  give a stale base. Before replacing a leftover local branch, check it holds no
+  commits absent from `origin/<default-branch>`; if it does (an unpushed commit
+  from an earlier rejected push), stop and report rather than discarding work.
+
+If the branch operation fails for any other reason — most commonly
+`git switch` aborting because unrelated uncommitted files would be overwritten —
+stop and report it. Do not stash or discard the user's work to get past it.
+
+Remember whether this run created the branch. If the run later ends without a
+commit, the wrap-up deletes it.
+
+### Phase 3: Detect which rules are relevant
+
+Detection runs **after** the checkout above, so it reflects the branch the pull
+request will actually be based on. Detecting against the session's own branch
+would be wrong in both directions: a `Dockerfile` that exists only on a feature
+branch would be reported as the reason for a rule the pull request's base does
+not contain, and a file deleted on that feature branch but present on the default
+branch would be missed.
+
+For each rule, test its `Detect` patterns against the files present in the
 repository. Use git's own file list, so `.gitignore` is honoured and files added
 but not yet committed still count. Run **one invocation per pattern**, so you
 know which pattern matched and not merely that something did:
@@ -182,33 +254,6 @@ Notes:
 Record, per detected rule, the pattern that matched and one example file, so the
 pull request can explain why every rule is there.
 
-### Phase 3: Establish the working branch
-
-Do this **before** reading the target file, so everything that follows reads,
-renders, compares, and writes against one single branch's copy of the file.
-
-```bash
-git fetch origin
-```
-
-Determine the default branch (e.g.
-`gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`), then:
-
-- **A sync branch already exists** (local `chore/sync-agent-rules` or
-  `origin/chore/sync-agent-rules`) → check it out and fast-forward it to the
-  remote. That branch's `AGENTS.md` already carries the block and may carry
-  hand edits a reviewer made on the open pull request; reading and writing there
-  is what preserves them. If the local branch has diverged and cannot
-  fast-forward, stop and report — do not merge, rebase, or force anything.
-- **No sync branch exists** → create it from the freshly fetched default branch:
-  `git switch -c chore/sync-agent-rules origin/<default-branch>`. **Never base
-  it on the session's current branch** — a feature branch would drag unrelated
-  commits into the pull request, and a stale local default branch would give a
-  stale base.
-
-Remember whether this run created the branch. If the run later ends without a
-commit, the wrap-up deletes it.
-
 ### Phase 4: Read the target file
 
 Pick the target file, in this order:
@@ -216,20 +261,24 @@ Pick the target file, in this order:
 | Situation | Target |
 |---|---|
 | `AGENTS.md` exists | `AGENTS.md` |
-| `AGENTS.md` absent, but `CLAUDE.md` contains a managed block | `CLAUDE.md`. A previous run wrote there on the user's instruction; the block's location *is* that recorded decision, so do not ask again |
+| `AGENTS.md` absent, but `CLAUDE.md` contains a `BEGIN` delimiter line | `CLAUDE.md`. A previous run wrote there on the user's instruction; the block's location *is* that recorded decision, so do not ask again. Test for the `BEGIN` line alone, not for a well-formed pair — a stray unmatched `BEGIN` must reach step 1 below and be refused, not be treated as "no block" and get a second one appended |
 | Otherwise | **Undecided** — resolved in Phase 6, after Phase 5 can still cancel the run |
 
 Then, on the chosen file:
 
 1. **Validate the block.** Count the lines whose entire content, ignoring
    surrounding whitespace, is exactly the `BEGIN` delimiter, and likewise for
-   `END`. Requiring the delimiter to be the whole line is what stops a prose
-   mention of it in the document from being miscounted. Accept only **zero** of
-   each (no block yet) or **exactly one of each, `BEGIN` before `END`**.
-   Anything else — a `BEGIN` with no `END` (truncated file, deleted marker) or
-   two pairs (bad merge) — is a malformed block: **stop and report, write
-   nothing.** Never guess the missing boundary; treating an unterminated block
-   as running to end of file would destroy every hand-written section below it.
+   `END`, **skipping fenced code regions** as Phase 1 does. Requiring the
+   delimiter to be the whole line stops a prose mention of it from being
+   miscounted; skipping fences stops a target file that *documents* this
+   mechanism with a fenced example from being treated as the real block — which
+   would replace the fence's contents and leave stray fence lines behind. Accept
+   only **zero** of each (no block yet) or **exactly one of each, `BEGIN` before
+   `END`**. Anything else — a `BEGIN` with no `END` (truncated file, deleted
+   marker) or two pairs (bad merge) — is a malformed block: **stop and report,
+   write nothing.** Never guess the missing boundary; treating an unterminated
+   block as running to end of file would destroy every hand-written section
+   below it.
 2. **Record the file's line ending** (LF or CRLF, by majority) and whether the
    file ends with a newline. Phase 9 compares and Phase 10 writes in the file's
    own line ending, so a CRLF checkout does not diff against an LF render on
@@ -240,11 +289,19 @@ Then, on the chosen file:
    with the blank lines around them. Phase 8 re-emits both verbatim. **Skipping
    this step is what makes a second run produce a spurious diff**, because the
    preamble would otherwise be captured as content and then duplicated.
-4. **Parse the remainder into an ordered list of entries.** An entry carrying a
-   `<!-- rule: <id> -->` marker is a **managed entry**; anything else between the
-   delimiters is a **foreign entry** — including a hand-written paragraph that
-   sits before the first `###` heading. A file with no delimiters yields an empty
-   list.
+4. **Parse the remainder into an ordered list of entries, trimming each entry's
+   surrounding blank lines** exactly as Phase 1 trims a corpus body. An entry
+   carrying a `<!-- rule: <id> -->` marker is a **managed entry**; anything else
+   between the delimiters is a **foreign entry** — including a hand-written
+   paragraph that sits before the first `###` heading. A file with no delimiters
+   yields an empty list.
+
+   The trim is not cosmetic. Phase 8 supplies the separator blank lines on emit,
+   so an entry parsed *with* its trailing blank line gains another one on every
+   render — the gap grows by one line per run and the block never reaches a fixed
+   point, breaking Principle 4. Managed entries escape this only because step 2 of
+   Phase 7 replaces their bodies wholesale; foreign entries are preserved as
+   parsed, so untrimmed input persists.
 
 ### Phase 5: Bootstrap when nothing is detected
 
@@ -281,6 +338,16 @@ Option 1 is the only case where a second file is touched; it is a one-line
 addition to a file that already exists, it happens only on the user's explicit
 selection, and like everything else it is applied in Phase 10. No other file in
 the repository is ever created or modified.
+
+**Then apply Phase 4 steps 1–4 to the resolved file before continuing.** Phase 4
+routed this file to "Undecided" and so never validated or measured it. If the
+target resolved to an existing file — option 2's `CLAUDE.md` — it still needs its
+block validated, its line ending recorded, its preamble stripped and its entries
+parsed. Skipping that appends an LF block to a CRLF `CLAUDE.md` (whose mismatch
+the *next* run would "fix" with a purely cosmetic second pull request), and
+appends a second block to a `CLAUDE.md` holding a stray unmatched `BEGIN` instead
+of refusing it. For a file that does not exist yet, the steps are trivially
+satisfied: no block, no entries, and LF as the line ending.
 
 ### Phase 7: Merge into the managed block
 
@@ -343,9 +410,9 @@ Phase 9's comparison meaningful:
 
 Placement:
 
-- **Creating the file** (Phase 6 rows 1–2): the file *is* the block —
-  `<!-- BEGIN … -->` is line 1, with no leading blank line, and the file ends
-  with a single newline after `<!-- END … -->`.
+- **Creating the file** (Phase 6 rows 1–2, and row 3 options 1 and 3): the file
+  *is* the block — `<!-- BEGIN … -->` is line 1, with no leading blank line, and
+  the file ends with a single newline after `<!-- END … -->`.
 - **Appending to an existing file with no block**: if the file does not already
   end with a newline, add one; then one blank line, then the block; then a
   single trailing newline.
@@ -367,7 +434,7 @@ recorded line ending so the comparison reflects real content and not encoding.
 ### Phase 10: Write, commit, and open a pull request
 
 This is the only phase that modifies anything. The branch is already checked out
-and up to date from Phase 3.
+and up to date from Phase 2.
 
 1. Write the target file, and `CLAUDE.md` too if the user chose Phase 6 option 1.
 2. Stage **only** those files by name. Never `git add -A` / `git add .` — that is
@@ -385,7 +452,7 @@ and up to date from Phase 3.
 4. Push (`git push -u origin chore/sync-agent-rules`). If the push is rejected as
    non-fast-forward, someone pushed to the sync branch during this run: **stop and
    report, and do not force-push** — the local commit is preserved, and re-running
-   the skill picks the new remote state up in Phase 3.
+   the skill picks the new remote state up in Phase 2.
 5. Open the pull request, or, when one is already open for this branch
    (`gh pr list --head chore/sync-agent-rules`), let the push update it instead of
    opening a second one. The body states, per rule, whether it was **added**,
@@ -403,7 +470,7 @@ part of this skill.
 Reached by every exit path — success, "already in sync", a cancelled bootstrap, or
 a refusal.
 
-1. Restore the starting position recorded in Phase 0 step 4 (branch name, or
+1. Restore the starting position recorded in Phase 0 step 5 (branch name, or
    commit SHA for a detached HEAD).
 2. If this run created the sync branch and made no commit on it, delete it
    (`git branch -d chore/sync-agent-rules`) so a cancelled run leaves nothing

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
@@ -27,7 +27,7 @@
       "id": 1,
       "name": "detect-subset-silently",
       "prompt": "Sync my shared agent rules into this repository's AGENTS.md. This is a Go service repo: it has a `Dockerfile`, `cmd/server/main.go`, `go.mod`, and `.github/workflows/ci.yml`. There are no Python files, no `pyproject.toml`, no `aqua.yaml`, and no `.tool-versions`. An `AGENTS.md` exists with a few repo-specific sections and no managed block yet. Do this as a paper exercise: describe exactly what you read, what you detect, what you write, and what you ask me. Do not actually push anything.",
-      "expected_output": "The skill fetches the rule corpus from aoshimash/skills over the GitHub API (not from its own bundled directory), runs detection against the repository's actual file list, and finds two rules relevant: the container image policy (Dockerfile) and the GitHub Actions pinning rule (.github/workflows/ci.yml). The Python package management and CLI tool version management rules do not match any pattern, so they are skipped SILENTLY — the skill does not write them, does not list them as options, and does not ask whether Python or aqua might be used later. The two detected rules are appended to AGENTS.md inside a managed block delimited by the BEGIN/END aoshimash-agent-rules HTML comments, each rule carrying its per-rule marker comment, with rule bodies copied verbatim from the corpus. The existing repo-specific sections of AGENTS.md are left untouched. The change lands on a branch as a pull request, not as a direct commit to the default branch.",
+      "expected_output": "The skill fetches the rule corpus from aoshimash/skills over the GitHub API (not from its own bundled directory), runs detection against the repository's actual file list, and finds two rules relevant: the container image policy (Dockerfile) and the GitHub Actions pinning rule (.github/workflows/ci.yml). The Python package management and CLI tool version management rules do not match any pattern, so they are skipped SILENTLY — the skill does not write them, does not list them as options, and does not ask whether Python or aqua might be used later. The two detected rules are appended to AGENTS.md inside a managed block delimited by the BEGIN/END aoshimash-agent-rules HTML comments, each rule carrying its per-rule marker comment, with rule bodies copied verbatim from the corpus and without the `**Rule:**` marker line. The existing repo-specific sections of AGENTS.md are left untouched. The change lands on a branch created from the fetched default branch, as a pull request, not as a direct commit to the default branch.",
       "files": [],
       "expectations": [
         "Fetches the corpus from the aoshimash/skills repository over the network rather than reading a copy bundled with the skill",
@@ -35,7 +35,7 @@
         "Does NOT write the Python package management rule or the CLI tool version management rule",
         "Does NOT prompt, ask, or offer options about the non-matching rules (silent skip, no forecasting of future tooling)",
         "Writes the rules inside delimiters that identify the block as managed (BEGIN/END aoshimash-agent-rules), with a per-rule id marker for each rule",
-        "Copies each rule body verbatim from the corpus rather than rewording or summarizing it",
+        "Copies each rule body verbatim from the corpus, excluding the `**Rule:**` marker line itself, rather than rewording or summarizing it",
         "Leaves the pre-existing repo-specific content of AGENTS.md unchanged",
         "Delivers the change as a pull request on its own branch rather than committing to the default branch"
       ]
@@ -43,43 +43,49 @@
     {
       "id": 2,
       "name": "idempotent-second-run",
-      "prompt": "Sync the shared agent rules into this repository again. I ran the same sync yesterday: AGENTS.md already contains the managed block with the container image rule and the GitHub Actions pinning rule, and nothing in the repository or the corpus has changed since. Paper exercise — tell me precisely what you do.",
-      "expected_output": "The skill fetches the corpus, re-runs detection, renders what the block should contain, and compares it against the file on disk. Because the rendered result is byte-identical to the current AGENTS.md, it makes no edit at all: no branch is created, no commit is made, no pull request is opened. It reports that the repository is already in sync, listing which rules are present and which were detected. It does not open an empty or no-op pull request, does not reorder or reformat the existing block, and does not treat the already-present rules as new additions.",
+      "prompt": "Sync the shared agent rules into this repository again. I ran the same sync yesterday and the PR was merged: AGENTS.md on the default branch already contains the managed block with the container image rule and the GitHub Actions pinning rule, and nothing in the repository or the corpus has changed since. Paper exercise — tell me precisely what you do, and be specific about how you avoid producing a spurious diff.",
+      "expected_output": "The skill fetches the corpus, re-runs detection, reads the existing block, renders what the block should contain, and compares it against the file on disk. Critically, when parsing the existing block it strips the generated preamble — the `## Shared Conventions` heading and the `<!-- Managed by the sync-agent-rules skill ... -->` comment — instead of capturing them as content, because re-emitting them on top of captured copies would duplicate the header and manufacture a diff on every run. It compares in the file's own line ending rather than assuming LF. Because the rendered result is identical to the current AGENTS.md, it makes no edit at all: no commit, and no pull request. It reports that the repository is already in sync, listing which rules are present and which were detected, and restores the branch the session started on, deleting the sync branch it created since nothing was committed to it.",
       "files": [],
       "expectations": [
         "Renders the expected block and compares it against the current file before writing anything",
+        "Strips the generated preamble (the `## Shared Conventions` heading and the managed-by comment) when parsing the existing block, rather than treating it as content to preserve",
+        "Does not duplicate the block header or otherwise manufacture a diff on the second run",
+        "Compares using the target file's existing line ending rather than assuming LF",
         "Makes no change to AGENTS.md because the result is identical",
-        "Creates no branch, no commit, and no pull request on the second run",
+        "Creates no commit and no pull request on the second run",
         "Reports that the repository is already in sync rather than claiming to have added rules",
-        "Does not reorder, reformat, or re-wrap the existing managed block (which would manufacture a spurious diff)"
+        "Does not reorder, reformat, or re-wrap the existing managed block"
       ]
     },
     {
       "id": 3,
       "name": "additive-preserve-and-confirm-removal",
-      "prompt": "Sync the shared agent rules into this repository. The existing managed block in AGENTS.md currently contains three entries: (1) the Python package management rule — I added it explicitly months ago when this repo was empty, and the repo still has no Python files at all; (2) an entry marked with the rule id `legacy-changelog-policy`, which no longer exists in the shared corpus; (3) a paragraph I hand-wrote directly inside the block about our staging database, which has no rule id marker. Detection currently matches only the container image rule, which is not yet in the block. Paper exercise: what does the block look like afterwards, and what do you ask me?",
-      "expected_output": "Writes are additive. The Python package management rule is KEPT even though detection does not produce it — the skill does not remove it and does not ask about it, because a user may have placed it deliberately. The hand-written staging-database paragraph is kept verbatim in place, and mentioned in the pull request body as content inside the block that the skill does not manage. The `legacy-changelog-policy` entry is orphaned (its id is gone from the corpus), so the skill presents it for explicit confirmation — Keep (default) or Remove — and does not delete it unless the user explicitly chooses removal. The container image rule is appended. Nothing is removed automatically under any circumstance.",
+      "prompt": "Sync the shared agent rules into this repository. The existing managed block in AGENTS.md currently contains three entries: (1) the Python package management rule — I added it explicitly months ago when this repo was empty, and the repo still has no Python files at all; (2) an entry marked with the rule id `legacy-changelog-policy`, which no longer exists in the shared corpus; (3) a paragraph I hand-wrote directly inside the block about our staging database, sitting above the first rule heading and carrying no rule id marker. Detection currently matches only the container image rule, which is not yet in the block. Paper exercise: what does the block look like afterwards, and what do you ask me?",
+      "expected_output": "Writes are additive. The Python package management rule is KEPT even though detection does not produce it — the skill does not remove it and does not ask about it, because a user may have placed it deliberately. The hand-written staging-database paragraph is a foreign entry and is kept verbatim in place: even though it sits above the first `###` heading, it is NOT mistaken for the generated preamble (only the `## Shared Conventions` heading and the managed-by comment are stripped), and it is mentioned in the pull request body as content inside the block that the skill does not manage. The `legacy-changelog-policy` entry is orphaned (its id is gone from the corpus), so the skill presents it for explicit confirmation — Keep (default) or Remove — and does not delete it unless the user explicitly chooses removal. The container image rule is appended. Nothing is removed automatically under any circumstance.",
       "files": [],
       "expectations": [
         "Keeps the Python package management rule in the block despite detection not matching it",
         "Does not prompt about the undetected-but-present Python rule — it is simply preserved",
-        "Preserves the hand-written unmarked paragraph inside the block verbatim rather than deleting or rewriting it",
+        "Preserves the hand-written unmarked paragraph verbatim, and does not discard it as part of the generated preamble even though it precedes the first rule heading",
         "Identifies the `legacy-changelog-policy` entry as orphaned because its id is absent from the corpus",
         "Presents the orphaned entry for explicit user confirmation before any removal, defaulting to keeping it",
         "Never removes any entry automatically",
-        "Appends the newly detected container image rule"
+        "Appends the newly detected container image rule",
+        "Reports the foreign entry in the pull request body as unmanaged content inside the block"
       ]
     },
     {
       "id": 4,
       "name": "empty-repo-bootstrap",
-      "prompt": "I just created this repository ten minutes ago. It contains a README.md and a LICENSE, nothing else — no Dockerfile, no workflows, no source code. Sync my shared agent rules into it. Paper exercise: describe exactly what happens.",
-      "expected_output": "Detection matches nothing, and there is no existing managed block, so this is the bootstrap case. The skill does NOT finish with an empty run, does not write an empty managed block, and does not report that there is nothing to do. Instead it presents the full corpus catalog — every rule with its id, title, and a one-line gist — and asks the user to select which rules to write, supporting multiple selections plus select-all and cancel. Whatever the user picks is written exactly as detected rules would be, in the managed block, and the result lands as a pull request. The skill notes that a later run which detects nothing must still preserve these explicitly chosen rules.",
+      "prompt": "I just created this repository ten minutes ago. It contains a README.md and a LICENSE, nothing else — no Dockerfile, no workflows, no source code. Sync my shared agent rules into it. Paper exercise: describe exactly what happens, including what happens if I cancel at any prompt.",
+      "expected_output": "Detection matches nothing, and there is no existing managed block, so this is the bootstrap case. The skill does NOT finish with an empty run, does not write an empty managed block, and does not report that there is nothing to do. Instead it presents the full corpus catalog — every rule with its id, title, and a one-line gist — and asks the user to select which rules to write, supporting multiple selections plus select-all and cancel. This deliberate catalog is the documented exception to the silent-skip principle, not a violation of it. Whatever the user picks is written exactly as detected rules would be, and the result lands as a pull request. If the user cancels, nothing has been written yet because all filesystem edits are deferred to the final phase: the skill restores the original branch and deletes the sync branch it created, leaving no stray AGENTS.md and no leftover branch. The skill notes that a later run which detects nothing must still preserve these explicitly chosen rules.",
       "files": [],
       "expectations": [
         "Recognizes that nothing was detected and that no managed block exists yet (the bootstrap case)",
         "Offers the FULL corpus catalog for explicit user selection rather than reporting an empty result or writing nothing",
+        "Treats the catalog as the documented exception to silent-skip rather than suppressing it to obey that principle",
         "Supports selecting multiple rules, and allows cancelling without changes",
+        "On cancellation, leaves no stray AGENTS.md, no partial edit, and no leftover sync branch",
         "Writes the explicitly selected rules into the managed block in the same format as detected rules",
         "Does not fabricate detection matches to justify writing rules"
       ]
@@ -87,17 +93,19 @@
     {
       "id": 5,
       "name": "claude-md-only-target",
-      "prompt": "Sync the shared agent rules into this repository. Note that this repo has no AGENTS.md — it has a 200-line CLAUDE.md written by hand, and that CLAUDE.md does not reference or import AGENTS.md anywhere. Detection matches the container image rule and the GitHub Actions pinning rule. Paper exercise: what do you do about the target file?",
-      "expected_output": "The skill recognizes that silently creating a fresh AGENTS.md here would put the rules in a file no agent actually loads, since this CLAUDE.md does not import AGENTS.md. It does not guess. It asks the user to choose between: creating AGENTS.md and adding a one-line `@AGENTS.md` import to the existing CLAUDE.md (recommended, matching the convention); writing the managed block into CLAUDE.md instead; creating AGENTS.md only, with an explicit warning that nothing will load it until something imports it; or aborting. It creates no file other than AGENTS.md, and it only touches CLAUDE.md if the user explicitly picks an option that does so. It does not rewrite, reorganize, or reformat the rest of CLAUDE.md.",
+      "prompt": "Sync the shared agent rules into this repository. Note that this repo has no AGENTS.md — it has a 200-line CLAUDE.md written by hand, and that CLAUDE.md does not reference or import AGENTS.md anywhere. Detection matches the container image rule and the GitHub Actions pinning rule. Paper exercise: what do you do about the target file, and when exactly do you create it?",
+      "expected_output": "The skill recognizes that silently creating a fresh AGENTS.md here would put the rules in a file no agent actually loads, since this CLAUDE.md does not import AGENTS.md. It does not guess. It asks the user to choose between: targeting AGENTS.md and adding a one-line `@AGENTS.md` import to the existing CLAUDE.md (recommended, matching the convention); writing the managed block into CLAUDE.md instead; targeting AGENTS.md only, with an explicit warning that nothing will load it until something imports it; or aborting. Crucially the question only DECIDES the target — no file is created at that point. All writes happen in the final phase, so aborting leaves the repository untouched. It creates no file other than AGENTS.md, touches CLAUDE.md only if the user explicitly picks an option that does so, and does not rewrite, reorganize, or reformat the rest of CLAUDE.md. A newly created AGENTS.md begins with the BEGIN delimiter on line 1, with no leading blank line.",
       "files": [],
       "expectations": [
         "Detects that AGENTS.md is absent and that CLAUDE.md does not import it",
         "Does not silently create an AGENTS.md that nothing loads",
         "Asks the user to choose, offering at minimum the AGENTS.md-plus-import option and the write-into-CLAUDE.md option",
         "Marks the create-AGENTS.md-plus-import option as the recommended one (it matches the established convention)",
+        "Treats the answer as a decision about the target and defers the actual file creation to the write phase, so aborting leaves the repository untouched",
         "Touches CLAUDE.md only as a result of an explicit user selection, and then only to add the import line",
         "Creates no file in the repository other than AGENTS.md",
-        "Does not rewrite or reformat the existing hand-written CLAUDE.md content"
+        "Does not rewrite or reformat the existing hand-written CLAUDE.md content",
+        "A newly created AGENTS.md starts with the BEGIN delimiter at line 1 rather than a leading blank line"
       ]
     },
     {
@@ -118,18 +126,82 @@
     {
       "id": 7,
       "name": "no-clone-no-extra-files",
-      "prompt": "Sync the shared agent rules into this repository — it's a Python service with pyproject.toml, a Dockerfile, and GitHub Actions workflows. Paper exercise: list every file you create or modify anywhere, every git command you run, and where you put anything you download.",
-      "expected_output": "The skill runs in place inside the target repository. It never runs `git clone` — the target is the current working tree and the corpus is fetched over the API. The only repository file created or modified is AGENTS.md. No per-repository state file, config file, manifest, cache, or scratch file is created in the repository; the managed block itself is the state. The fetched corpus is written to a temporary location outside the working tree, or held in memory. Staging is explicit — only AGENTS.md is added, never `git add -A` or `git add .`. The work lands on its own branch (reusing an existing sync branch or pull request rather than opening a duplicate) with a pull request, never a direct commit to the default branch, and the skill does not merge the pull request itself.",
+      "prompt": "Sync the shared agent rules into this repository — it's a Python service with pyproject.toml, a Dockerfile, and GitHub Actions workflows. I'm currently on a feature branch called `feat/checkout-flow` with two of my own commits on it. Paper exercise: list every file you create or modify anywhere, every git command you run, and where you put anything you download.",
+      "expected_output": "The skill runs in place inside the target repository. It never runs `git clone` — the target is the current working tree and the corpus is fetched over the API. It runs `git fetch origin` and creates the sync branch from `origin/<default-branch>`, NOT from the current `feat/checkout-flow` HEAD, so the user's two unrelated commits do not end up in the pull request and the base is not stale. The only repository file created or modified is AGENTS.md. No per-repository state file, config file, manifest, cache, or scratch file is created in the repository; the managed block itself is the state. The fetched corpus is written to a temporary location outside the working tree, or held in memory. Staging is explicit — only AGENTS.md is added, never `git add -A` or `git add .`. The work lands on its own branch with a pull request, never a direct commit to the default branch, and the skill does not merge the pull request itself. Afterwards it restores `feat/checkout-flow`.",
       "files": [],
       "expectations": [
         "Runs no `git clone` — operates on the current working tree",
+        "Runs `git fetch origin` and bases the sync branch on `origin/<default-branch>`, not on the current feature branch HEAD",
+        "Explicitly avoids carrying the user's unrelated feature-branch commits into the pull request",
         "Creates or modifies no repository file other than AGENTS.md",
         "Creates no per-repository state, config, or cache file to track what was synced",
         "Keeps the fetched corpus outside the working tree (temp location or memory)",
         "Stages only AGENTS.md explicitly, avoiding `git add -A` / `git add .`",
         "Commits to a dedicated branch and opens a pull request instead of committing to the default branch",
-        "Reuses an existing sync branch or open pull request rather than opening a duplicate",
-        "Does not merge the pull request as part of the skill"
+        "Does not merge the pull request as part of the skill",
+        "Restores the branch the session started on when finishing"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "self-sync-guard",
+      "prompt": "Sync the shared agent rules into this repository. Note the working directory is a checkout of aoshimash/skills itself — the repo that holds the shared corpus. It has GitHub Actions workflows, so at least one rule would match. Paper exercise: describe what you do.",
+      "expected_output": "The skill checks the remote in its preconditions and recognizes that the target IS the corpus repository. Rules there are authored rather than distributed, and writing a managed block into its AGENTS.md would duplicate the corpus the repository ships and confuse the collection skill, which relies on the delimiters to know what to ignore. Rather than proceeding silently on the strength of the matching workflow files, it says so and asks the user whether to continue or stop, defaulting to stopping. If the user does not explicitly choose to continue, nothing is written, no branch is created, and no pull request is opened.",
+      "files": [],
+      "expectations": [
+        "Checks the git remote during preconditions and identifies the target as the aoshimash/skills corpus repository itself",
+        "Does not proceed silently just because a rule's detect patterns match",
+        "Explains why syncing into the corpus repository is problematic (the rules there are authored, and the block would duplicate the shipped corpus)",
+        "Asks the user whether to continue or stop, defaulting to stopping",
+        "Writes nothing, creates no branch, and opens no pull request unless the user explicitly chooses to continue"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "malformed-block-refusal",
+      "prompt": "Sync the shared agent rules into this repository. Its AGENTS.md is in a bad state after a botched merge: it contains a `<!-- BEGIN aoshimash-agent-rules -->` line but no matching END line anywhere, and below that point there are about 150 lines of hand-written repo-specific documentation. Detection matches two rules. Paper exercise: describe exactly what you do to AGENTS.md.",
+      "expected_output": "The skill validates the block before doing anything with it: it counts the lines that consist solely of the BEGIN delimiter and solely of the END delimiter, and requires either zero of each or exactly one of each with BEGIN before END. Here there is one BEGIN and no END, so the block is malformed. It STOPS and reports the problem, writing nothing at all. In particular it does NOT interpret the unterminated block as running to end of file, which would replace and destroy the 150 lines of hand-written documentation below it, and it does not attempt to repair the block by inserting a guessed END marker. It leaves the repository untouched for a human to fix, and would refuse the same way on a file containing two BEGIN/END pairs from a bad merge.",
+      "files": [],
+      "expectations": [
+        "Validates the delimiters before merging or writing, counting BEGIN and END occurrences",
+        "Requires the delimiter to be the entire line, so a prose mention of it is not miscounted",
+        "Identifies the single unterminated BEGIN as a malformed block",
+        "Stops and reports without writing anything to AGENTS.md",
+        "Does NOT treat the unterminated block as extending to end of file, which would destroy the hand-written content below it",
+        "Does not attempt to auto-repair the block by inserting a guessed END delimiter",
+        "Would refuse equivalently on duplicated BEGIN/END pairs"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "dirty-worktree-refusal",
+      "prompt": "Sync the shared agent rules into this repository. Heads up: I'm in the middle of editing AGENTS.md right now — I have uncommitted changes to it in my working tree, and I've also already staged a change to another file for a commit I'm about to make. Detection would match two rules. Paper exercise: what do you do?",
+      "expected_output": "The skill checks the working tree in its preconditions and finds that AGENTS.md is modified and that there is already staged content. It refuses to proceed and says which precondition failed. The reasoning is that the sync commit must contain only the sync: committing on top of the user's in-progress AGENTS.md edits would mix unrelated work into the pull request, and the user's uncommitted edits could be overwritten by the rendered block. It does not stash, commit, discard, or work around the user's changes on their behalf, and it does not create a branch or open a pull request. It tells the user to commit or stash their work and re-run.",
+      "files": [],
+      "expectations": [
+        "Checks the working tree state during preconditions (e.g. `git status --porcelain`)",
+        "Identifies both the modified AGENTS.md and the pre-staged change as blocking",
+        "Refuses to proceed and names the failed precondition",
+        "Does not stash, commit, or discard the user's uncommitted or staged changes",
+        "Does not overwrite the user's in-progress AGENTS.md edits with the rendered block",
+        "Creates no branch and opens no pull request",
+        "Tells the user how to unblock (commit or stash, then re-run)"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "reuse-existing-sync-pr",
+      "prompt": "Sync the shared agent rules into this repository. There is already an open pull request from a previous run on the branch `chore/sync-agent-rules`, and a reviewer hand-edited the managed block on that branch to fix a typo in one rule's wording. The default branch's AGENTS.md has no managed block at all. Since then I added a Dockerfile, so one more rule now matches. Paper exercise: which branch do you read, what do you write, and what happens to the reviewer's edit?",
+      "expected_output": "The skill fetches and checks out the existing `chore/sync-agent-rules` branch FIRST, fast-forwarding it to the remote, and only then reads, renders, compares and writes against that branch's AGENTS.md. Reading the default branch instead would see no block, conclude every rule is a fresh addition, and clobber the reviewer's work. Because the corpus is authoritative for managed entries, the reviewer's typo fix inside a managed rule body IS overwritten by the corpus text on refresh — the skill should be clear that a correction belongs in the corpus, not in the target repository. The newly detected container image rule is appended. The commit goes on top of the existing branch and the push updates the already-open pull request rather than opening a second one. If the push is rejected as non-fast-forward, the skill stops and reports rather than force-pushing; if the local branch had diverged and could not fast-forward, it stops in the branch-setup step instead.",
+      "files": [],
+      "expectations": [
+        "Fetches and checks out the existing sync branch before reading the target file, rather than reading the default branch's copy",
+        "Reads, renders, compares, and writes against one single branch's copy of the file",
+        "Recognizes that reading the default branch would treat existing entries as new additions",
+        "Appends the newly detected container image rule on top of the existing branch",
+        "Updates the already-open pull request instead of opening a second one",
+        "Does not force-push; stops and reports if the push is rejected as non-fast-forward",
+        "Stops rather than merging or rebasing if the local sync branch has diverged and cannot fast-forward"
       ]
     }
   ]

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
@@ -126,13 +126,15 @@
     {
       "id": 7,
       "name": "no-clone-no-extra-files",
-      "prompt": "Sync the shared agent rules into this repository — it's a Python service with pyproject.toml, a Dockerfile, and GitHub Actions workflows. I'm currently on a feature branch called `feat/checkout-flow` with two of my own commits on it. Paper exercise: list every file you create or modify anywhere, every git command you run, and where you put anything you download.",
-      "expected_output": "The skill runs in place inside the target repository. It never runs `git clone` — the target is the current working tree and the corpus is fetched over the API. It runs `git fetch origin` and creates the sync branch from `origin/<default-branch>`, NOT from the current `feat/checkout-flow` HEAD, so the user's two unrelated commits do not end up in the pull request and the base is not stale. The only repository file created or modified is AGENTS.md. No per-repository state file, config file, manifest, cache, or scratch file is created in the repository; the managed block itself is the state. The fetched corpus is written to a temporary location outside the working tree, or held in memory. Staging is explicit — only AGENTS.md is added, never `git add -A` or `git add .`. The work lands on its own branch with a pull request, never a direct commit to the default branch, and the skill does not merge the pull request itself. Afterwards it restores `feat/checkout-flow`.",
+      "prompt": "Sync the shared agent rules into this repository — it's a Python service with pyproject.toml, a Dockerfile, and GitHub Actions workflows. I'm currently on a feature branch called `feat/checkout-flow` with two of my own commits on it, and one of those commits is the one that added the Dockerfile — it does not exist on the default branch yet. Paper exercise: list every file you create or modify anywhere, every git command you run, where you put anything you download, and say which branch you inspect to decide which rules are relevant.",
+      "expected_output": "The skill runs in place inside the target repository. It never runs `git clone` — the target is the current working tree and the corpus is fetched over the API. It runs `git fetch origin` and creates the sync branch from `origin/<default-branch>`, NOT from the current `feat/checkout-flow` HEAD, so the user's two unrelated commits do not end up in the pull request and the base is not stale. Critically, detection runs AFTER that checkout and therefore inspects the sync branch, not the feature branch: the Dockerfile that exists only on `feat/checkout-flow` is NOT detected, and the container image rule is neither written nor cited as relevant, because the pull request's base does not contain that file. The only repository file created or modified is AGENTS.md. No per-repository state file, config file, manifest, cache, or scratch file is created in the repository; the managed block itself is the state. The fetched corpus is written to a temporary location outside the working tree, or held in memory. Staging is explicit — only AGENTS.md is added, never `git add -A` or `git add .`. The work lands on its own branch with a pull request, never a direct commit to the default branch, and the skill does not merge the pull request itself. Afterwards it restores `feat/checkout-flow`.",
       "files": [],
       "expectations": [
         "Runs no `git clone` — operates on the current working tree",
         "Runs `git fetch origin` and bases the sync branch on `origin/<default-branch>`, not on the current feature branch HEAD",
         "Explicitly avoids carrying the user's unrelated feature-branch commits into the pull request",
+        "Runs detection AFTER checking out the sync branch, so relevance reflects the pull request's base rather than the session's branch",
+        "Does not detect or write the container image rule, because the Dockerfile exists only on the feature branch and not on the sync branch's base",
         "Creates or modifies no repository file other than AGENTS.md",
         "Creates no per-repository state, config, or cache file to track what was synced",
         "Keeps the fetched corpus outside the working tree (temp location or memory)",
@@ -146,7 +148,7 @@
       "id": 8,
       "name": "self-sync-guard",
       "prompt": "Sync the shared agent rules into this repository. Note the working directory is a checkout of aoshimash/skills itself — the repo that holds the shared corpus. It has GitHub Actions workflows, so at least one rule would match. Paper exercise: describe what you do.",
-      "expected_output": "The skill checks the remote in its preconditions and recognizes that the target IS the corpus repository. Rules there are authored rather than distributed, and writing a managed block into its AGENTS.md would duplicate the corpus the repository ships and confuse the collection skill, which relies on the delimiters to know what to ignore. Rather than proceeding silently on the strength of the matching workflow files, it says so and asks the user whether to continue or stop, defaulting to stopping. If the user does not explicitly choose to continue, nothing is written, no branch is created, and no pull request is opened.",
+      "expected_output": "The skill checks the remote in its preconditions and recognizes that the target IS the corpus repository. Rules there are authored rather than distributed, and writing a managed block into its AGENTS.md would duplicate the corpus the repository ships. Rather than proceeding silently on the strength of the matching workflow files, it says so and asks the user whether to continue or stop, defaulting to stopping. If the user does not explicitly choose to continue, nothing is written, no branch is created, and no pull request is opened.",
       "files": [],
       "expectations": [
         "Checks the git remote during preconditions and identifies the target as the aoshimash/skills corpus repository itself",
@@ -202,6 +204,22 @@
         "Updates the already-open pull request instead of opening a second one",
         "Does not force-push; stops and reports if the push is rejected as non-fast-forward",
         "Stops rather than merging or rebasing if the local sync branch has diverged and cannot fast-forward"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "fenced-template-is-not-a-rule",
+      "prompt": "Sync the shared agent rules into this repository. It was created this morning and holds a README.md and a LICENSE, nothing else — no Dockerfile, no workflows, no source files, no config. Paper exercise: before you offer me anything, list every rule you parsed out of the corpus with its exact id, then show me exactly the catalog you would present. Be explicit about which `## rule:` lines in the corpus file are rules and which are not, and why.",
+      "expected_output": "The corpus file documents itself before it lists rules: a \"Contract\" section, a \"Format\" section, and a \"Rules\" heading. The Format section shows the rule template inside a fenced code block whose first line is literally `## rule: <id>`, followed by `**Title:** <heading text used in the target repository>`, `**Detect:** `<glob>`, `<glob>`, …`, and `**Rule:**`. That fenced line is NOT a rule, and the skill skips fenced regions when enumerating rather than matching `## rule:` line by line. It therefore parses exactly four rules — container-base-image, python-package-management, cli-version-management, github-actions-pinning — and no fifth phantom entry with the placeholder id `<id>`. It also skips the headings that are not `## rule:` headings at all. Because nothing is detected here and there is no existing managed block, this is the bootstrap case and the full catalog is offered for explicit selection; the catalog contains exactly those four real rules and does NOT offer a placeholder `<id>` / `<glob>` entry. That is where a missed fence becomes visible: a phantom entry would be selectable, and selecting it would write the template's placeholder text into the target repository as if it were a convention.",
+      "files": [],
+      "expectations": [
+        "Skips fenced code regions when enumerating corpus rules rather than matching `## rule:` line by line",
+        "Does NOT treat the `## rule: <id>` line inside the Format section's fenced template as a rule",
+        "Parses exactly four rules and names their real ids (container-base-image, python-package-management, cli-version-management, github-actions-pinning)",
+        "Skips the corpus's own non-rule sections (Contract, Format, Rules) as well",
+        "Offers no phantom catalog entry with the placeholder id `<id>` or the placeholder detect pattern `<glob>`",
+        "Presents the bootstrap catalog containing exactly the four real rules for explicit selection",
+        "Never writes the fenced template's placeholder text into the target repository"
       ]
     }
   ]

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json
@@ -1,0 +1,136 @@
+{
+  "skill_name": "sync-agent-rules",
+  "trigger_evals": [
+    { "query": "sync the shared agent rules into this repo's AGENTS.md", "should_trigger": true },
+    { "query": "apply my standard conventions to this repository — only the ones that actually apply here", "should_trigger": true },
+    { "query": "共通ルールをこのリポジトリに同期して", "should_trigger": true },
+    { "query": "AGENTS.md に共通の規約を反映して。使ってないツールのルールは入れなくていい", "should_trigger": true },
+    { "query": "add my usual project rules to AGENTS.md and open a PR", "should_trigger": true },
+    { "query": "この新しいリポジトリに標準のルールを入れたい", "should_trigger": true },
+    { "query": "distribute the shared conventions from aoshimash/skills into this repo", "should_trigger": true },
+    { "query": "エージェントルールを同期して、PR 作って", "should_trigger": true },
+    { "query": "pull down my shared rule set and write the relevant ones into AGENTS.md", "should_trigger": true },
+    { "query": "collect the hand-written rules from my other repos and add the good ones to the shared corpus", "should_trigger": false },
+    { "query": "add a rule to the shared corpus saying we always use go-task instead of Make", "should_trigger": false },
+    { "query": "write an AGENTS.md for this repo describing its architecture, directory layout, and test commands", "should_trigger": false },
+    { "query": "this repo's Dockerfile uses alpine — switch it to a debian slim base and rebuild", "should_trigger": false },
+    { "query": "sync my fork with upstream main and resolve the conflicts", "should_trigger": false },
+    { "query": "what conventions do I usually use for Python projects?", "should_trigger": false },
+    { "query": "create an issue to centralize our project conventions across repos", "should_trigger": false },
+    { "query": "review the dependency PRs on this repo and merge the safe ones", "should_trigger": false },
+    { "query": "analyze my recent sessions and propose improvements to my skills", "should_trigger": false },
+    { "query": "pin all the GitHub Actions in .github/workflows to commit SHAs", "should_trigger": false },
+    { "query": "respond to the review comments on PR #12", "should_trigger": false }
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "name": "detect-subset-silently",
+      "prompt": "Sync my shared agent rules into this repository's AGENTS.md. This is a Go service repo: it has a `Dockerfile`, `cmd/server/main.go`, `go.mod`, and `.github/workflows/ci.yml`. There are no Python files, no `pyproject.toml`, no `aqua.yaml`, and no `.tool-versions`. An `AGENTS.md` exists with a few repo-specific sections and no managed block yet. Do this as a paper exercise: describe exactly what you read, what you detect, what you write, and what you ask me. Do not actually push anything.",
+      "expected_output": "The skill fetches the rule corpus from aoshimash/skills over the GitHub API (not from its own bundled directory), runs detection against the repository's actual file list, and finds two rules relevant: the container image policy (Dockerfile) and the GitHub Actions pinning rule (.github/workflows/ci.yml). The Python package management and CLI tool version management rules do not match any pattern, so they are skipped SILENTLY — the skill does not write them, does not list them as options, and does not ask whether Python or aqua might be used later. The two detected rules are appended to AGENTS.md inside a managed block delimited by the BEGIN/END aoshimash-agent-rules HTML comments, each rule carrying its per-rule marker comment, with rule bodies copied verbatim from the corpus. The existing repo-specific sections of AGENTS.md are left untouched. The change lands on a branch as a pull request, not as a direct commit to the default branch.",
+      "files": [],
+      "expectations": [
+        "Fetches the corpus from the aoshimash/skills repository over the network rather than reading a copy bundled with the skill",
+        "Detects the container image rule from the Dockerfile and the GitHub Actions pinning rule from .github/workflows/ci.yml",
+        "Does NOT write the Python package management rule or the CLI tool version management rule",
+        "Does NOT prompt, ask, or offer options about the non-matching rules (silent skip, no forecasting of future tooling)",
+        "Writes the rules inside delimiters that identify the block as managed (BEGIN/END aoshimash-agent-rules), with a per-rule id marker for each rule",
+        "Copies each rule body verbatim from the corpus rather than rewording or summarizing it",
+        "Leaves the pre-existing repo-specific content of AGENTS.md unchanged",
+        "Delivers the change as a pull request on its own branch rather than committing to the default branch"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "idempotent-second-run",
+      "prompt": "Sync the shared agent rules into this repository again. I ran the same sync yesterday: AGENTS.md already contains the managed block with the container image rule and the GitHub Actions pinning rule, and nothing in the repository or the corpus has changed since. Paper exercise — tell me precisely what you do.",
+      "expected_output": "The skill fetches the corpus, re-runs detection, renders what the block should contain, and compares it against the file on disk. Because the rendered result is byte-identical to the current AGENTS.md, it makes no edit at all: no branch is created, no commit is made, no pull request is opened. It reports that the repository is already in sync, listing which rules are present and which were detected. It does not open an empty or no-op pull request, does not reorder or reformat the existing block, and does not treat the already-present rules as new additions.",
+      "files": [],
+      "expectations": [
+        "Renders the expected block and compares it against the current file before writing anything",
+        "Makes no change to AGENTS.md because the result is identical",
+        "Creates no branch, no commit, and no pull request on the second run",
+        "Reports that the repository is already in sync rather than claiming to have added rules",
+        "Does not reorder, reformat, or re-wrap the existing managed block (which would manufacture a spurious diff)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "additive-preserve-and-confirm-removal",
+      "prompt": "Sync the shared agent rules into this repository. The existing managed block in AGENTS.md currently contains three entries: (1) the Python package management rule — I added it explicitly months ago when this repo was empty, and the repo still has no Python files at all; (2) an entry marked with the rule id `legacy-changelog-policy`, which no longer exists in the shared corpus; (3) a paragraph I hand-wrote directly inside the block about our staging database, which has no rule id marker. Detection currently matches only the container image rule, which is not yet in the block. Paper exercise: what does the block look like afterwards, and what do you ask me?",
+      "expected_output": "Writes are additive. The Python package management rule is KEPT even though detection does not produce it — the skill does not remove it and does not ask about it, because a user may have placed it deliberately. The hand-written staging-database paragraph is kept verbatim in place, and mentioned in the pull request body as content inside the block that the skill does not manage. The `legacy-changelog-policy` entry is orphaned (its id is gone from the corpus), so the skill presents it for explicit confirmation — Keep (default) or Remove — and does not delete it unless the user explicitly chooses removal. The container image rule is appended. Nothing is removed automatically under any circumstance.",
+      "files": [],
+      "expectations": [
+        "Keeps the Python package management rule in the block despite detection not matching it",
+        "Does not prompt about the undetected-but-present Python rule — it is simply preserved",
+        "Preserves the hand-written unmarked paragraph inside the block verbatim rather than deleting or rewriting it",
+        "Identifies the `legacy-changelog-policy` entry as orphaned because its id is absent from the corpus",
+        "Presents the orphaned entry for explicit user confirmation before any removal, defaulting to keeping it",
+        "Never removes any entry automatically",
+        "Appends the newly detected container image rule"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "empty-repo-bootstrap",
+      "prompt": "I just created this repository ten minutes ago. It contains a README.md and a LICENSE, nothing else — no Dockerfile, no workflows, no source code. Sync my shared agent rules into it. Paper exercise: describe exactly what happens.",
+      "expected_output": "Detection matches nothing, and there is no existing managed block, so this is the bootstrap case. The skill does NOT finish with an empty run, does not write an empty managed block, and does not report that there is nothing to do. Instead it presents the full corpus catalog — every rule with its id, title, and a one-line gist — and asks the user to select which rules to write, supporting multiple selections plus select-all and cancel. Whatever the user picks is written exactly as detected rules would be, in the managed block, and the result lands as a pull request. The skill notes that a later run which detects nothing must still preserve these explicitly chosen rules.",
+      "files": [],
+      "expectations": [
+        "Recognizes that nothing was detected and that no managed block exists yet (the bootstrap case)",
+        "Offers the FULL corpus catalog for explicit user selection rather than reporting an empty result or writing nothing",
+        "Supports selecting multiple rules, and allows cancelling without changes",
+        "Writes the explicitly selected rules into the managed block in the same format as detected rules",
+        "Does not fabricate detection matches to justify writing rules"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "claude-md-only-target",
+      "prompt": "Sync the shared agent rules into this repository. Note that this repo has no AGENTS.md — it has a 200-line CLAUDE.md written by hand, and that CLAUDE.md does not reference or import AGENTS.md anywhere. Detection matches the container image rule and the GitHub Actions pinning rule. Paper exercise: what do you do about the target file?",
+      "expected_output": "The skill recognizes that silently creating a fresh AGENTS.md here would put the rules in a file no agent actually loads, since this CLAUDE.md does not import AGENTS.md. It does not guess. It asks the user to choose between: creating AGENTS.md and adding a one-line `@AGENTS.md` import to the existing CLAUDE.md (recommended, matching the convention); writing the managed block into CLAUDE.md instead; creating AGENTS.md only, with an explicit warning that nothing will load it until something imports it; or aborting. It creates no file other than AGENTS.md, and it only touches CLAUDE.md if the user explicitly picks an option that does so. It does not rewrite, reorganize, or reformat the rest of CLAUDE.md.",
+      "files": [],
+      "expectations": [
+        "Detects that AGENTS.md is absent and that CLAUDE.md does not import it",
+        "Does not silently create an AGENTS.md that nothing loads",
+        "Asks the user to choose, offering at minimum the AGENTS.md-plus-import option and the write-into-CLAUDE.md option",
+        "Marks the create-AGENTS.md-plus-import option as the recommended one (it matches the established convention)",
+        "Touches CLAUDE.md only as a result of an explicit user selection, and then only to add the import line",
+        "Creates no file in the repository other than AGENTS.md",
+        "Does not rewrite or reformat the existing hand-written CLAUDE.md content"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "corpus-is-authoritative",
+      "prompt": "Sync the shared agent rules into this repository. Two things to know: I edited the shared corpus in aoshimash/skills an hour ago — I corrected the wording of the container image rule and added a brand new rule — and the copy of this skill installed on my machine is from a release that predates both edits. This repo already carries the older container image rule in its managed block. Paper exercise: describe what you read and what ends up in AGENTS.md.",
+      "expected_output": "The skill reads the corpus from the aoshimash/skills repository over the network (e.g. `gh api .../contents/plugins/aoshimash-skills/rules/agent-rules.md` with the raw Accept header, or the raw.githubusercontent equivalent), explicitly NOT from its own installed directory, which is a version-pinned copy that predates the edits. Both the corrected container image wording and the brand new rule are therefore available immediately, with no plugin update required. The existing container image entry in the block is refreshed in place with the corrected corpus text — matched by rule id, not by comparing body text — which is how a corrected rule propagates to repositories that already carry it. The new rule is written only if its detect patterns match this repository. If the fetch fails, the skill stops and reports it rather than falling back to a bundled copy or reconstructing rule text from memory.",
+      "files": [],
+      "expectations": [
+        "Reads the corpus from the aoshimash/skills repository over the network, not from the skill's own installed directory",
+        "States or demonstrates that a stale installed copy of the skill does not limit which rules are available",
+        "Refreshes the existing container image entry in place with the corrected corpus wording",
+        "Matches existing entries by rule id rather than by comparing or fuzzy-matching body text",
+        "Writes the newly added corpus rule only if its detect patterns match this repository",
+        "On a failed fetch, stops and reports rather than falling back to a bundled copy or writing remembered rule text"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "no-clone-no-extra-files",
+      "prompt": "Sync the shared agent rules into this repository — it's a Python service with pyproject.toml, a Dockerfile, and GitHub Actions workflows. Paper exercise: list every file you create or modify anywhere, every git command you run, and where you put anything you download.",
+      "expected_output": "The skill runs in place inside the target repository. It never runs `git clone` — the target is the current working tree and the corpus is fetched over the API. The only repository file created or modified is AGENTS.md. No per-repository state file, config file, manifest, cache, or scratch file is created in the repository; the managed block itself is the state. The fetched corpus is written to a temporary location outside the working tree, or held in memory. Staging is explicit — only AGENTS.md is added, never `git add -A` or `git add .`. The work lands on its own branch (reusing an existing sync branch or pull request rather than opening a duplicate) with a pull request, never a direct commit to the default branch, and the skill does not merge the pull request itself.",
+      "files": [],
+      "expectations": [
+        "Runs no `git clone` — operates on the current working tree",
+        "Creates or modifies no repository file other than AGENTS.md",
+        "Creates no per-repository state, config, or cache file to track what was synced",
+        "Keeps the fetched corpus outside the working tree (temp location or memory)",
+        "Stages only AGENTS.md explicitly, avoiding `git add -A` / `git add .`",
+        "Commits to a dedicated branch and opens a pull request instead of committing to the default branch",
+        "Reuses an existing sync branch or open pull request rather than opening a duplicate",
+        "Does not merge the pull request as part of the skill"
+      ]
+    }
+  ]
+}

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
@@ -25,9 +25,9 @@ that should **not**. Full set in `evals.json` under `trigger_evals`.
 
 ### Should NOT trigger (near-misses)
 
-- **Collecting** rules from other repos into the corpus → that is the opposite
-  direction, `collect-agent-rules`. This is the sharpest near-miss: same
-  vocabulary, opposite data flow.
+- **Collecting** rules from other repos into the corpus → the opposite direction
+  (the future `collect-agent-rules` skill, issue #83, not yet implemented). This
+  is the sharpest near-miss: same vocabulary, opposite data flow.
 - **Editing the corpus** ("add a rule saying we use go-task not Make") → a
   normal edit to `aoshimash/skills`, not a distribution run.
 - **Authoring an `AGENTS.md`** describing this repo's architecture and test
@@ -52,7 +52,8 @@ need no live repository.
 
 **Cases 1–7 are success paths**; **cases 8–10 are guard/refusal paths** (the
 skill must decline and leave the repository untouched); **case 11** covers the
-re-run-against-an-open-PR path.
+re-run-against-an-open-PR path; **case 12** covers corpus parsing, where the
+corpus itself guarantees the tricky input is present on every run.
 
 ### Case 1: Detected subset, silent skip (`detect-subset-silently`)
 
@@ -159,14 +160,20 @@ carries the older container image rule.
 ### Case 7: No clone, no extra files (`no-clone-no-extra-files`)
 
 **Setup**: A Python service with `pyproject.toml`, a `Dockerfile`, and
-workflows. **The session is on a feature branch with two unrelated commits.**
-The prompt asks for every file touched and every git command run.
+workflows. **The session is on a feature branch with two unrelated commits**, and
+**one of them is the commit that added the `Dockerfile`** — that file does not
+exist on the default branch yet. The prompt asks for every file touched, every
+git command run, and which branch is inspected to decide relevance.
 
 **Expected behavior**:
 - **No `git clone`** — operates on the current working tree.
 - `git fetch origin`, then the sync branch is based on
   **`origin/<default-branch>`**, never on the current feature-branch HEAD, so the
   user's two commits stay out of the PR and the base is not stale.
+- **Detection runs *after* that checkout**, so relevance reflects the PR's base
+  rather than the session's branch: the `Dockerfile` that exists only on
+  `feat/checkout-flow` is **not** detected, and the container image rule is
+  neither written nor cited as relevant.
 - The only repository file created or modified is `AGENTS.md`.
 - **No per-repository state/config/cache file** — the managed block is the state.
 - Fetched corpus kept outside the working tree.
@@ -183,7 +190,7 @@ repository that holds the corpus. It has workflows, so a rule *would* match.
 - Identifies the target as the corpus repository during preconditions.
 - **Does not proceed silently** on the strength of the matching files.
 - Explains the problem (rules there are authored, not distributed; the block
-  would duplicate the shipped corpus and confuse `collect-agent-rules`).
+  would duplicate the corpus the repository ships).
 - Asks whether to continue or stop, **defaulting to stopping**.
 - Absent an explicit "continue": nothing written, no branch, no PR.
 
@@ -234,6 +241,28 @@ A newly added `Dockerfile` makes one more rule match.
 - **No force-push**: stops and reports on a non-fast-forward rejection, and stops
   in branch setup if the local branch diverged.
 
+### Case 12: The fenced template is not a rule (`fenced-template-is-not-a-rule`)
+
+**Setup**: A repository created this morning — `README.md` and `LICENSE` only, so
+nothing is detected and the bootstrap catalog is what gets shown. The prompt asks
+for every parsed rule id, the exact catalog, and which `## rule:` lines in the
+corpus are rules and which are not.
+
+**Expected behavior**:
+- **Fenced regions are skipped when enumerating rules.** The corpus's "Format"
+  section shows the rule template inside a fence whose first line is literally
+  `## rule: <id>`; matching `## rule:` line by line parses a fifth, phantom rule
+  with the placeholder id `<id>` and the placeholder detect pattern `<glob>`.
+- Exactly the four real rules are parsed, by id.
+- The corpus's own non-rule sections (Contract, Format, Rules) are skipped too.
+- **The catalog offers exactly those four rules** — no `<id>` entry. This is where
+  a missed fence stops being harmless: on the detected path the phantom matches
+  nothing, but a bootstrap catalog makes it *selectable*, and selecting it would
+  write the template's placeholder text into the repository as a convention.
+
+Unlike every other case, this one needs no special fixture: the corpus ships the
+fenced template, so **every** run of the skill exercises this path.
+
 ## Evaluation Log
 
 ### 2026-07-26 — Mechanism verification (issue #82, review fix round 1)
@@ -249,7 +278,7 @@ reading `SKILL.md` follows it.
 
 | # | Claim under test | Result |
 |---|---|---|
-| T1 | Per-pattern `git ls-files --cached --others --exclude-standard -- ':(glob)<p>'` detection (Phase 2) | **Pass** — on a Go+Docker fixture, `container-base-image` matched via `**/Dockerfile` and `github-actions-pinning` via `.github/workflows/*.yml`, while the Python and CLI-version rules matched nothing. Exactly case 1's expectation, and one invocation per pattern does reveal *which* pattern matched. |
+| T1 | Per-pattern `git ls-files --cached --others --exclude-standard -- ':(glob)<p>'` detection (Phase 3) | **Pass** — on a Go+Docker fixture, `container-base-image` matched via `**/Dockerfile` and `github-actions-pinning` via `.github/workflows/*.yml`, while the Python and CLI-version rules matched nothing. Exactly case 1's expectation, and one invocation per pattern does reveal *which* pattern matched. |
 | T2 | `.gitignore`d paths excluded | **Pass** — a planted `node_modules/Dockerfile` did not appear; only the root `Dockerfile` matched. |
 | T3 | Malformed-block validation by whole-line delimiter count (Phase 4 step 1) | **Pass** — well-formed 1/1; unterminated 1/0; doubled 2/2; a file mentioning both delimiters inline in prose counted 0/0, i.e. not miscounted. All four states are distinguishable, so case 9's refusal is implementable. |
 | T4 | Preamble strip → re-emit is idempotent (Phase 4 step 3) | **Pass** — three successive render→parse→render rounds were byte-identical, with the `## Shared Conventions` heading and the managed-by comment each appearing exactly once. |
@@ -257,17 +286,38 @@ reading `SKILL.md` follows it.
 | T6 | Case 3 survives the preamble strip | **Pass** — a hand-written paragraph above the first `###` was preserved verbatim while the preamble was still emitted exactly once. The strip is narrow (two known items only), not "everything before the first heading". |
 | T7 | Line-ending normalization (Phase 9) | **Pass** — an LF render compared byte-wise against a CRLF file differs, which would have produced a pull request on every run; comparing after normalizing to the file's own ending matches. |
 
-**Accepted deviation.** The 11 behavioral cases and 20 trigger cases in
-`evals.json` have **not** been benchmarked. Both need the eval harness (skill
-registration, repeated executor runs, independent grading) plus a with-skill vs
-baseline comparison to be meaningful, and neither is available here. They are
-authored and reviewed but unmeasured — treat the table above as evidence that
-the mechanisms work, not that the skill triggers or is followed reliably. Run
-the full benchmark before relying on any pass-rate claim, as
-`merge-renovate-prs` did on 2026-06-21.
+### 2026-07-26 — Mechanism verification (issue #82, review fix round 2)
+
+**What was run.** Same method and same limits as round 1: the *mechanical claims*
+added or changed in round 2 were executed directly — the fence-aware enumerator
+and delimiter counter, and the entry trim — against the real corpus file in this
+branch and against synthetic target files. Still not a skill-behavior benchmark.
+
+| # | Claim under test | Result |
+|---|---|---|
+| M1 | A `## rule:` line inside a fence is not a rule (Phase 1) | **Pass** — run against the actual corpus in this branch: a naive line-by-line match finds **5** `## rule:` lines, a fence-aware enumerator finds **4**. The one suppressed line is the Format section's template (`## rule: <id>`), and it is the corpus's only fenced `##` line. This is the input case 12 asserts, and it is present on **every** run. |
+| M2 | Trimming each parsed entry's blank lines reaches a fixed point (Phase 4 step 4) | **Pass** — with a foreign entry supplied carrying a trailing blank line, the untrimmed parser grew the block by exactly one line per render (17→18→19→20, no fixed point). With the trim, render 1 normalizes (17→16) and renders 2 and 3 are byte-identical at 16. Confirms the round-2 claim and that the failure it fixes was real. |
+| M3 | A body terminated at the next `##`-level heading, not just the next `## rule:` (Phase 1) | **Pass** — parsing the real corpus this way yields 4 bodies (13/8/11/12 lines) and **no body contains a markdown heading**, which is what the corpus format requires of a body copied into a target repository. |
+| M4 | Fence-aware whole-line delimiter counting (Phase 4 step 1) | **Pass** — real block 1/1; a target file that documents the mechanism inside a fence 0/0; that same file plus one real block 1/1 fence-aware but **2/2 counted naively**, i.e. naive counting would refuse a legitimate file as malformed. Round 1's four states still distinguishable: unterminated 1/0, doubled 2/2, prose mention 0/0. |
+| M5 | `evals.json` valid and schema-identical to `merge-renovate-prs` | **Pass** — parses as JSON; same top-level keys (`skill_name`, `trigger_evals`, `evals`); every eval carries exactly `id`/`name`/`prompt`/`expected_output`/`files`/`expectations`; every trigger eval exactly `query`/`should_trigger`; ids sequential 1–12. |
+
+### Accepted deviation (both rounds)
+
+The 12 behavioral cases and 20 trigger cases in `evals.json` have **not** been
+benchmarked. Both need the eval harness (skill registration, repeated executor
+runs, independent grading) plus a with-skill vs baseline comparison to be
+meaningful, and neither is available here. They are authored and reviewed but
+unmeasured — treat the tables above as evidence that the mechanisms work, not
+that the skill triggers or is followed reliably. Run the full benchmark before
+relying on any pass-rate claim, as `merge-renovate-prs` did on 2026-06-21.
+
+This applies to case 12 as well: the fence-skipping *mechanism* is verified
+against the real corpus (M1), but whether an agent reading `SKILL.md` actually
+skips the fence is exactly the unmeasured part.
 
 | Date | Case | Result | Notes |
 |------|------|--------|-------|
-| 2026-07-26 | T1–T7 mechanism checks | 7/7 pass | Executed against a scratch repo; the preamble defect was reproduced and the fix verified. |
+| 2026-07-26 | T1–T7 mechanism checks (round 1) | 7/7 pass | Executed against a scratch repo; the preamble defect was reproduced and the fix verified. |
+| 2026-07-26 | M1–M5 mechanism checks (round 2) | 5/5 pass | Executed against the real corpus file and synthetic target files; the untrimmed-entry growth defect was reproduced and the fix verified. |
 | 2026-07-26 | Trigger evals (20) | not run | Accepted deviation — harness unavailable. |
-| 2026-07-26 | Behavioral cases 1–11 | not run | Accepted deviation — harness unavailable. |
+| 2026-07-26 | Behavioral cases 1–12 | not run | Accepted deviation — harness unavailable. |

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
@@ -46,9 +46,13 @@ that should **not**. Full set in `evals.json` under `trigger_evals`.
 
 ## Behavioral Evals
 
-Each maps to an entry in `evals/evals.json` with objective expectations. All
-seven are paper exercises — they judge the discipline of the described approach,
-so they need no live repository.
+Each maps to an entry in `evals/evals.json` with objective expectations. All are
+paper exercises — they judge the discipline of the described approach, so they
+need no live repository.
+
+**Cases 1–7 are success paths**; **cases 8–10 are guard/refusal paths** (the
+skill must decline and leave the repository untouched); **case 11** covers the
+re-run-against-an-open-PR path.
 
 ### Case 1: Detected subset, silent skip (`detect-subset-silently`)
 
@@ -63,18 +67,23 @@ repo-specific sections and no managed block.
 - Python and CLI-version rules **not written and not mentioned** — no prompt, no
   option list, no question about future tooling.
 - Written inside the `BEGIN`/`END aoshimash-agent-rules` delimiters with a
-  per-rule id marker each; bodies copied verbatim.
-- Existing `AGENTS.md` content untouched; result is a pull request on a branch.
+  per-rule id marker each; bodies copied verbatim, **excluding** the `**Rule:**`
+  marker line.
+- Existing `AGENTS.md` content untouched; result is a pull request on a branch
+  based on the freshly fetched default branch.
 
 ### Case 2: Idempotent second run (`idempotent-second-run`)
 
-**Setup**: The same sync ran yesterday. Neither the repository nor the corpus
-has changed.
+**Setup**: The same sync ran yesterday and merged. Neither the repository nor the
+corpus has changed.
 
 **Expected behavior**:
 - Renders the expected block and **compares before writing**.
-- No edit, no branch, no commit, **no pull request**.
-- Reports "already in sync" rather than claiming additions.
+- **Strips the generated preamble** (the `## Shared Conventions` heading and the
+  managed-by comment) when parsing, instead of capturing it as content — see the
+  evaluation log below for why this specific step is load-bearing.
+- Compares in the **file's own line ending**, not assuming LF.
+- No edit, no commit, **no pull request**; reports "already in sync".
 - No reordering or re-wrapping that would manufacture a diff.
 
 ### Case 3: Additive, confirm before removal (`additive-preserve-and-confirm-removal`)
@@ -82,29 +91,35 @@ has changed.
 **Setup**: The block holds three entries — the Python rule the user added
 explicitly when the repo was empty (repo still has no Python), an entry with id
 `legacy-changelog-policy` that no longer exists in the corpus, and a
-hand-written paragraph inside the block with no id marker. Detection matches
-only the container image rule.
+hand-written paragraph inside the block, **above the first rule heading**, with
+no id marker. Detection matches only the container image rule.
 
 **Expected behavior**:
 - The undetected Python rule is **kept**, and **not** prompted about.
-- The unmarked hand-written paragraph is kept **verbatim, in place**, and
-  reported in the pull request body.
+- The unmarked hand-written paragraph is kept **verbatim, in place** — and
+  specifically is **not** swallowed by the preamble strip from case 2, even
+  though it precedes the first `###`. Only the two known generated items are
+  stripped.
 - `legacy-changelog-policy` is recognized as orphaned and **presented for
   explicit confirmation**, Keep as default.
 - Nothing is ever removed automatically.
-- The container image rule is appended.
+- The container image rule is appended; the foreign entry is reported in the PR
+  body.
 
 ### Case 4: Empty-repo bootstrap (`empty-repo-bootstrap`)
 
 **Setup**: A repository created ten minutes ago — `README.md` and `LICENSE`
-only.
+only. The prompt also asks what happens on cancellation.
 
 **Expected behavior**:
 - Nothing detected and no existing block → the bootstrap case.
 - **The full catalog is offered for explicit selection** (id, title, one-line
   gist), multi-select, with select-all and cancel — not an empty run, not an
-  empty block, not "nothing to do".
-- Selections are written exactly as detected rules would be.
+  empty block, not "nothing to do". This is the documented **exception** to the
+  silent-skip principle, not a violation of it.
+- **On cancellation, nothing is left behind** — no stray `AGENTS.md`, no partial
+  edit, no leftover sync branch — because all writes are deferred to the final
+  phase.
 - No fabricated detection matches.
 
 ### Case 5: `CLAUDE.md`-only target (`claude-md-only-target`)
@@ -114,11 +129,14 @@ import `AGENTS.md`. Two rules detected.
 
 **Expected behavior**:
 - Recognizes that a fresh `AGENTS.md` here would not be loaded by anything.
-- **Asks** rather than guessing: create `AGENTS.md` + add the `@AGENTS.md`
-  import to `CLAUDE.md` (recommended) / write into `CLAUDE.md` / create
-  `AGENTS.md` only with an explicit warning / abort.
+- **Asks** rather than guessing: target `AGENTS.md` + add the `@AGENTS.md`
+  import to `CLAUDE.md` (recommended) / write into `CLAUDE.md` / `AGENTS.md`
+  only with an explicit warning / abort.
+- The answer **only decides the target** — the file is created in the write
+  phase, so aborting leaves the repository untouched.
 - `CLAUDE.md` is touched only on an explicit selection, and only by one line.
 - No other file created; the existing `CLAUDE.md` content is not reformatted.
+- A newly created `AGENTS.md` starts with `<!-- BEGIN … -->` on line 1.
 
 This case is the one that exercises the documented no-`AGENTS.md` behavior.
 
@@ -141,19 +159,115 @@ carries the older container image rule.
 ### Case 7: No clone, no extra files (`no-clone-no-extra-files`)
 
 **Setup**: A Python service with `pyproject.toml`, a `Dockerfile`, and
-workflows. The prompt asks for every file touched and every git command run.
+workflows. **The session is on a feature branch with two unrelated commits.**
+The prompt asks for every file touched and every git command run.
 
 **Expected behavior**:
 - **No `git clone`** — operates on the current working tree.
+- `git fetch origin`, then the sync branch is based on
+  **`origin/<default-branch>`**, never on the current feature-branch HEAD, so the
+  user's two commits stay out of the PR and the base is not stale.
 - The only repository file created or modified is `AGENTS.md`.
 - **No per-repository state/config/cache file** — the managed block is the state.
 - Fetched corpus kept outside the working tree.
 - Staging is explicit (`git add AGENTS.md`), never `git add -A` / `git add .`.
-- Own branch + pull request, reusing an existing sync branch/PR instead of
-  duplicating; never a direct commit to the default branch; never self-merged.
+- Own branch + pull request; never a direct commit to the default branch; never
+  self-merged; the starting branch is restored at the end.
+
+### Case 8: Self-sync guard (`self-sync-guard`)
+
+**Setup**: The working directory is a checkout of `aoshimash/skills` itself — the
+repository that holds the corpus. It has workflows, so a rule *would* match.
+
+**Expected behavior**:
+- Identifies the target as the corpus repository during preconditions.
+- **Does not proceed silently** on the strength of the matching files.
+- Explains the problem (rules there are authored, not distributed; the block
+  would duplicate the shipped corpus and confuse `collect-agent-rules`).
+- Asks whether to continue or stop, **defaulting to stopping**.
+- Absent an explicit "continue": nothing written, no branch, no PR.
+
+### Case 9: Malformed block refusal (`malformed-block-refusal`)
+
+**Setup**: `AGENTS.md` has a `BEGIN` delimiter with **no matching `END`** after a
+botched merge, followed by ~150 lines of hand-written documentation. Two rules
+detected.
+
+**Expected behavior**:
+- **Validates the delimiters before merging or writing** — counts `BEGIN` and
+  `END`, requiring the delimiter to be the entire line so a prose mention is not
+  miscounted, and accepting only 0/0 or exactly 1/1 in order.
+- **Stops and reports, writing nothing.**
+- Critically, does **not** treat the unterminated block as extending to end of
+  file — that reading would destroy the 150 lines below it.
+- Does not auto-repair by inserting a guessed `END`.
+- Refuses equivalently on duplicated `BEGIN`/`END` pairs.
+
+### Case 10: Dirty worktree refusal (`dirty-worktree-refusal`)
+
+**Setup**: The user has uncommitted edits to `AGENTS.md` and an unrelated staged
+change.
+
+**Expected behavior**:
+- Checks the working tree in preconditions; identifies **both** the modified
+  `AGENTS.md` and the pre-staged change as blocking.
+- Refuses and names the failed precondition.
+- **Does not stash, commit, or discard** the user's work, and does not overwrite
+  the in-progress `AGENTS.md` with the rendered block.
+- No branch, no PR; tells the user to commit or stash and re-run.
+
+### Case 11: Re-run against an open sync PR (`reuse-existing-sync-pr`)
+
+**Setup**: An open PR already exists on `chore/sync-agent-rules`, where a
+reviewer hand-edited the managed block. The default branch has no block at all.
+A newly added `Dockerfile` makes one more rule match.
+
+**Expected behavior**:
+- **Fetches and checks out the existing sync branch first**, then reads, renders,
+  compares and writes against *that* branch's file — reading the default branch
+  would see no block, treat every entry as new, and clobber the reviewer's work.
+- Honest about the consequence: a reviewer's typo fix **inside a managed rule
+  body is overwritten** by the corpus text, because the corpus is authoritative
+  — corrections belong in the corpus.
+- Appends the newly detected rule; the push **updates the open PR** rather than
+  opening a second one.
+- **No force-push**: stops and reports on a non-fast-forward rejection, and stops
+  in branch setup if the local branch diverged.
 
 ## Evaluation Log
 
+### 2026-07-26 — Mechanism verification (issue #82, review fix round 1)
+
+**What was run.** Not a skill-behavior benchmark. The eval harness used for
+`merge-renovate-prs` (repeated executor runs per case × with-skill/baseline ×
+independent graders) was not available in this environment, so instead the
+*mechanical claims* the skill's instructions depend on were executed directly
+against a throwaway git repository and a reference implementation of the
+render/parse recipe. This checks that the procedure in `SKILL.md` is executable
+and produces the asserted result; it does **not** measure whether an agent
+reading `SKILL.md` follows it.
+
+| # | Claim under test | Result |
+|---|---|---|
+| T1 | Per-pattern `git ls-files --cached --others --exclude-standard -- ':(glob)<p>'` detection (Phase 2) | **Pass** — on a Go+Docker fixture, `container-base-image` matched via `**/Dockerfile` and `github-actions-pinning` via `.github/workflows/*.yml`, while the Python and CLI-version rules matched nothing. Exactly case 1's expectation, and one invocation per pattern does reveal *which* pattern matched. |
+| T2 | `.gitignore`d paths excluded | **Pass** — a planted `node_modules/Dockerfile` did not appear; only the root `Dockerfile` matched. |
+| T3 | Malformed-block validation by whole-line delimiter count (Phase 4 step 1) | **Pass** — well-formed 1/1; unterminated 1/0; doubled 2/2; a file mentioning both delimiters inline in prose counted 0/0, i.e. not miscounted. All four states are distinguishable, so case 9's refusal is implementable. |
+| T4 | Preamble strip → re-emit is idempotent (Phase 4 step 3) | **Pass** — three successive render→parse→render rounds were byte-identical, with the `## Shared Conventions` heading and the managed-by comment each appearing exactly once. |
+| T5 | The reviewed revision's preamble defect was real | **Confirmed** — with the strip disabled and a parser that (as case 3 requires) preserves content above the first `###` as a foreign entry, the run was **not** idempotent and the preamble accumulated to **3 copies after two runs**. The defect is invisible to a parser that discards pre-`###` content — but such a parser fails case 3, so the strip is load-bearing either way. |
+| T6 | Case 3 survives the preamble strip | **Pass** — a hand-written paragraph above the first `###` was preserved verbatim while the preamble was still emitted exactly once. The strip is narrow (two known items only), not "everything before the first heading". |
+| T7 | Line-ending normalization (Phase 9) | **Pass** — an LF render compared byte-wise against a CRLF file differs, which would have produced a pull request on every run; comparing after normalizing to the file's own ending matches. |
+
+**Accepted deviation.** The 11 behavioral cases and 20 trigger cases in
+`evals.json` have **not** been benchmarked. Both need the eval harness (skill
+registration, repeated executor runs, independent grading) plus a with-skill vs
+baseline comparison to be meaningful, and neither is available here. They are
+authored and reviewed but unmeasured — treat the table above as evidence that
+the mechanisms work, not that the skill triggers or is followed reliably. Run
+the full benchmark before relying on any pass-rate claim, as
+`merge-renovate-prs` did on 2026-06-21.
+
 | Date | Case | Result | Notes |
 |------|------|--------|-------|
-| — | — | not yet run | Cases authored with the skill (issue #82); no benchmark run yet. |
+| 2026-07-26 | T1–T7 mechanism checks | 7/7 pass | Executed against a scratch repo; the preamble defect was reproduced and the fix verified. |
+| 2026-07-26 | Trigger evals (20) | not run | Accepted deviation — harness unavailable. |
+| 2026-07-26 | Behavioral cases 1–11 | not run | Accepted deviation — harness unavailable. |

--- a/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/sync-agent-rules/references/eval-cases.md
@@ -1,0 +1,159 @@
+# Evaluation Test Cases
+
+Human-readable index of the eval scenarios. The runnable source of truth is
+[../evals/evals.json](../evals/evals.json); this file explains each case in
+prose. Two kinds: **trigger evals** (does the skill fire on the right
+phrasing?) and **behavioral evals** (does it do the right thing?).
+
+## Trigger Evals
+
+Phrases that **should** invoke `sync-agent-rules` (write the shared conventions
+into the current repository's `AGENTS.md`), and genuinely-tricky near-misses
+that should **not**. Full set in `evals.json` under `trigger_evals`.
+
+### Should trigger (EN + JA)
+
+- "sync the shared agent rules into this repo's AGENTS.md"
+- "apply my standard conventions to this repository — only the ones that actually apply here"
+- "共通ルールをこのリポジトリに同期して"
+- "AGENTS.md に共通の規約を反映して。使ってないツールのルールは入れなくていい"
+- "add my usual project rules to AGENTS.md and open a PR"
+- "この新しいリポジトリに標準のルールを入れたい"
+- "distribute the shared conventions from aoshimash/skills into this repo"
+- "エージェントルールを同期して、PR 作って"
+- "pull down my shared rule set and write the relevant ones into AGENTS.md"
+
+### Should NOT trigger (near-misses)
+
+- **Collecting** rules from other repos into the corpus → that is the opposite
+  direction, `collect-agent-rules`. This is the sharpest near-miss: same
+  vocabulary, opposite data flow.
+- **Editing the corpus** ("add a rule saying we use go-task not Make") → a
+  normal edit to `aoshimash/skills`, not a distribution run.
+- **Authoring an `AGENTS.md`** describing this repo's architecture and test
+  commands → writing project documentation, not syncing shared rules.
+- **Applying a rule to code** ("this Dockerfile uses alpine — switch it to
+  debian slim") → the skill writes rule *text*; it does not enforce rules.
+- **"sync my fork with upstream main"** → git branch sync; a trap on the word
+  "sync".
+- A **conceptual question** ("what conventions do I usually use for Python?") →
+  informational, no repository change.
+- **Creating an issue** about centralizing conventions → issue creation.
+- **Dependency PRs** / **session analysis** / **PR review comments** → other
+  skills.
+- **Pinning the actions in `.github/workflows` to SHAs** → doing the work a rule
+  describes, not distributing the rule.
+
+## Behavioral Evals
+
+Each maps to an entry in `evals/evals.json` with objective expectations. All
+seven are paper exercises — they judge the discipline of the described approach,
+so they need no live repository.
+
+### Case 1: Detected subset, silent skip (`detect-subset-silently`)
+
+**Setup**: A Go service repo — `Dockerfile`, `go.mod`, `.github/workflows/ci.yml`
+— with no Python files and no `aqua.yaml`. `AGENTS.md` exists with
+repo-specific sections and no managed block.
+
+**Expected behavior**:
+- Corpus fetched from `aoshimash/skills` over the API, not from the skill's own
+  directory.
+- Container image rule and GitHub Actions pinning rule detected and written.
+- Python and CLI-version rules **not written and not mentioned** — no prompt, no
+  option list, no question about future tooling.
+- Written inside the `BEGIN`/`END aoshimash-agent-rules` delimiters with a
+  per-rule id marker each; bodies copied verbatim.
+- Existing `AGENTS.md` content untouched; result is a pull request on a branch.
+
+### Case 2: Idempotent second run (`idempotent-second-run`)
+
+**Setup**: The same sync ran yesterday. Neither the repository nor the corpus
+has changed.
+
+**Expected behavior**:
+- Renders the expected block and **compares before writing**.
+- No edit, no branch, no commit, **no pull request**.
+- Reports "already in sync" rather than claiming additions.
+- No reordering or re-wrapping that would manufacture a diff.
+
+### Case 3: Additive, confirm before removal (`additive-preserve-and-confirm-removal`)
+
+**Setup**: The block holds three entries — the Python rule the user added
+explicitly when the repo was empty (repo still has no Python), an entry with id
+`legacy-changelog-policy` that no longer exists in the corpus, and a
+hand-written paragraph inside the block with no id marker. Detection matches
+only the container image rule.
+
+**Expected behavior**:
+- The undetected Python rule is **kept**, and **not** prompted about.
+- The unmarked hand-written paragraph is kept **verbatim, in place**, and
+  reported in the pull request body.
+- `legacy-changelog-policy` is recognized as orphaned and **presented for
+  explicit confirmation**, Keep as default.
+- Nothing is ever removed automatically.
+- The container image rule is appended.
+
+### Case 4: Empty-repo bootstrap (`empty-repo-bootstrap`)
+
+**Setup**: A repository created ten minutes ago — `README.md` and `LICENSE`
+only.
+
+**Expected behavior**:
+- Nothing detected and no existing block → the bootstrap case.
+- **The full catalog is offered for explicit selection** (id, title, one-line
+  gist), multi-select, with select-all and cancel — not an empty run, not an
+  empty block, not "nothing to do".
+- Selections are written exactly as detected rules would be.
+- No fabricated detection matches.
+
+### Case 5: `CLAUDE.md`-only target (`claude-md-only-target`)
+
+**Setup**: No `AGENTS.md`; a hand-written 200-line `CLAUDE.md` that does **not**
+import `AGENTS.md`. Two rules detected.
+
+**Expected behavior**:
+- Recognizes that a fresh `AGENTS.md` here would not be loaded by anything.
+- **Asks** rather than guessing: create `AGENTS.md` + add the `@AGENTS.md`
+  import to `CLAUDE.md` (recommended) / write into `CLAUDE.md` / create
+  `AGENTS.md` only with an explicit warning / abort.
+- `CLAUDE.md` is touched only on an explicit selection, and only by one line.
+- No other file created; the existing `CLAUDE.md` content is not reformatted.
+
+This case is the one that exercises the documented no-`AGENTS.md` behavior.
+
+### Case 6: The corpus is authoritative (`corpus-is-authoritative`)
+
+**Setup**: The corpus was edited an hour ago (one rule's wording corrected, one
+rule added); the installed copy of the skill predates both. The repo already
+carries the older container image rule.
+
+**Expected behavior**:
+- Reads the corpus over the network from `aoshimash/skills`, **not** from its own
+  installed directory — freshness is independent of plugin-update timing.
+- The existing entry is **refreshed in place** with the corrected text, matched
+  **by rule id**, never by comparing body text. This is the mechanism that
+  pushes a corrected rule out to repositories already carrying it.
+- The newly added rule is written only if its patterns match.
+- A failed fetch **stops the run** — no bundled fallback, no rule text written
+  from memory.
+
+### Case 7: No clone, no extra files (`no-clone-no-extra-files`)
+
+**Setup**: A Python service with `pyproject.toml`, a `Dockerfile`, and
+workflows. The prompt asks for every file touched and every git command run.
+
+**Expected behavior**:
+- **No `git clone`** — operates on the current working tree.
+- The only repository file created or modified is `AGENTS.md`.
+- **No per-repository state/config/cache file** — the managed block is the state.
+- Fetched corpus kept outside the working tree.
+- Staging is explicit (`git add AGENTS.md`), never `git add -A` / `git add .`.
+- Own branch + pull request, reusing an existing sync branch/PR instead of
+  duplicating; never a direct commit to the default branch; never self-merged.
+
+## Evaluation Log
+
+| Date | Case | Result | Notes |
+|------|------|--------|-------|
+| — | — | not yet run | Cases authored with the skill (issue #82); no benchmark run yet. |


### PR DESCRIPTION
## Summary

- Adds a `sync-agent-rules` skill that writes the shared personal conventions into the current repository's `AGENTS.md`, keeping only the rules whose tooling is actually present.
- Adds the shared rule corpus at `plugins/aoshimash-skills/rules/agent-rules.md`, seeded with the four conventions that motivated the initiative.
- Fixes the things #83 (`collect-agent-rules`) consumes: the corpus path, the rule format, the managed-block delimiters, and the generated block preamble.

Closes #82

## Changes

- **`plugins/aoshimash-skills/rules/agent-rules.md`** (new) — the corpus. A "Contract" section fixes the file path, the delimiters `<!-- BEGIN aoshimash-agent-rules -->` / `<!-- END aoshimash-agent-rules -->`, the generated preamble that sits immediately inside `BEGIN`, and the per-rule marker `<!-- rule: <id> -->`. A "Format" section specifies the rule shape: one `## rule: <id>` section with `**Title:**`, `**Detect:**` (comma-separated backticked globs), and `**Rule:**` followed by the body — which starts on the line *after* the marker and runs to the next `##`-level heading. Seeded with `container-base-image`, `python-package-management`, `cli-version-management`, `github-actions-pinning`.
- **`plugins/aoshimash-skills/skills/sync-agent-rules/SKILL.md`** (new, 496 lines) — 7 core principles, an Environment Adaptation section with the single capability the skill uses (user choice), the Contract table, and an 11-phase workflow: preconditions → fetch corpus over the GitHub API → establish branch → detect → read target → bootstrap → resolve target → merge → render → compare/stop-early → write/commit/PR → wrap-up.
- **`plugins/aoshimash-skills/skills/sync-agent-rules/evals/evals.json`** (new) — 20 trigger evals (9 positive EN+JA, 11 negatives) and 12 behavioral cases, in the `merge-renovate-prs` schema.
- **`references/eval-cases.md`** (new) — prose index, plus a dated evaluation log.
- **`README.md`** — skills-table row, `rules/` in the structure diagram, and a note on why the corpus sits outside every skill.
- **`AGENTS.md`** — architecture bullet for the corpus, pointing at its Contract/Format sections as authoritative.

## What a user will notice

Behaviours worth knowing before running this against a real repository:

- **The sync branch is `chore/sync-agent-rules`, based on `origin/<default-branch>` after a fetch** — never on whatever branch the session happens to be on. Running the skill mid-feature-work does not drag those commits into the PR.
- **Relevance is decided from the sync branch, not from your branch.** The branch is established *before* detection runs, so a file that exists only on your feature branch no longer triggers a rule. If you added a `Dockerfile` on `feat/x` and it is not on the default branch yet, the container image rule is not written and not cited as relevant — the PR's base does not contain that file. Merge the file first, then sync.
- **A re-run against an already-open sync PR reads that branch**, not the default branch, and the push updates the existing PR rather than opening a second one. Consequence: a hand edit a reviewer makes *inside a managed rule body* on that branch is overwritten on the next sync, because the corpus is authoritative. Corrections belong in the corpus.
- **A leftover local `chore/sync-agent-rules` with no open PR is recreated, not reused.** Reuse is keyed on an actually-open pull request (`gh pr list --head … --state open`), because nothing deletes the local branch when a PR merges. After a squash merge that stale branch's merge base is the pre-sync commit, so reusing it would make the next PR re-add the whole block and conflict with the already-merged version. The recreate refuses (rather than discarding) if the leftover branch holds commits absent from `origin/<default-branch>`.
- **A malformed managed block stops the run.** If `AGENTS.md` has a `BEGIN` with no `END`, or two pairs after a bad merge, the skill refuses and writes nothing rather than guessing the boundary — the naive reading would replace everything below the `BEGIN`. Delimiter counting now **skips fenced regions**, so a target file that documents this mechanism with a fenced example is neither mistaken for the real block nor miscounted into a spurious refusal.
- **A target resolved late is still validated and measured.** When the target is undecided until the `CLAUDE.md` question is answered, the chosen file gets the same treatment as one picked up front: block validated, line ending recorded, preamble stripped, entries parsed. Without that, an LF block would land in a CRLF `CLAUDE.md` (a purely cosmetic second PR on the next run), and a `CLAUDE.md` holding a stray unmatched `BEGIN` would get a second block appended instead of being refused.
- **Nothing is written until the final phase** — with one honest caveat. Cancelling the bootstrap catalog, or aborting the `CLAUDE.md` question, leaves no stray file. But git branch operations are not nothing: establishing the sync branch moves refs and can swap tracked files on disk. The wrap-up restores the starting position and deletes a branch this run created without committing to it.
- **Refusals**: an already-modified `AGENTS.md`/`CLAUDE.md` or pre-staged content blocks the run; a missing `origin` remote blocks it in preconditions rather than failing mid-run; a `git switch` that would clobber unrelated uncommitted files stops the run instead of stashing; the corpus repository itself is confirmed before proceeding, defaulting to stop; a rejected push stops rather than force-pushing.

## Design notes

Decisions came from #82 and #81; these are the ones I resolved by convention and that a reviewer may want to revisit:

- **Rule bodies are written in English.** The author's hand-written rules are mixed (Japanese in `shokutore-ai`, `yjlab-demo`; English in the newer `eln`, `optel-workout`, `nixos-config`, `gh-costbook`). English matches this repository and the newer `AGENTS.md` files.
- **Detection runs one `git ls-files --cached --others --exclude-standard -- ':(glob)<pattern>'` per pattern.** This honours `.gitignore` (so `node_modules/`, `.venv/` never match), still sees files added but not yet committed, needs no clone, and — one invocation per pattern — makes the *matched pattern* knowable for the PR body.
- **The managed block is rendered by a fixed byte-level recipe** and compared before writing, in the target file's own line ending, so a second run is a true no-op even on a CRLF checkout. Parsed entries are blank-line trimmed on the way in, because the renderer supplies the separators — otherwise a foreign entry's trailing blank line accumulates one line per run and the block never reaches a fixed point.
- **Fenced regions are skipped everywhere a marker is counted** — enumerating `## rule:` sections in the corpus, and counting block delimiters in a target file. The corpus ships its own rule template inside a fence, so this path is exercised on every single run.
- **Only the target file is staged by name** (never `git add -A`), which is the guard behind "creates no other file".
- **A `CLAUDE.md`-only target** is a user choice (target `AGENTS.md` + add the `@AGENTS.md` import / write into `CLAUDE.md` / `AGENTS.md` only with a warning / abort). Option 1 is recommended because all 4 repos that have both files use the `@AGENTS.md` stub pattern. This is the only case where a second file is touched, and only on explicit selection. If a previous run wrote into `CLAUDE.md`, the block's location records that decision and the question is not asked again — tested on the `BEGIN` line alone, so a stray unmatched `BEGIN` reaches the refusal path rather than being read as "no block".

## Assumptions for you to confirm

Wording was reused from your existing files where it exists; two rules needed judgement:

- **`github-actions-pinning` — wording is new.** No prose rule exists anywhere in your repos; the convention exists only as Renovate config (`helpers:pinGitHubActionDigests` in `nixos-config`, `site`, `optel-workout`, `homelab-k8s`, `shokutore-ai`; `pinDigests: true` in `AdGorillaTrack`, `site`). I wrote the rule to match what that config produces. Note this repo's own workflows use `actions/checkout@v4` and have no `renovate.json`, so it does not yet follow the rule it now ships.
- **`cli-version-management` — the exception clause is synthesized** from two of your own sources: the "aqua is the single source, no `.nvmrc`/`.terraform-version`" principle (`shokutore-ai`) and the deliberate `.node-version` exception (`yjlab-demo`). The combination is mine.
- `container-base-image` and `python-package-management` follow your existing rules closely (`shokutore-ai/CLAUDE.md` §14; `3d-models/CLAUDE.md`). The container rule keeps your example image tags (`golang:1.25-bookworm`, `gcr.io/distroless/static-debian12`) verbatim rather than genericizing them. The Python rule is scoped to package management and omits the `ruff format` / `ruff check --fix` clause that is bundled with it in `3d-models`, since linting is a separate category.

Facts verified against primary sources when the corpus was authored: `helpers:pinGitHubActionDigests` exists and is described as "Pin `github-action` digests" (docs.renovatebot.com/presets-helpers); aqua's config search covers `\.?aqua\.ya?ml` and `\.?aqua/aqua\.ya?ml` (aquaproj.github.io/docs/reference/config); the SHA-plus-version-comment format matches your actual workflows (`actions/checkout@de0fac2e... # v6.0.2`); all three corpus-fetch commands were run successfully against `aoshimash/skills`.

## Known, tracked deviation

- **`SKILL.md` is 496 lines.** Under `AGENTS.md`'s 500-line limit, but above this repo's usual pattern of a short `SKILL.md` plus `references/` files (`merge-renovate-prs` is 119 lines plus 5 reference files). Splitting the managed-block format machinery — the render recipe, the parse/validate steps, and the placement rules — into `references/block-format.md` is tracked as separate follow-up work and deliberately not done here, so this PR keeps a reviewable diff.

## Test Plan

No automated checks exist in this repository (markdown/JSON only, no pre-commit hooks configured). Verification was by inspection plus direct execution of the mechanisms the skill prescribes — recorded in full in the evaluation log in `references/eval-cases.md`.

Round 1 mechanism checks, executed against a scratch git repo (7/7 pass):

- [x] Per-pattern `git ls-files` detection picks exactly the expected two rules on a Go+Docker fixture and skips the other two
- [x] `.gitignore`d paths excluded (a planted `node_modules/Dockerfile` does not match)
- [x] Malformed-block validation distinguishes all four states (0/0, 1/1, unterminated 1/0, doubled 2/2) and does not miscount a prose mention of the delimiters
- [x] Preamble strip → re-emit is idempotent across three render/parse rounds, header emitted exactly once
- [x] The defect round 1 fixed was reproduced: without the strip, the preamble accumulated to 3 copies after two runs
- [x] A hand-written paragraph above the first rule heading survives the strip (the strip is narrow, not "everything before the first heading")
- [x] Line-ending normalization: an LF render vs a CRLF file differs byte-wise but matches after normalizing

Round 2 mechanism checks, executed against the real corpus file on this branch and synthetic target files (5/5 pass):

- [x] Fence-aware enumeration of the real corpus finds **4** rules where a naive line-by-line match finds **5** — the suppressed line is the Format section's `## rule: <id>` template, and it is the corpus's only fenced `##` line, so this path runs on every sync
- [x] The entry trim reaches a fixed point: untrimmed, the block grew exactly one line per render (17→18→19→20); trimmed, render 1 normalizes to 16 and renders 2–3 are byte-identical
- [x] Terminating a body at the next `##`-level heading yields 4 bodies from the real corpus and none of them contains a markdown heading, which is what the format requires of text copied into a target repository
- [x] Fence-aware delimiter counting: real block 1/1; a file documenting the mechanism in a fence 0/0; that file plus one real block 1/1 fence-aware but **2/2 naively**, i.e. naive counting would refuse a legitimate file as malformed
- [x] `evals.json` parses and is schema-identical to `merge-renovate-prs`: same top-level keys, same per-eval keys, same trigger keys, ids sequential 1–12

Verified by inspection:

- [x] Corpus holds all rules in one file, seeded with the four conventions; every rule carries an id and Detect patterns
- [x] Adding a rule needs no `SKILL.md` edit — no rule id, title, pattern, or body appears in `SKILL.md`; verified by grep
- [x] `SKILL.md` is 496 lines (< 500); frontmatter has `name` and a `description` with EN + JA trigger phrases
- [x] Environment Adaptation section instantiated from the `AGENTS.md` template with only the capability used (user choice)
- [x] Corpus read from `aoshimash/skills`, not the skill's own directory — all three commands verified live
- [x] `SKILL.md` states the no-`AGENTS.md` behaviour (all four variants) and eval case 5 exercises it
- [x] Every "Phase N" cross-reference in `SKILL.md` re-audited after the Phase 2/3 swap (53 mentions, 42 of them cross-references); 3 stale ones fixed — two pointing at the old detection phase for the branch state, and the wrap-up's restore step, whose Phase 0 step number shifted when the `origin`-remote precondition was inserted
- [x] `references/eval-cases.md` and `evals/evals.json` describe the same 12 cases with the same expectations; checked mechanically by case id, case name, and positive trigger query
- [x] `README.md` skills table has a row for the skill

Accepted deviation:

- [ ] The 12 behavioral cases and 20 trigger cases are **not** benchmarked — that needs the eval harness (skill registration, repeated executor runs, independent grading, with-skill vs baseline), which was unavailable here. Recorded as an explicit accepted deviation in the evaluation log rather than a bare "not yet run". This covers new case 12 too: the fence-skipping *mechanism* is verified against the real corpus, but whether an agent reading `SKILL.md` follows it is the unmeasured part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
