### PR TITLE
Restore push credentials in the version-bump workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Personal Claude Code skills collection",
-    "version": "1.3.1"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "aoshimash-skills",
       "description": "Collection of personal Claude Code skills by Shuji Aoshima",
       "source": "./plugins/aoshimash-skills",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "Shuji Aoshima"
       },

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -140,11 +140,23 @@ jobs:
 
       - name: Commit and push
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           LEVEL: ${{ steps.resolve.outputs.level }}
           REASON: ${{ steps.resolve.outputs.reason }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git diff --quiet .claude-plugin/marketplace.json && exit 0
+
+          # Restore this workflow's own credentials before touching the remote.
+          # "Classify bump level" runs claude-code-action, which unsets the
+          # http.<server>/.extraheader that actions/checkout persisted and
+          # repoints origin at its own GitHub App token. That token cannot push
+          # here, so without this the push fails with "Invalid username or
+          # token" after every other step has already succeeded. Fetching still
+          # works anonymously on a public repository, which is why only the push
+          # breaks.
+          git remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Every `Bump plugin version` run since 2026-07-23 has failed — including the one for #87. Five merges have lost their version bump as a result.

## Symptom

The workflow does all its work, then dies on the final `git push`:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/aoshimash/skills.git/'
```

## Cause

The `Classify bump level from diff` step runs `anthropics/claude-code-action@v1`. Its `configureGitAuth` ([`src/github/operations/git-config.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/git-config.ts)) unsets the credential `actions/checkout` persisted and repoints `origin` at its own GitHub App token. Straight from the run log for #87:

```
Configuring git authentication for non-signing mode
Setting git user as claude[bot]...
Removing existing git authentication headers...
✓ Removed existing authentication headers
Updating remote URL with authentication...
✓ Updated remote URL with authentication token
```

That app token cannot push here, so by the time `Commit and push` runs, this workflow's own `GITHUB_TOKEN` is gone.

Nothing in this repository caused it. `bump-version.yml` has been untouched since 81c82d5 (2026-07-20), the last run that succeeded; the action's behaviour changed underneath it. Two things made it quiet:

- it fails on the very last step, after the classification and the version edit have already succeeded, so the step summary looks healthy;
- `git pull --rebase` on the line above still works, because fetching a public repository needs no credentials — only the push breaks.

## Fix

Re-point `origin` at this workflow's own `GITHUB_TOKEN` immediately before the remote is touched. This holds for both branches of `configureGitAuth`: a URL-embedded token takes precedence over the `credential.helper` the action installs for non-write actors.

The token is passed through `env:`, not interpolated into the `run:` body.

## Version catch-up

| PR | Classified | Landed |
|---|---|---|
| #80 | minor | — |
| #84 | minor | — |
| #85 | minor | — |
| `claude/zealous-knuth-e79625` | minor | — |
| #87 | patch | — |

`main` is still on 1.3.1. There are no tags and no releases, so the version lives only in `marketplace.json` and the one fact it carries is "behaviour changed since 1.3.1" — a single minor bump to **1.4.0** records that, rather than replaying five bumps to 1.7.1 for releases that never existed.

Merging this PR will then trigger the repaired workflow, which classifies it `patch` (it touches no `plugins/` file) and lands **1.4.1**. That is also the check that the fix works: if `main` reaches 1.4.1 on its own, the push path is healthy again.