### PR TITLE
Rewrite implement-issue: autonomous Single mode with review-first PRs

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -1,34 +1,61 @@
 ---
 name: implement-issue
 description: >
-  Read platform issues (GitHub/GitLab/Backlog), analyze the codebase, plan,
-  implement, and open pull/merge requests with two-stage review (spec
-  compliance, then code quality). Implements a single issue interactively by
-  default; when given a parent issue, a milestone, a label, or a list of
-  issues, offers batch implementation with a dependency graph, git worktrees,
-  and parallel agent instances where the environment supports them (sequential
-  otherwise). Use when the user says "implement issue",
-  "issue を実装", "issue #N を対応", "この issue をやって", "implement #N",
-  "fix issue #N", "work on issue", "run sprint", "スプリント実行",
-  "これらの issue を実装", "implement these issues", "start the sprint",
-  "issue を順に実装して", "sprint を回して", or references issue numbers/URLs
-  with the intent to implement them.
+  Read platform issues (GitHub/GitLab/Backlog), analyze the codebase,
+  implement autonomously, and open review-first pull/merge requests: draft
+  PR with decisions logged in the body, two-stage review (spec compliance,
+  then code quality), a pre-push security review, and a flip to
+  ready-for-review once gates and CI pass. Implements a single issue end to
+  end with zero routine questions by default; when given a parent issue, a
+  milestone, a label, or a list of issues, offers batch implementation with
+  a dependency graph, git worktrees, and parallel agent instances where the
+  environment supports them (sequential otherwise). Use when the user says
+  "implement issue", "issue を実装", "issue #N を対応", "この issue をやって",
+  "implement #N", "fix issue #N", "work on issue", "run sprint",
+  "スプリント実行", "これらの issue を実装", "implement these issues",
+  "start the sprint", "issue を順に実装して", "sprint を回して", or references
+  issue numbers/URLs with the intent to implement them.
 ---
 
 # Implement Issue
 
-Read an issue (or a set of issues), plan the implementation, get approval, implement, and create PR(s)/MR(s) with two-stage review. **Single mode** (one issue, interactive) is the default. **Batch mode** (many issues, dependency-ordered, parallel where the environment supports it) is used for parent issues, milestones, labels, or explicit lists.
+Read an issue (or a set of issues), implement autonomously, and deliver
+review-first PR(s)/MR(s). **Single mode** (one issue) is the default and runs
+end to end without routine user interaction: decisions are resolved from the
+issue, its parent, repository agent instructions, or user-level configuration
+— and logged in the PR instead of asked. **Batch mode** (many issues,
+dependency-ordered, parallel where the environment supports it) is used for
+parent issues, milestones, labels, or explicit lists.
 
 ## Core Principles
 
-1. **Issues are the source of truth** — Scope to what each issue describes. Do not add unrelated changes. Do not deviate from acceptance criteria.
-2. **Plan before code** — In Single mode, always present an implementation plan and get user approval before writing code.
-3. **Small, reviewable changes** — Prefer focused PRs. If an issue is large, suggest splitting (see the create-issue skill's Split Proposal). If the user insists on a single PR, implement incrementally with clear scope per commit.
-4. **Follow project conventions** — Read CLAUDE.md and existing code patterns before implementing.
-5. **Two-stage review on every PR** — Spec compliance, then code quality, in both modes (see [references/review-gates.md](references/review-gates.md)). They catch different classes of problems; combining them into one review loses signal.
-6. **Dependency-driven parallelism** (Batch mode) — Issues with no unresolved dependencies can run in parallel where the environment supports it. The dependency graph is the scheduler; parallelism is an optimization on top of it, not a requirement (see [references/batch.md](references/batch.md)).
-7. **Worktree isolation** (Batch mode) — Each issue gets its own git worktree. No cross-contamination between parallel implementations.
-8. **Fail fast, report clearly** (Batch mode) — If an issue fails after retries, mark it blocked and continue with independent issues. Never block the entire batch on one failure.
+1. **Issues are the source of truth** — Scope to what each issue describes. Do
+   not add unrelated changes. Do not deviate from acceptance criteria.
+2. **Autonomous by default, decisions logged not asked** — There is no plan
+   approval gate and no location question. Settled decisions are followed;
+   local, reversible decisions are made by repository convention and logged in
+   the PR body (`Decisions & Deviations`). The only routine-flow stop is a
+   genuinely undecidable decision, asked as **one batched question** whose
+   answers are written back to the issue before implementation proceeds —
+   never ask twice.
+3. **Review-first PRs; machines finish before humans start** — The PR is
+   created as a **draft** and flipped to ready-for-review only after CI and
+   both review-gate stages pass. The body is ordered for the reviewer:
+   decisions and risk areas first, acceptance criteria mapped to verification
+   evidence, mechanical change lists last. Repository PR templates, when
+   present, take precedence as the skeleton.
+4. **Nothing unsafe leaves the machine** — A security review of the pending
+   changes runs after checks and self-review pass and **before the branch is
+   pushed**; unresolved Critical/High findings block the push.
+5. **Two-stage review on every PR** — Spec compliance, then code quality, in
+   both modes (see [references/review-gates.md](references/review-gates.md)).
+   They catch different classes of problems; combining them loses signal.
+6. **Small, reviewable changes** — Prefer focused PRs. If an issue is too
+   large for one, suggest splitting (see the create-issue skill); if it must
+   be one PR, implement incrementally with clear scope per commit.
+7. **Batch mode: the DAG is the scheduler** — Dependency-driven parallelism,
+   one worktree per issue, fail fast without blocking independent issues (see
+   [references/batch.md](references/batch.md)).
 
 ## Environment Adaptation
 
@@ -37,94 +64,112 @@ below use capability terms; map them to your environment as follows.
 
 | Capability | With native support (example) | Fallback |
 |---|---|---|
-| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
-| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body or reply comment the step produces) |
-| **Model selection** — run a separate agent instance on a chosen model | Per-instance model override (e.g. Claude Code's Task tool `model` parameter, or an agent definition's `model` frontmatter) | Run every instance on the session's default model — the workflow is unchanged, only the reviewer-stronger-than-implementer recommendation (see [references/review-gates.md](references/review-gates.md)) is unavailable |
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`, which can carry several questions in one round) | Numbered options as plain text; wait for the user's reply |
+| **Separate agent instance** — run a task in a fresh context that has not seen this conversation | Subagent dispatch (e.g. Claude Code's Task tool) | Run sequentially in the current context; for verification, mark the result `SELF-REVIEWED` in the artifact it lands in (e.g. the PR body) |
+| **Model selection** — run a separate agent instance on a chosen model | Per-instance model override (e.g. Claude Code's Task tool `model` parameter, or an agent definition's `model` frontmatter) | Run every instance on the session's default model — only the reviewer-stronger-than-implementer recommendation (see [references/review-gates.md](references/review-gates.md)) is unavailable |
+| **Security review** — security-focused review of the pending diff | Dedicated command (e.g. Claude Code's `/security-review`) | Review the diff yourself against the checklist in [references/workflow.md](references/workflow.md) step 2-6 |
 
 ## Phase 0: Setup and Mode Selection
 
-1. Detect the **issue tracker** platform (check CLAUDE.md `## Issue Tracker` → git remote → ask user). Note: the issue tracker and code hosting platform may differ (e.g., Backlog for issues + GitHub for PRs). Read the platform-specific guide:
+1. Detect the **issue tracker** platform (check the project's agent
+   instructions for an `## Issue Tracker` section → git remote → ask the user
+   only if neither identifies it). The issue tracker and code hosting platform
+   may differ (e.g. Backlog issues + GitHub PRs). Read the platform guide:
    - GitHub: [references/platform-github.md](references/platform-github.md)
    - GitLab: [references/platform-gitlab.md](references/platform-gitlab.md)
    - Backlog: [references/platform-backlog.md](references/platform-backlog.md)
-2. Obtain the issue identifier(s). If none are provided, list open issues from the platform (when supported) and ask the user to select.
+2. Obtain the issue identifier(s). If none are provided, list open issues from
+   the platform (when supported) and ask the user to select.
 3. **Mode routing:**
-   - **Multiple issues referenced** — a list of numbers, "these issues", a milestone, a label, or "run sprint" / "スプリント実行" phrasing → **Batch mode**. If the source is ambiguous, ask the user to choose (see Environment Adaptation): Parent issue / Milestone / Label / Manual list.
-   - **Single issue referenced** — fetch it, then **check whether it is a parent issue** with open sub-issues (GitHub: sub-issues API; GitLab: issue links/task list; Backlog: `--parent` search — see the platform guide's "Detect Sub-Issues / Child Items" section).
-     - If it has open sub-issues, ask the user to choose (see Environment Adaptation): "Issue #N has M open sub-issue(s). How do you want to proceed?" with options:
-       - **Implement all sub-issues (batch)** — mark "(Recommended)" when 2+ children are open. Proceeds to Batch mode with those sub-issues as the source set.
-       - **Implement only this issue** — treat #N itself as a normal single issue, ignore its children.
-       - **Pick one sub-issue** — list the children, let the user select one, continue in Single mode with that child.
-     - If it has no open sub-issues → **Single mode** on #N.
-4. **Single mode only** — check issue state: if the issue is already closed or merged:
-   - Inform the user: "Issue #N is already \<state\>."
-   - Ask the user to choose (see Environment Adaptation): "Reopen and implement" / "Pick another issue" / "Abort"
-   - If "Reopen and implement": reopen the issue, then continue. If "Pick another issue": return to step 2. If "Abort": stop.
+   - **Multiple issues referenced** — a list of numbers, "these issues", a
+     milestone, a label, or "run sprint" / "スプリント実行" phrasing →
+     **Batch mode**. If the source is ambiguous, ask the user to choose (see
+     Environment Adaptation): Parent issue / Milestone / Label / Manual list.
+   - **Single issue referenced** — fetch it, then **check whether it is a
+     parent issue** with open sub-issues (see the platform guide's sub-issue
+     detection section).
+     - If it has open sub-issues, ask the user to choose (see Environment
+       Adaptation): "Issue #N has M open sub-issue(s). How do you want to
+       proceed?" — **Implement all sub-issues (batch)** (mark "(Recommended)"
+       when 2+ children are open) / **Implement only this issue** / **Pick one
+       sub-issue** (list the children, continue in Single mode with the
+       selection). This is a scope decision, not a routine gate — it changes
+       what gets implemented.
+     - No open sub-issues → **Single mode** on #N.
+4. **Issue state check.** Single mode: if the issue is already closed or
+   merged, inform the user and ask (see Environment Adaptation): "Reopen and
+   implement" / "Pick another issue" / "Abort". Batch mode: closed issues in
+   the source set are filtered out silently; if all are closed, inform the
+   user and stop.
 
-   **Batch mode**: closed/merged issues in the source set are filtered out silently. If all issues are closed, inform the user and stop.
-5. **Single mode only** — ask the user where to implement (see Environment Adaptation) with numbered options:
-   - **Worktree** (default) — Create a git worktree for isolated work. Keeps current branch untouched.
-   - **New branch** — Create a new branch in the current working tree.
-   - **Current branch** — Work directly on the current branch (useful if already on a feature branch).
-
-   **Batch mode**: always uses a worktree per issue (see Batch Mode below) — do not ask.
+There is no implementation-location question: Single mode works in a git
+worktree by default, reusing one the host environment already prepared for
+this run when present (see [references/workflow.md](references/workflow.md)
+step 2-1). Batch mode always uses one worktree per issue.
 
 ## Single Mode
 
-The default mode: one issue, main agent executes directly, user present throughout.
+One issue, executed by the main agent in the **Direct** context of
+[references/workflow.md](references/workflow.md) — read that file and follow
+its phases end to end without pausing between them:
 
-### Phase 1: Plan
+1. **Understand and decide** — parse the issue, its parent, and any attached
+   research comment (re-verify only the delta against current code); analyze
+   the codebase; resolve decisions from the stores or by convention. Genuinely
+   undecidable decisions become one batched question; the answers are appended
+   to the issue's Design Decisions before any code is written.
+2. **Implement and verify** — worktree, implement, project checks (max 3
+   attempts), self-review (max 3 rounds, with a visible summary line),
+   security review **before any push** (Critical/High findings block the
+   push), commit.
+3. **PR and gates** — push, create a **draft** PR with the review-first body,
+   run Stage 1 and Stage 2 review gates, monitor CI, and flip the PR to ready
+   only when gates and CI all pass; otherwise it stays a draft with the
+   unresolved state recorded.
+4. **Recap** — report the PR URL and state, every decision made, every issue
+   write-back performed, the review-focus areas, and one line per gate.
 
-See [references/workflow.md](references/workflow.md) (Interactive columns) for the detailed procedure.
-
-**Summary:**
-1. Parse the issue — extract motivation, background, proposal, acceptance criteria.
-2. Analyze the codebase — identify files, patterns, dependencies relevant to the issue.
-3. Resolve design decisions — if multiple valid approaches exist, ask the user to choose (see Environment Adaptation) from numbered options with pros/cons and a recommendation. Wait for the user's choice.
-4. Draft implementation plan — list files to create/modify, approach for each, edge cases.
-5. Self-evaluate — verify plan addresses all acceptance criteria and stays in scope.
-6. Present the plan as text output, then ask the user to choose (see Environment Adaptation) for approval with options: Approve / Request changes / Abort. If the user requests changes, revise and re-present. Do not proceed without approval.
-
-**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — present the plan directly as text and collect approval via a user choice. Plan mode's approval UI can cause accidental rejections with no way to provide feedback.
-
-### Phase 2: Implement
-
-See [references/workflow.md](references/workflow.md) for the detailed procedure.
-
-**Summary:**
-1. Prepare working environment (worktree / new branch / current branch, per Phase 0 Step 5).
-2. Implement changes following the approved plan. Regenerate derived files if source files that drive code generation were modified.
-3. Run auto-fix commands (formatters, linters with `--fix`) once, then run project checks (tests, lint, type-check, build) — loop until all pass (max 3 attempts).
-4. AI self-review of the full diff — loop until clean (max 3 rounds). Escalate to the user (via a user choice, see Environment Adaptation) when human judgment is needed. After completion, output a visible self-review summary (e.g., "Self-review: N round(s), N issue(s) found, N fixed").
-5. Commit with a message referencing the issue (`Refs #N`).
-
-**Continuous flow**: After user approves the plan, proceed through Phase 2 and Phase 3 without stopping — do not pause between steps unless user input is needed (e.g., escalation).
-
-### Phase 3: Pull/Merge Request and Review Gates
-
-See [references/workflow.md](references/workflow.md) for the PR/MR body format and [references/review-gates.md](references/review-gates.md) for the review procedure.
-
-1. Detect the **code hosting** platform from the git remote URL (this may differ from the issue tracker).
-2. Push the branch and create a PR/MR (title under 70 chars; body with Closes #N / Relates to #N and a test plan).
-3. **Review gates**: run Stage 1 (spec compliance) then Stage 2 (code quality) against the PR diff. Fix findings and push; max 2 fix rounds per stage. If a stage still fails after 2 rounds, escalate to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon rather than silently marking anything — Stage 2.5 (pattern propagation) is always skipped in Single mode, since there are no other in-flight PRs to propagate a fix to.
-4. Monitor CI — run `gh pr checks --watch` (GitHub) or `glab mr checks` (GitLab) and verify all checks pass. If CI fails and is fixable, push a fix commit and re-monitor.
-5. If the issue tracker supports comments (e.g., Backlog), post a comment on the issue with the PR/MR link.
-6. Return the PR/MR URL to the user, along with a summary of the review gate results.
+Former mid-run stops (plan approval, location choice, per-decision questions,
+failing-check and self-review escalations) no longer exist: they either
+resolved into the batched question or complete with the concern recorded in
+the PR. **On Claude Code specifically:** plan mode is opt-in only — enter it
+solely when the user explicitly asks for a plan gate; never by default.
 
 ## Batch Mode
 
-Used for a parent issue's sub-issues, a milestone, a label, or a manual list of issues. See [references/batch.md](references/batch.md) for the full procedure.
+Used for a parent issue's sub-issues, a milestone, a label, or a manual list.
+See [references/batch.md](references/batch.md) for the full procedure.
 
 **Summary:**
 
-1. **Dependency graph** — collect dependencies from the platform's own relationship records (e.g. GitHub's `blockedBy` field) and, as a fallback, from `Blocked by` / `Depends on` / `After` declarations in each issue body; build a DAG from the union; detect cycles and ask the user how to resolve them; compute parallel execution groups (topological levels); visualize the plan; get approval via a user choice (see Environment Adaptation) with options Approve / Reorder / Abort.
-2. **Execution loop** — for each group, implement its issues, each in its own git worktree and executing [references/workflow.md](references/workflow.md) in **Autonomous mode** (see that file's Execution Modes table). Where the environment supports separate agent instances, dispatch one implementer per issue in parallel; otherwise implement them sequentially in dependency order in the current context (see [references/batch.md](references/batch.md)) — the DAG, review gates, and failure cascade are identical either way, only wall-clock parallelism differs. After each PR is created, the orchestrator runs the two-stage review gates ([references/review-gates.md](references/review-gates.md)), including **Stage 2.5 pattern propagation** across other in-flight PRs when a rule-violation is found. Update the DAG as issues complete; on failure, mark the issue `BLOCKED` and cascade `SKIPPED` to its transitive dependents, then continue with independent issues.
-3. **Summary** — present a status table (issue, title, status, PR) covering DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED / SKIPPED, explain any blockers, and optionally post a summary comment on the parent issue.
+1. **Dependency graph** — collect dependencies from the platform's own
+   relationship records (e.g. GitHub's `blockedBy` field) and, as a fallback,
+   from `Blocked by` / `Depends on` / `After` declarations in each issue body;
+   build a DAG from the union; detect cycles and ask the user how to resolve
+   them; compute parallel execution groups (topological levels); visualize the
+   plan; get approval via a user choice (see Environment Adaptation) with
+   options Approve / Reorder / Abort.
+2. **Execution loop** — for each group, implement its issues, each in its own
+   git worktree, executing [references/workflow.md](references/workflow.md) in
+   the **Orchestrated** context (see that file's Invocation Contexts). Where
+   the environment supports separate agent instances, dispatch one implementer
+   per issue in parallel; otherwise implement sequentially in dependency order
+   — the DAG, review gates, and failure cascade are identical either way.
+   After each draft PR is created, the orchestrator runs the two-stage review
+   gates ([references/review-gates.md](references/review-gates.md)), including
+   **Stage 2.5 pattern propagation** across other in-flight PRs when a
+   rule-violation is found, and flips the PR to ready when gates and CI pass.
+   Update the DAG as issues complete; on failure, mark the issue `BLOCKED`,
+   cascade `SKIPPED` to its transitive dependents, and continue with
+   independent issues.
+3. **Summary** — present a status table (issue, title, status, PR) covering
+   DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED / SKIPPED, explain any
+   blockers, and optionally post a summary comment on the parent issue.
 
 ## References
 
-- [references/workflow.md](references/workflow.md) — Canonical plan/implement/PR procedure, used by both Single mode (Interactive) and Batch mode's implementer agent instances (Autonomous)
-- [references/batch.md](references/batch.md) — Batch mode dependency graph, dependency-ordered dispatch (parallel where supported), and failure handling
+- [references/workflow.md](references/workflow.md) — Canonical autonomous pipeline (Direct context for Single mode, Orchestrated context for Batch implementers)
+- [references/batch.md](references/batch.md) — Batch mode dependency graph, dispatch, and failure handling
 - [references/review-gates.md](references/review-gates.md) — Two-stage review procedure (Stage 1 spec compliance, Stage 2 code quality, Stage 2.5 pattern propagation)
 - [references/platform-github.md](references/platform-github.md) — GitHub CLI commands
 - [references/platform-gitlab.md](references/platform-gitlab.md) — GitLab CLI commands

--- a/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
@@ -100,7 +100,7 @@ Run each issue's implementer with an instruction set that includes:
 1. The full issue body and issue number. When the batch source is a parent issue, also include the parent issue's body — its Background, Design Decisions, and Task Overview are shared context for every sub-issue.
 2. The absolute path to the worktree already created for it (step B2-1) — the implementer works there, it does not create its own.
 3. The absolute paths to this skill's [workflow.md](workflow.md) and the relevant `platform-*.md` guide, with the instruction:
-   > "Read these files, then execute workflow.md Phases 1–3 in the **Orchestrated context** inside the given worktree. Create the PR/MR as a draft and leave it a draft. Stop after monitoring CI (workflow.md step 3-3) — do not run the review gates or flip the PR to ready yourself, the orchestrator does both. Return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md step 3-6."
+   > "Read these files, then execute workflow.md Phases 1–3 in the **Orchestrated context** inside the given worktree. Create the PR/MR as a draft and leave it a draft. Skip the review gates (3-2) and the ready flip (3-4) — the orchestrator does both; do run CI monitoring (3-3) and the issue comment (3-5). Then return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md step 3-6."
 4. The project's CLAUDE.md path.
 
 Resolve the absolute paths to `workflow.md` and the platform guide before starting the implementer (they live alongside this file in the skill's `references/` directory) — do not rely on the implementer inferring them. When running as a separate agent instance, pass this as its dispatch prompt; when running in the current context, follow it directly.
@@ -146,6 +146,7 @@ After each issue completes (regardless of status):
   git worktree remove .worktrees/<branch-name>
   ```
 - If BLOCKED: keep the worktree for debugging. Inform the user of the path.
+- If NEEDS_CONTEXT: the implementer stopped before making changes — remove the worktree.
 
 ## Phase B3: Summary
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
@@ -2,7 +2,7 @@
 
 This procedure is used in **Batch Mode** (see SKILL.md) to implement a set of issues — from a parent issue's sub-issues, a milestone, a label, or a manual list — in dependency order (in parallel where the environment allows), with worktree isolation and two-stage review per issue.
 
-The per-issue implementation itself is NOT duplicated here: each issue is implemented by running [workflow.md](workflow.md) in **Autonomous mode** (see workflow.md's Execution Modes table). This file covers only the orchestration around that: building the dependency graph, running the implementer for each issue, running review gates, and handling failures.
+The per-issue implementation itself is NOT duplicated here: each issue is implemented by running [workflow.md](workflow.md) in the **Orchestrated context** (see workflow.md's Invocation Contexts). This file covers only the orchestration around that: building the dependency graph, running the implementer for each issue, running review gates, flipping each draft PR to ready, and handling failures.
 
 **Separate agent instances are an optimization, not a requirement.** Where the environment supports separate agent instances (see Environment Adaptation in SKILL.md), the orchestrator runs each issue's implementer and each review gate as its own instance, and dispatches an entire dependency group at once for wall-clock parallelism. Where it does not, the orchestrator runs the same steps sequentially in dependency order in the current context. The dependency DAG, review gates, and failure cascade below are identical either way — only wall-clock parallelism is lost in the sequential case.
 
@@ -100,7 +100,7 @@ Run each issue's implementer with an instruction set that includes:
 1. The full issue body and issue number. When the batch source is a parent issue, also include the parent issue's body — its Background, Design Decisions, and Task Overview are shared context for every sub-issue.
 2. The absolute path to the worktree already created for it (step B2-1) — the implementer works there, it does not create its own.
 3. The absolute paths to this skill's [workflow.md](workflow.md) and the relevant `platform-*.md` guide, with the instruction:
-   > "Read these files, then execute workflow.md Phases 1–3 in **Autonomous mode** inside the given worktree. Stop after creating the PR/MR and monitoring CI (workflow.md step 3-2) — do not run the review gates yourself, the orchestrator runs them. Return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md's Report Status step."
+   > "Read these files, then execute workflow.md Phases 1–3 in the **Orchestrated context** inside the given worktree. Create the PR/MR as a draft and leave it a draft. Stop after monitoring CI (workflow.md step 3-3) — do not run the review gates or flip the PR to ready yourself, the orchestrator does both. Return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md step 3-6."
 4. The project's CLAUDE.md path.
 
 Resolve the absolute paths to `workflow.md` and the platform guide before starting the implementer (they live alongside this file in the skill's `references/` directory) — do not rely on the implementer inferring them. When running as a separate agent instance, pass this as its dispatch prompt; when running in the current context, follow it directly.
@@ -115,6 +115,7 @@ After each issue's PR/MR is created (and the implementer has reported):
    Where the environment supports model selection, run reviewers on a model at least as capable as the implementer's — see review-gates.md "Reviewer model".
 3. Stage 2.5: **Pattern Propagation** — if a `rule-violation-instance` is found, scan other in-flight PRs for the same pattern and offer to propagate the fix (see [review-gates.md](review-gates.md)). This stage only runs in Batch mode, when 2+ issues are in flight.
 4. If issues are found at Stage 1 or 2 → re-run the implementer to fix → re-review (max 2 fix rounds per stage).
+5. **Flip draft to ready** — when both stages pass and the PR/MR's CI is green, mark it ready for review (see the platform guide). A PR whose gates or CI never passed stays a draft with the unresolved state recorded in its body, and the issue is reported `DONE_WITH_CONCERNS`.
 
 Run each reviewer as a separate agent instance with fresh context where the environment supports one; otherwise self-review and mark the gate result `SELF-REVIEWED` — see review-gates.md's "Reviewer Dispatch" note for the exact procedure and marker semantics.
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -279,7 +279,7 @@ fixes one AC miss.
 directly; Stage 2.5 not run; the recap's gate lines show the fix round; ready
 flip after gates and CI pass.
 
-**Criteria to test**: 12, 14, 15, 22
+**Criteria to test**: 12, 14, 15
 
 ### Case 24: Parent issue, user picks "only this issue"
 
@@ -583,8 +583,8 @@ see that skill's own evaluation log entry for the same date.
 
 Wholesale rewrite per the settled decisions in #91/#93: Single mode is now a
 single autonomous flow with zero routine interactions. Criteria and cases 1–24
-above were rewritten for the new flow; the entries below this one evaluate the
-pre-rewrite interactive skill and are historical.
+above were rewritten for the new flow; the log entries **above this one**
+evaluate the pre-rewrite interactive skill and are historical.
 
 Structural changes:
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -275,9 +275,10 @@ asked even though Single mode itself is autonomous.
 **Scenario**: A standalone issue implemented in Single mode; Stage 1 finds and
 fixes one AC miss.
 
-**Expected behavior**: main agent runs both gates itself, fixes and pushes
-directly; Stage 2.5 not run; the recap's gate lines show the fix round; ready
-flip after gates and CI pass.
+**Expected behavior**: the main agent is responsible for both gates
+(dispatching fresh-context reviewers where supported, per review-gates.md) and
+fixes and pushes directly; Stage 2.5 not run; the recap's gate lines show the
+fix round; ready flip after gates and CI pass.
 
 **Criteria to test**: 12, 14, 15
 
@@ -601,9 +602,9 @@ Structural changes:
   gains a **Security review** capability row; plan mode is opt-in only.
 - `review-gates.md`: Single-mode "ask the user" escalations replaced with
   record-in-PR + stay-draft; the flow diagram ends at the ready flip.
-- `batch.md`: implementer instruction updated (draft PR, stop after CI
-  monitoring at 3-3); the orchestrator now also flips PRs to ready (B2-3
-  step 5).
+- `batch.md`: implementer instruction updated (draft PR; run CI monitoring
+  (3-3) and the issue comment (3-5), skip the gates and the ready flip); the
+  orchestrator now also flips PRs to ready (B2-3 step 5).
 - Platform guides: verified draft/ready/write-back/comment commands added
   (`gh` verified locally on 2.x; `glab` flags verified against the official
   CLI docs; Backlog write-backs use the already-verified comment command

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -1,376 +1,294 @@
 # Evaluation Test Cases
 
+Cases 1–15 evaluate Single mode's autonomous flow (workflow.md, Direct
+context). Cases 16–21 evaluate Batch mode, 22–24 evaluate mode routing.
+
 ## Quality Criteria
 
 | # | Criterion | Pass Condition |
 |---|---|---|
-| 1 | Issue parsed correctly | All fields extracted (summary, motivation, proposal, acceptance criteria) |
-| 2 | Codebase analyzed | Related files, patterns, conventions, and existing branches identified |
-| 3 | Design decisions resolved | User consulted when multiple valid approaches exist, with options and recommendation |
-| 4 | Plan covers all criteria | Every acceptance criterion has a verification method |
-| 5 | Plan stays in scope | No changes unrelated to the issue |
-| 6 | Plan follows conventions | Consistent with CLAUDE.md and existing patterns |
-| 7 | User approval obtained | Plan presented and explicit approval received before coding |
-| 8 | Implementation location chosen | User asked to choose worktree (default) / new branch / current branch |
-| 9 | Branch naming correct | Follows `<type>/<issue-number>-<description>` convention |
-| 10 | Implementation matches plan | No unplanned changes, no scope creep |
-| 11 | Checks pass with loop | Project checks run and failures fixed in loop (max 3 attempts, then escalate) |
-| 12 | AI self-review completed | Diff reviewed, issues fixed in loop (max 3 rounds, then escalate) |
-| 13 | Human escalation works | User consulted when human judgment is needed, with options and recommendation |
-| 14 | PR/MR well-formed | Has summary, issue link, changes list, test plan |
-| 15 | Closed issue detected early | Closed/merged issues caught in Phase 0 with user options (reopen/pick another/abort) |
-| 16 | "Other" free-text respected | When user selects "Other" with free-text, their text is treated as the chosen approach without re-presenting new options |
-| 17 | Auto-fix runs before check loop | Auto-fix commands (formatters, linters with --fix) run once before the check loop when defined in CLAUDE.md |
-| 18 | Post-PR CI monitored | CI checks monitored after PR creation; fixable failures result in a fix commit before returning the PR URL |
-| 19 | Parent-issue confirmation asked | When a single referenced issue has open sub-issues, the user is asked to choose batch / this-issue-only / pick-one before proceeding |
-| 20 | Review gates run in Single mode | Stage 1 (spec compliance) then Stage 2 (code quality) run after PR creation even for a single issue; Stage 2.5 is skipped |
-| 21 | Batch dependency graph correct | Dependencies read from the platform's relationship records first and from issue bodies as fallback, unioned into a valid DAG; closed blockers excluded; cycles are surfaced to the user; parallel groups are computed correctly |
-| 22 | Batch failure cascade works | A BLOCKED issue causes its transitive dependents to be marked SKIPPED; independent issues continue |
-| 23 | Stage 2.5 pattern propagation offered | When a `rule-violation-instance` is found in Batch mode, other in-flight PRs are scanned and the user is offered a fix, without blocking the original issue |
+| 1 | Zero routine interactions | On a well-formed issue, no user question is asked between invocation and the recap |
+| 2 | Issue fully read | Body, parent context, and any attached research comment are read; with a research comment, only the delta is re-verified |
+| 3 | Settled decisions followed | Decisions recorded in the issue, its parent, repository agent instructions, or user-level config are followed without re-asking |
+| 4 | Local decisions logged | Unrecorded reversible decisions are made by repository convention and appear in the PR body's Decisions & Deviations |
+| 5 | Batched question + write-back | Genuinely undecidable decisions produce exactly one batched question; answers are appended to the issue's Design Decisions before implementation proceeds |
+| 6 | Worktree without asking | Implementation happens in a worktree by default (or one already prepared for the run); no location question |
+| 7 | Branch naming correct | `<type>/<issue-number>-<description>` convention |
+| 8 | Checks loop, then record | Auto-fix once, checks loop max 3 attempts; on persistent failure the run continues with the failure recorded in the PR (Direct) or reports BLOCKED (Orchestrated) |
+| 9 | Self-review visible, non-blocking | Diff reviewed max 3 rounds with a visible summary line; remaining concerns recorded in the PR, never escalated mid-run |
+| 10 | Security review gates the push | Security review runs after checks/self-review and before any push; unresolved Critical/High findings block the push; the outcome appears in the PR body |
+| 11 | Review-first draft PR | PR created as a draft; body leads with Decisions & Deviations and Risk Areas, maps each AC to evidence, puts mechanical change lists last; a repository PR template, when present, is the skeleton |
+| 12 | Review gates run | Stage 1 then Stage 2 on every PR; failures after max fix rounds are recorded and the PR stays a draft |
+| 13 | CI monitored | Checks watched after PR creation; fixable failures get a fix commit |
+| 14 | Ready only when done | Draft flips to ready only after both gates and CI pass; otherwise it stays a draft with the state recorded |
+| 15 | Recap complete | Recap reports PR URL and state, every decision made, every issue write-back, review-focus areas, and one line per gate |
+| 16 | Plan mode opt-in only | Plan mode entered only on explicit user request, never by default |
+| 17 | Closed issue detected early | Closed/merged issues caught in Phase 0 with user options (reopen / pick another / abort) |
+| 18 | Parent-issue routing asked | A single referenced issue with open sub-issues triggers the batch / this-issue-only / pick-one question |
+| 19 | Batch DAG correct | Platform relationship records and body declarations unioned; closed blockers excluded; cycles surfaced; parallel groups correct |
+| 20 | Batch failure cascade | BLOCKED issues cascade SKIPPED to transitive dependents; independent issues continue |
+| 21 | Stage 2.5 propagation offered | Rule violations in Batch mode trigger a scan of other in-flight PRs and an offer to propagate, without blocking the original issue |
+| 22 | Orchestrated statuses replace questions | The Orchestrated context never asks the user: NEEDS_CONTEXT / BLOCKED / DONE_WITH_CONCERNS statuses instead; the orchestrator runs the gates and performs the ready flip |
 
-## Single-Issue Test Cases
+## Single-Mode Test Cases
 
-### Case 1: Simple bug fix issue
+### Case 1: Well-formed issue, zero interactions
 
-**Scenario**: User says "implement issue #12" — issue describes a null pointer error in a specific function with clear reproduction steps and acceptance criteria.
+**Scenario**: "implement issue #12" — the issue has motivation, proposal, and
+binary acceptance criteria; all needed decisions are recorded or conventional.
 
-**Expected behavior**:
-- Ask implementation location (default: worktree)
-- Plan is concise (1 file change), no design decisions needed (skip step 1-3)
-- Fix is minimal and targeted
-- Checks and review pass quickly
-- PR references and closes the issue
-- Two-stage review gates run after PR creation (Stage 1 then Stage 2); Stage 2.5 is skipped since only one issue is in flight
+**Expected behavior**: no user question at any point. Worktree created without
+asking, implementation and verification run straight through, a draft PR with
+the review-first body appears, gates and CI pass, the PR flips to ready, and
+the recap reports PR/decisions/write-backs/focus/gates.
 
-**Criteria to test**: 1, 2, 4, 5, 8, 10, 11, 14, 20
+**Criteria to test**: 1, 2, 6, 7, 11, 12, 13, 14, 15
 
-### Case 2: Feature request with multiple valid approaches
+### Case 2: Decisions settled in the parent issue
 
-**Scenario**: User provides issue URL — issue requests a new API endpoint. Both REST and GraphQL are viable.
+**Scenario**: A sub-issue's parent records "use REST, not GraphQL" in its
+Design Decisions.
 
-**Expected behavior**:
-- Present REST vs GraphQL (or similar) as options with pros/cons and recommendation
-- Wait for user's choice before drafting plan
-- Plan lists all files (route, controller, model, migration, tests)
-- Checks loop runs; any test failures are fixed
-- AI review catches issues and fixes them
-- PR created after all checks and review pass
-- Two-stage review gates run after PR creation; Stage 2.5 is skipped
+**Expected behavior**: parent fetched in 1-1; REST followed without any
+question and without re-litigating; no entry needed in the PR's Decisions
+section for it (it is a settled decision, not an implementation-time one).
 
-**Criteria to test**: 3, 4, 6, 7, 10, 11, 12, 14, 20
+**Criteria to test**: 2, 3
 
-### Case 3: Issue with vague acceptance criteria
+### Case 3: Genuinely undecidable decision
 
-**Scenario**: User says "issue #45 を実装して" — issue has good motivation/proposal but acceptance criteria are vague ("it should work well").
+**Scenario**: The issue requires choosing between two storage schemas with
+materially different migration costs; no store records a preference and no
+convention points either way.
 
-**Expected behavior**:
-- Flag the vague criteria during planning
-- Propose 2-3 concrete, testable criteria for user approval
-- Do not proceed with implementation until criteria are clarified
+**Expected behavior**: exactly one batched question (this and any other
+undecidable points together), each with numbered options and a recommendation.
+Answers are appended to the issue's `## Design Decisions` via the platform
+write-back command **before** implementation starts; the recap lists the
+write-back.
 
-**Criteria to test**: 1, 4, 7
+**Criteria to test**: 1, 5, 15
 
-### Case 4: Large issue that should be split
+### Case 4: Vague acceptance criteria
 
-**Scenario**: Issue describes 3+ independent features bundled together.
+**Scenario**: "issue #45 を実装して" — good motivation/proposal, but AC says
+"it should work well".
 
-**Expected behavior**:
-- Recognize the issue is too large for a single PR
-- Suggest splitting into smaller issues/PRs
-- If user insists, implement incrementally with clear scope per commit
+**Expected behavior**: concrete binary criteria are derived from the
+motivation and proposal without asking; they appear in the PR's AC → Evidence
+section. Only if the intent itself is ambiguous does it join the batched
+question.
 
-**Criteria to test**: 5, 7, 10
+**Criteria to test**: 1, 2, 11
 
-### Case 5: Issue in GitLab project
+### Case 5: Checks still failing after 3 attempts
 
-**Scenario**: User says "implement issue #7" in a project with GitLab remote.
+**Scenario**: A test failure survives the auto-fix pass and 3 fix attempts.
 
-**Expected behavior**:
-- Detect GitLab platform from remote URL
-- Ask implementation location
-- Use `glab` CLI to read issue and create MR
-- MR format matches GitLab conventions
+**Expected behavior**: no user escalation. The failure and what was tried are
+recorded under Risk Areas; the run continues to the PR, CI fails, the PR stays
+a draft, and the recap flags it prominently.
 
-**Criteria to test**: 1, 8, 9, 14
+**Criteria to test**: 8, 14, 15
 
-### Case 6: Issue with existing partial implementation
+### Case 6: Self-review finds an ambiguous concern
 
-**Scenario**: User says "implement #30" — there's already a stale branch with partial work.
+**Scenario**: Self-review surfaces a business-rule edge the issue does not
+address, after the batched-question window has passed.
 
-**Expected behavior**:
-- Detect existing branch during codebase analysis
-- Ask user whether to build on existing branch or start fresh
-- Plan accounts for already-completed work if continuing
+**Expected behavior**: resolved by convention if one applies (logged under
+Decisions), otherwise recorded under Risk Areas for the reviewer; the visible
+`Self-review complete: …` line is printed; the run does not stop.
 
-**Criteria to test**: 2, 7, 10
+**Criteria to test**: 4, 9
 
-### Case 7: Tests fail repeatedly during implementation
+### Case 7: Security review finds a Critical issue before push
 
-**Scenario**: Implementation causes test failures that are hard to fix. After 3 attempts, tests still fail.
+**Scenario**: The pending diff contains a hard-coded credential.
 
-**Expected behavior**:
-- Attempt to fix failures up to 3 times
-- After 3 attempts, escalate to user with: which checks fail, what was tried, options (continue/skip/abandon)
-- Respect user's choice and proceed accordingly
+**Expected behavior**: the security review (run after checks and self-review,
+before any push) catches it; the finding is fixed and the review re-run before
+anything is pushed. If it cannot be resolved in 2 rounds, nothing is pushed
+and the run stops with a report. The review outcome appears in Gate Results.
 
-**Criteria to test**: 11, 13
+**Criteria to test**: 10
 
-### Case 8: AI review finds issue needing human judgment
+### Case 8: Review gate fails past its fix rounds
 
-**Scenario**: During AI self-review, a business logic ambiguity is discovered that the issue doesn't address.
+**Scenario**: Stage 2 keeps finding a Critical issue after 2 fix rounds.
 
-**Expected behavior**:
-- Present the ambiguity to user with 2-3 options and a recommendation
-- Wait for user's choice
-- Apply the fix based on user's decision
-- Re-run checks after fix
-- Continue review loop
+**Expected behavior**: the findings are recorded in Risk Areas and Gate
+Results, the PR remains a draft, and the recap's review-focus areas lead with
+them. No mid-run user question.
 
-**Criteria to test**: 12, 13
+**Criteria to test**: 12, 14, 15
 
-### Case 9: Backlog issue implementation
+### Case 9: CI catches what local checks missed
 
-**Scenario**: User says "PROJ-42 を実装して" in a project with Backlog configured as issue tracker and GitHub as code hosting.
+**Scenario**: Local checks pass; CI fails on a stricter rule.
 
-**Expected behavior**:
-- Detects Backlog as issue tracker from CLAUDE.md
-- Fetches issue via `bee issue view` using key `PROJ-42`
-- Updates issue status to "In Progress" on Backlog after plan approval (Phase 2, not Phase 0)
-- Detects GitHub as code hosting from git remote
-- Creates PR on GitHub (not Backlog)
-- Posts comment on Backlog issue with PR link
-- Continuous flow from Phase 2 to Phase 3 without stopping
+**Expected behavior**: failure investigated, fix commit pushed (max 1 round),
+CI re-watched; the ready flip happens only after CI is green.
 
-**Criteria to test**: 1, 2, 4, 5, 8, 9, 10, 14
+**Criteria to test**: 13, 14
 
-### Case 10: Cross-platform with issue listing
+### Case 10: Repository defines a PR template
 
-**Scenario**: User says "implement issue" without specifying an identifier, in a project with Backlog + GitHub setup.
+**Scenario**: The repository has `.github/PULL_REQUEST_TEMPLATE.md`.
 
-**Expected behavior**:
-- Lists open issues from Backlog
-- Presents the list and asks user to select one
-- After selection, proceeds with the normal implementation flow
-- Issue status updated to "In Progress" on Backlog
-- PR created on GitHub
-- Comment posted on Backlog issue with PR link
+**Expected behavior**: the template is the skeleton — its sections filled,
+review-first content mapped into semantically matching sections, unmatched
+sections appended after the template body. The recap still carries the
+decisions-first reading path.
 
-**Criteria to test**: 1, 2, 7, 8, 14
+**Criteria to test**: 11, 15
 
-### Case 11: Already-closed issue
+### Case 11: User explicitly asks for a plan gate
 
-**Scenario**: User says "implement issue #15" — issue #15 is already closed (e.g., fixed in a previous PR).
+**Scenario**: "issue #50 を実装して。まずプランをレビューさせて"
 
-**Expected behavior**:
-- Fetch the issue and detect that it is closed/merged in Phase 0 (before Phase 1)
-- Inform the user: "Issue #15 is already closed."
-- Present options via a user choice: "Reopen and implement" / "Pick another issue" / "Abort"
-- If "Reopen and implement": reopen the issue and proceed with normal flow
-- If "Pick another issue": return to issue selection
-- If "Abort": stop without entering Phase 1
+**Expected behavior**: the explicit request makes plan mode (or a plan
+presentation) opt-in for this run; without such a request, no plan is ever
+presented for approval.
 
-**Criteria to test**: 15
+**Criteria to test**: 16
 
-### Case 12: User selects "Other" with free-text in design decision
+### Case 12: Already-closed issue
 
-**Scenario**: During step 1-3, user is presented with 3 approach options (e.g., REST vs GraphQL vs gRPC) but selects "Other" and types "Use WebSocket for real-time updates".
+**Scenario**: "implement issue #15" — #15 is closed.
 
-**Expected behavior**:
-- Treat "Use WebSocket for real-time updates" as the chosen approach
-- Draft the plan using WebSocket — do NOT present new options like "WebSocket vs SSE vs long polling"
-- Only re-ask if the text is genuinely ambiguous (e.g., too vague to implement)
+**Expected behavior**: detected in Phase 0; the user chooses reopen / pick
+another / abort. This is an anomaly gate, not a routine interaction.
 
-**Criteria to test**: 3, 7, 16
+**Criteria to test**: 17
 
-### Case 13: User selects "Other" with free-text in plan approval
+### Case 13: Cross-platform (Backlog issues + GitHub PRs)
 
-**Scenario**: Plan is presented for approval. User selects "Other" and types "Looks good but use a factory pattern instead of direct instantiation in the service layer".
+**Scenario**: "PROJ-42 を実装して" with Backlog as tracker, GitHub as host.
 
-**Expected behavior**:
-- Treat the text as a specific change request
-- Revise the plan to use factory pattern in the service layer
-- Re-present the revised plan for approval — do NOT present new multiple-choice options about the factory pattern
-- Only re-ask if the feedback contradicts other requirements or is too vague
+**Expected behavior**: issue fetched via `bee`, status set to In Progress
+after decisions are resolved, draft PR created via `gh`, decision write-backs
+posted as Backlog comments, PR link commented on the issue, ready flip via
+`gh pr ready`.
 
-**Criteria to test**: 7, 16
+**Criteria to test**: 5, 11, 14, 15
 
-### Case 14: Auto-fix reduces check loop iterations
+### Case 14: Research comment attached
 
-**Scenario**: CLAUDE.md defines a format auto-fix command (e.g., `prettier --write .`). Generated code has formatting violations that would fail the strict format check.
+**Scenario**: The issue's parent carries a research comment from the
+create-issue Design Flow, dated three weeks ago.
 
-**Expected behavior**:
-- Before entering the check loop, run the auto-fix command once
-- Strict format check now passes on the first loop attempt instead of requiring a manual fix cycle
-- Check loop completes in 1 attempt instead of 2-3
+**Expected behavior**: the comment is read first; only the delta since its
+date is re-verified against the current code instead of re-researching from
+scratch.
 
-**Criteria to test**: 11, 17
+**Criteria to test**: 2
 
-### Case 15: Post-PR CI monitoring catches a fixable failure
+### Case 15: GitLab project
 
-**Scenario**: All local checks pass. PR is created. CI fails due to a check that wasn't run locally (e.g., an integration test or a stricter linting rule enabled only in CI).
+**Scenario**: "implement issue #7" in a GitLab-hosted project.
 
-**Expected behavior**:
-- After PR creation, run `gh pr checks --watch` (GitHub) or `glab mr checks` (GitLab)
-- Detect the CI failure and investigate
-- If fixable: push a fix commit and re-monitor CI until it passes
-- Return the PR URL only after CI is green (or note the failure if not fixable)
+**Expected behavior**: platform detected from the remote; draft MR created
+with `glab mr create --draft`; ready flip with `glab mr update --ready`;
+write-backs via `glab issue update --description`.
 
-**Criteria to test**: 14, 18
+**Criteria to test**: 6, 11, 14
 
 ## Batch Mode Test Cases
 
 ### Case 16: Simple linear batch
 
-**Input:** Parent issue #100 with 3 sub-issues (#101 → #102 → #103, linear dependencies)
+**Input:** Parent issue #100 with 3 sub-issues (#101 → #102 → #103, linear).
 
-**Expected behavior:**
-1. Fetches sub-issues of #100
-2. Builds DAG: #101 → #102 → #103
-3. Executes sequentially: #101 first, then #102, then #103
-4. Each issue gets its own worktree
-5. Two-stage review after each
-6. Summary shows all 3 completed with PR links
+**Expected behavior**: DAG built from platform records ∪ body declarations;
+issues executed in order, each in its own worktree, each producing a draft PR;
+the orchestrator runs both gates per issue and flips each PR to ready when its
+gates and CI pass; summary table accurate.
 
-**Verification:**
-- [ ] Correct dependency graph displayed
-- [ ] Issues executed in correct order
-- [ ] Each PR references the correct issue
-- [ ] Two-stage review ran for each issue
-- [ ] Worktrees cleaned up after completion
-- [ ] Summary table accurate
+**Criteria to test**: 19, 22
 
 ### Case 17: Parallel batch
 
-**Input:** Parent issue #200 with 4 sub-issues:
-- #201 (no deps), #202 (no deps) — parallel
-- #203 (depends on #201), #204 (depends on #202) — parallel after their deps
+**Input:** 4 sub-issues: #201, #202 independent; #203 ← #201, #204 ← #202.
 
-**Expected behavior:**
-1. Builds DAG with 2 groups: {#201, #202} then {#203, #204}
-2. Group 1: #201 and #202 dispatched in parallel (separate worktrees)
-3. Group 2: #203 and #204 dispatched in parallel after Group 1 completes
-4. All 4 PRs created
+**Expected behavior**: two groups; group members dispatched in parallel where
+separate agent instances exist, sequentially otherwise; no worktree conflicts;
+identical DAG semantics either way.
 
-**Verification:**
-- [ ] #201 and #202 run in parallel (concurrent agent instances, where the environment supports them)
-- [ ] #203 waits for #201 to complete
-- [ ] #204 waits for #202 to complete
-- [ ] No worktree conflicts between parallel issues
+**Criteria to test**: 19, 22
 
 ### Case 18: Failure cascading
 
-**Input:** 4 issues: #301 (no deps), #302 (depends on #301), #303 (depends on #302), #304 (no deps)
+**Input:** #301 fails its checks after 3 attempts; #302 ← #301, #303 ← #302,
+#304 independent.
 
-**Scenario:** #301 fails (tests don't pass after 3 attempts)
+**Expected behavior**: #301 reports BLOCKED (no user question), #302/#303
+marked SKIPPED, #304 completes; batch continues; blocked worktree kept for
+debugging.
 
-**Expected behavior:**
-1. #301 and #304 start in parallel
-2. #301 fails → marked BLOCKED
-3. #302 marked SKIPPED (depends on #301)
-4. #303 marked SKIPPED (transitively depends on #301)
-5. #304 continues and completes normally
-6. Summary shows: 1 done, 1 blocked, 2 skipped
+**Criteria to test**: 8, 20, 22
 
-**Verification:**
-- [ ] Batch does NOT stop when #301 fails
-- [ ] #304 completes independently
-- [ ] Transitive dependencies correctly identified
-- [ ] Failed worktree kept for debugging
-- [ ] Summary accurately reflects all statuses
+### Case 19: Spec-compliance catch in batch
 
-### Case 19: Two-stage review catches issues (batch)
+**Input:** #401's AC requires pagination; the implementation omits it.
 
-**Input:** Issue #401 with clear AC: "search returns paginated results"
+**Expected behavior**: Stage 1 FAIL → implementer re-invoked → fix pushed →
+re-review PASS → Stage 2 runs → PR flipped to ready only after both stages and
+CI pass.
 
-**Scenario:** Implementation doesn't include pagination
+**Criteria to test**: 12, 14, 22
 
-**Expected behavior:**
-1. Issue implemented without pagination
-2. Spec compliance review (Stage 1): FAIL — AC "paginated results" not met
-3. Implementer fixes: adds pagination
-4. Re-review: PASS
-5. Code quality review (Stage 2): runs on updated code
-6. Final status: DONE (after fix round)
+### Case 20: Manual issue list
 
-**Verification:**
-- [ ] Spec compliance correctly identifies missing AC
-- [ ] Fix round addresses the issue
-- [ ] Code quality review runs after spec compliance passes
-- [ ] Status reflects the fix round in summary
+**Input:** "implement these issues #501, #502, #503" (no parent).
 
-### Case 20: Manual issue list (batch)
-
-**Input:** User provides "implement these issues #501, #502, #503" (no parent issue)
-
-**Expected behavior:**
-1. Fetches all 3 issues individually
-2. Parses dependencies from issue bodies
-3. Builds DAG from parsed dependencies
-4. Executes normally in Batch mode
-
-**Verification:**
-- [ ] Works without a parent issue
-- [ ] Dependencies parsed from issue body text
-- [ ] Same workflow as parent-based batch
-
-### Case 21: Cross-platform batch (Backlog issues + GitHub PRs)
-
-**Input:** Backlog project issues, code hosted on GitHub
-
-**Expected behavior:**
-1. Detects Backlog as issue tracker
-2. Fetches issues with `bee`
-3. Detects GitHub as code hosting from git remote
-4. Creates PRs with `gh`
-5. Comments on Backlog issues with PR links
-
-**Verification:**
-- [ ] Correct platform detection for both issue tracker and code hosting
-- [ ] Uses `bee` for issue operations
-- [ ] Uses `gh` for PR operations
-- [ ] Backlog issue gets comment with GitHub PR link
-
-## Mode-Routing Test Cases (new)
-
-### Case 22: Parent detection on plain "implement issue #N"
-
-**Scenario**: User says "implement issue #40" — #40 has 3 open sub-issues (#41, #42, #43) and no unresolved dependencies among them.
-
-**Expected behavior**:
-- Phase 0 detects that #40 has open sub-issues (via the platform guide's sub-issue/child detection)
-- Presents a user choice: "Implement all sub-issues (batch)" (Recommended, since 2+ children are open) / "Implement only this issue" / "Pick one sub-issue"
-- If the user picks batch: proceeds to Batch mode (Phase B1 dependency graph) using #41-#43 as the source set
-- If the user picks "only this issue": treats #40 as a normal single issue, does not touch #41-#43
-- If the user picks "pick one": lists #41-#43 and continues in Single mode with the selected child
-
-**Criteria to test**: 19, 21
-
-### Case 23: Single-mode spec-compliance catch
-
-**Scenario**: User says "implement issue #55" (a single, standalone issue with clear AC including "response is paginated"). Implementation is drafted without pagination.
-
-**Expected behavior**:
-- PR is created
-- Stage 1 spec compliance review (run by the main agent, not a separate agent instance) finds AC "paginated" not met → FAIL
-- Main agent fixes and pushes directly (no orchestrator, no re-dispatch)
-- Re-review: PASS
-- Stage 2 code quality review runs next
-- Stage 2.5 pattern propagation is explicitly NOT run — only one issue is in flight
-- User sees the gate results in the final summary
-
-**Criteria to test**: 20
-
-### Case 24: Parent issue, user chooses "implement only this issue"
-
-**Scenario**: User says "implement issue #60" — #60 has 2 open sub-issues, but the user explicitly wants #60 itself implemented (e.g., #60 is a tracking issue with its own small piece of work).
-
-**Expected behavior**:
-- Phase 0 detects the open sub-issues and asks the batch/this-issue-only/pick-one question
-- User selects "Implement only this issue"
-- Flow proceeds as normal Single mode on #60 — plan, approval, implement, PR, review gates
-- The 2 sub-issues are not fetched, planned, or touched in any way
+**Expected behavior**: dependencies parsed from platform records and bodies;
+normal batch flow.
 
 **Criteria to test**: 19
+
+### Case 21: Stage 2.5 pattern propagation
+
+**Input:** Stage 2 flags a `rule-violation-instance` while 3 issues are in
+flight.
+
+**Expected behavior**: other in-flight PR diffs scanned for the pattern; user
+offered Apply to all / Select / Skip; propagation failures do not block the
+original issue.
+
+**Criteria to test**: 21
+
+## Mode-Routing Test Cases
+
+### Case 22: Parent detection on "implement issue #N"
+
+**Scenario**: #40 has 3 open sub-issues.
+
+**Expected behavior**: sub-issues detected in Phase 0; the user chooses batch
+(recommended for 2+) / only this issue / pick one. This scope question is
+asked even though Single mode itself is autonomous.
+
+**Criteria to test**: 18
+
+### Case 23: Single-mode gate results in the recap
+
+**Scenario**: A standalone issue implemented in Single mode; Stage 1 finds and
+fixes one AC miss.
+
+**Expected behavior**: main agent runs both gates itself, fixes and pushes
+directly; Stage 2.5 not run; the recap's gate lines show the fix round; ready
+flip after gates and CI pass.
+
+**Criteria to test**: 12, 14, 15, 22
+
+### Case 24: Parent issue, user picks "only this issue"
+
+**Scenario**: #60 has 2 open sub-issues, but the user wants #60 itself.
+
+**Expected behavior**: after the routing question, #60 proceeds through the
+normal autonomous Single flow; sub-issues untouched.
+
+**Criteria to test**: 1, 18
 
 ---
 
@@ -660,3 +578,69 @@ disproved that. REST reports `state` lower-case where the JSON fields report `OP
 
 `create-issue`'s `platform-github.md` was given the matching treatment in the same change —
 see that skill's own evaluation log entry for the same date.
+
+### 2026-07-27 — Autonomous Single mode rewrite (Refs #93)
+
+Wholesale rewrite per the settled decisions in #91/#93: Single mode is now a
+single autonomous flow with zero routine interactions. Criteria and cases 1–24
+above were rewritten for the new flow; the entries below this one evaluate the
+pre-rewrite interactive skill and are historical.
+
+Structural changes:
+
+- `workflow.md`: the Interactive/Autonomous Execution Modes table became
+  **Invocation Contexts** — Direct (Single) and Orchestrated (Batch) run the
+  same autonomous pipeline and differ only at seven divergence points. Plan
+  approval, the location question, and per-decision questions are gone;
+  decision resolution follows the store order (issue → parent → repository
+  agent instructions → user-level config), undecidable decisions become one
+  batched question whose answers are written back to the issue, and a security
+  review (new step 2-6) gates the push. Phase 3 creates a draft PR with a
+  review-first body and flips it to ready only after both gates and CI pass.
+- `SKILL.md`: principles and description rewritten; Environment Adaptation
+  gains a **Security review** capability row; plan mode is opt-in only.
+- `review-gates.md`: Single-mode "ask the user" escalations replaced with
+  record-in-PR + stay-draft; the flow diagram ends at the ready flip.
+- `batch.md`: implementer instruction updated (draft PR, stop after CI
+  monitoring at 3-3); the orchestrator now also flips PRs to ready (B2-3
+  step 5).
+- Platform guides: verified draft/ready/write-back/comment commands added
+  (`gh` verified locally on 2.x; `glab` flags verified against the official
+  CLI docs; Backlog write-backs use the already-verified comment command
+  rather than unverified description-edit flags).
+
+Plan-mode claim re-evaluation (required by #93): the old prohibition cited
+accidental rejections in the plan-approval UI with no feedback path. That
+claim was not re-verified against the current UI — it no longer needs to be
+load-bearing: with the plan gate removed, plan mode is opt-in regardless of
+UI quality, because any unrequested gate is a round trip. The skill text
+therefore justifies opt-in by round-trip cost alone and no longer asserts the
+UI-misfire claim.
+
+Desk-check of the rewritten cases against the new texts:
+
+| Case | Result | Notes |
+|------|--------|-------|
+| 1 | Pass | Happy path has no question site: worktree without asking (2-1), no plan gate (1-4), draft PR (3-1), ready flip (3-4), recap (3-6) |
+| 2 | Pass | Parent context in 1-1; settled-decision rule in 1-3 category 1 |
+| 3 | Pass | 1-3 category 3: one batched question, write-back before implementation; platform guides carry the write-back commands |
+| 4 | Pass | 1-1 derives binary criteria itself; only intent-level ambiguity joins the batched question |
+| 5 | Pass | 2-4 Direct: record in Risk Areas, continue; PR stays draft via 3-4; recap flags it |
+| 6 | Pass | 2-5 resolves by convention or records under Risk Areas; visible summary line retained |
+| 7 | Pass | 2-6 runs before any push; Critical/High blocks push in both contexts; outcome lands in Gate Results |
+| 8 | Pass | review-gates.md On Failure records findings, PR stays draft, recap flags |
+| 9 | Pass | 3-3 fix loop; 3-4 requires CI green |
+| 10 | Pass | 3-1 template-precedence paragraph; template lookup in platform guides |
+| 11 | Pass | 1-4 and SKILL.md: plan mode only on explicit request |
+| 12 | Pass | Phase 0 step 4 unchanged from previous version |
+| 13 | Pass | Backlog guide: status update, comment write-back, code-host draft/ready delegation |
+| 14 | Pass | 1-1 research-comment paragraph: read first, re-verify delta only |
+| 15 | Pass | GitLab guide: `--draft`, `--ready`, `--description` all doc-verified |
+| 16–21 | Pass | Batch orchestration semantics unchanged; B2-2/B2-3 updated for draft→ready; statuses replace questions (criterion 22) |
+| 22–24 | Pass | Routing and closed-issue questions retained as scope/anomaly gates |
+
+All 24 cases pass the desk-check. This entry records a static evaluation
+(instructions inspected against expected behavior); the first live run of the
+autonomous flow is the session that produced this rewrite's own PR, which
+followed the new pipeline (no plan gate, security review before push, draft
+PR with review-first body, gates, ready flip, recap).

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
@@ -58,17 +58,24 @@ Backlog does not have built-in blocking relationships. Parse the issue body for:
 - `Blocked by: PROJ-123`
 - `Depends on: PROJ-456`
 
-## Create Branch and Worktree
+## Read Issue Comments (research comment)
 
-**New branch or current-branch flows (Single mode):**
+workflow.md 1-1 looks for a research comment attached by the create-issue
+Design Flow. If the installed `bee` version does not expose issue comments,
+skip the research comment and research fresh — do not guess at flags.
+
+## Write Back Design Decisions to the Issue
+
+Backlog write-backs (workflow.md 1-3) are recorded as an issue **comment**
+rather than a description edit, using the verified comment command:
 
 ```bash
-git fetch origin
-git checkout <default-branch> && git pull
-git checkout -b <branch-name>
+bee issue comment PROJ-123 -b "Design Decisions (added <date>): <decisions and rationale>"
 ```
 
-**Worktree flow (Single mode default, and always in Batch mode):**
+## Create Branch and Worktree
+
+**Worktree flow (the default in both modes):**
 
 ```bash
 git fetch origin
@@ -84,7 +91,7 @@ git push -u origin <branch-name>
 
 ## Create Pull Request
 
-Backlog PRs are created through the code hosting platform (GitHub/GitLab), not through Backlog itself. Detect the code hosting platform from the git remote URL and use the appropriate CLI.
+Backlog PRs are created through the code hosting platform (GitHub/GitLab), not through Backlog itself. Detect the code hosting platform from the git remote URL and use that platform's guide — including its draft creation and ready-for-review flip commands.
 
 ## Update Issue Status
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
@@ -138,14 +138,7 @@ source would drop a real edge.
 
 ## Create Branch
 
-**New branch or current-branch flows (Single mode):**
-
-```bash
-git checkout main && git pull
-git checkout -b <branch-name>
-```
-
-**Worktree flow (Single mode default, and always in Batch mode):**
+**Worktree flow (the default in both modes):**
 
 ```bash
 git fetch origin
@@ -159,22 +152,55 @@ git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branc
 git push -u origin <branch-name>
 ```
 
-## Create Pull Request
+## Read Issue Comments (research comment)
+
+Used in workflow.md 1-1 to find a research comment attached by the create-issue
+Design Flow:
 
 ```bash
-gh pr create --title "<title>" --body "$(cat <<'EOF'
-## Summary
-<bullets>
+gh issue view <number> --comments
+```
 
-Closes #<issue-number>
+Structured: `gh issue view <number> --json comments`.
 
-## Changes
-<file-level changes>
+## Write Back Design Decisions to the Issue
 
-## Test Plan
-<verification checklist>
-EOF
-)"
+Used in workflow.md 1-3 to append batched-question answers to the issue's
+`## Design Decisions` section (create the section if absent):
+
+```bash
+gh issue view <number> --json body --jq '.body' > <tmpfile>
+# append the new decisions under "## Design Decisions" in <tmpfile>
+gh issue edit <number> --body-file <tmpfile>
+```
+
+## Check for a PR Template
+
+A repository template, when present, is the PR body skeleton (workflow.md 3-1).
+Look for `.github/PULL_REQUEST_TEMPLATE.md`, `PULL_REQUEST_TEMPLATE.md`,
+`docs/PULL_REQUEST_TEMPLATE.md`, or a `.github/PULL_REQUEST_TEMPLATE/` directory.
+
+## Create Draft Pull Request
+
+PRs are always created as drafts (workflow.md 3-1); the body sections come from
+workflow.md 3-1 (or the repository's PR template when one exists):
+
+```bash
+gh pr create --draft --title "<title>" --body-file <body-file>
+```
+
+## Update PR Body (gate results)
+
+```bash
+gh pr edit <number> --body-file <body-file>
+```
+
+## Mark PR Ready for Review
+
+Only after both review-gate stages pass and CI is green (workflow.md 3-4):
+
+```bash
+gh pr ready <number>
 ```
 
 ## Link PR to Issue

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
@@ -51,14 +51,7 @@ Also parse the issue body for `Blocked by: #N` patterns.
 
 ## Create Branch
 
-**New branch or current-branch flows (Single mode):**
-
-```bash
-git checkout main && git pull
-git checkout -b <branch-name>
-```
-
-**Worktree flow (Single mode default, and always in Batch mode):**
+**Worktree flow (the default in both modes):**
 
 ```bash
 git fetch origin
@@ -72,22 +65,47 @@ git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branc
 git push -u origin <branch-name>
 ```
 
-## Create Merge Request
+## Read Issue Comments (research comment)
+
+Used in workflow.md 1-1 to find a research comment attached by the create-issue
+Design Flow:
 
 ```bash
-glab mr create --title "<title>" --description "$(cat <<'EOF'
-## Summary
-<bullets>
+glab issue view <number> --comments
+```
 
-Closes #<issue-number>
+## Write Back Design Decisions to the Issue
 
-## Changes
-<file-level changes>
+Used in workflow.md 1-3 to append batched-question answers to the issue's
+`## Design Decisions` section (create the section if absent). Fetch the current
+description (`glab issue view <number> --output json`), append the decisions,
+then:
 
-## Test Plan
-<verification checklist>
-EOF
-)"
+```bash
+glab issue update <number> --description "<updated body>"
+```
+
+## Check for an MR Template
+
+A repository template, when present, is the MR body skeleton (workflow.md 3-1).
+Look for `.gitlab/merge_request_templates/` (the default template is usually
+`Default.md`).
+
+## Create Draft Merge Request
+
+MRs are always created as drafts (workflow.md 3-1); the body sections come from
+workflow.md 3-1 (or the repository's MR template when one exists):
+
+```bash
+glab mr create --draft --title "<title>" --description "<body>"
+```
+
+## Mark MR Ready for Review
+
+Only after both review-gate stages pass and CI is green (workflow.md 3-4):
+
+```bash
+glab mr update <number> --ready
 ```
 
 ## Link MR to Issue

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
@@ -100,6 +100,12 @@ workflow.md 3-1 (or the repository's MR template when one exists):
 glab mr create --draft --title "<title>" --description "<body>"
 ```
 
+## Update MR Description (gate results)
+
+```bash
+glab mr update <number> --description "<updated body>"
+```
+
 ## Mark MR Ready for Review
 
 Only after both review-gate stages pass and CI is green (workflow.md 3-4):
@@ -123,6 +129,14 @@ glab mr checks
 
 ```bash
 glab issue note <number> --message "<comment>"
+```
+
+## Reopen Issue
+
+Used by Phase 0's closed-issue check ("Reopen and implement"):
+
+```bash
+glab issue reopen <number>
 ```
 
 ## CLAUDE.md Config Example

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Every PR/MR goes through two review stages before being marked as done — whether it came from Single mode (one issue, interactive) or Batch mode (many issues, orchestrated). This mirrors superpowers' two-stage review pattern:
+Every PR/MR goes through two review stages before being marked as done — whether it came from Single mode (one issue, Direct context) or Batch mode (many issues, Orchestrated context). Together with CI, these gates control the draft → ready flip: a PR/MR leaves draft status only after both stages pass (see workflow.md 3-4). This mirrors superpowers' two-stage review pattern:
 
 1. **Spec compliance** — Does the implementation match what the issue asked for?
 2. **Code quality** — Is the code well-written, safe, and maintainable?
@@ -19,7 +19,7 @@ A review is strongest when run by a **separate agent instance** (see Environment
 
 **Reviewer model.** Where the environment supports **model selection** (see Environment Adaptation in SKILL.md), run each reviewer on a model at least as capable as — ideally more capable than — the implementer's. Well-formed issues deliberately carry no implementation detail (they record decisions and constraints, never steps), so the implementer derives the implementation plan itself; a stronger reviewer is the cheapest guard against derivation errors, especially when implementers run on a faster/cheaper model. On Claude Code, pass a `model` override when dispatching the reviewer as a subagent (e.g. an `opus`-class reviewer over `sonnet`-class implementers). Where model selection is unavailable, run reviewers on the default model — the two-stage structure and fix routing are unchanged.
 
-**Fallback when no separate agent instance is available.** Run the stage's checklist yourself and produce the stage's real verdict exactly as defined below (Stage 1: PASS/FAIL with the issue list; Stage 2: severity-tagged issue counts and PASS/NEEDS_FIXES). Then mark that verdict `SELF-REVIEWED (no independent reviewer available)`. The marker **rides on** the real result — it does not replace it — so the On-Failure fix routing (max 2 rounds, then DONE_WITH_CONCERNS in Batch / escalate in Single) applies unchanged. Record the marker next to the gate outcome in the PR/MR body so a human can see the independent-review guarantee did not hold.
+**Fallback when no separate agent instance is available.** Run the stage's checklist yourself and produce the stage's real verdict exactly as defined below (Stage 1: PASS/FAIL with the issue list; Stage 2: severity-tagged issue counts and PASS/NEEDS_FIXES). Then mark that verdict `SELF-REVIEWED (no independent reviewer available)`. The marker **rides on** the real result — it does not replace it — so the On-Failure fix routing (max 2 rounds, then DONE_WITH_CONCERNS in Batch / record-and-stay-draft in Single) applies unchanged. Record the marker next to the gate outcome in the PR/MR body so a human can see the independent-review guarantee did not hold.
 
 ## Stage 1: Spec Compliance Review
 
@@ -70,7 +70,7 @@ If spec compliance fails:
 2. Re-run spec compliance review.
 3. Max 2 fix rounds. If still failing:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS` and include the review output in the batch summary.
-   - **Single mode**: present the remaining findings to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon instead of silently marking anything — there is a user present to decide.
+   - **Single mode**: record the remaining findings in the PR body (Risk Areas and Gate Results), leave the PR/MR a **draft**, and surface the findings in the recap's review-focus areas. Do not ask the user mid-run — the draft state plus the recorded findings put the decision where it belongs, at PR review.
 
 ## Stage 2: Code Quality Review
 
@@ -126,7 +126,7 @@ If code quality review finds Critical or Important issues:
 2. Re-run code quality review.
 3. Max 2 fix rounds. If Critical issues remain:
    - **Batch mode**: mark the issue as `DONE_WITH_CONCERNS`.
-   - **Single mode**: present the remaining Critical findings to the user via a user choice (see Environment Adaptation) with options Proceed as-is / Keep fixing / Abandon.
+   - **Single mode**: record the remaining Critical findings in the PR body (Risk Areas and Gate Results), leave the PR/MR a **draft**, and surface them in the recap's review-focus areas.
 
 ## Stage 2.5: Pattern Propagation (Batch Mode Only)
 
@@ -159,25 +159,27 @@ Failures in propagation fixes do **not** block the original issue from completin
 ## Review Flow Diagram
 
 ```
-PR Created
+Draft PR Created
   ↓
 Stage 1: Spec Compliance
   ├─ PASS → Stage 2
   └─ FAIL → Fix (implementer in Batch / main agent in Single) → Re-review (max 2 rounds)
               ├─ PASS → Stage 2
-              └─ FAIL → Batch: DONE_WITH_CONCERNS | Single: ask user
+              └─ FAIL → Record in PR, stays draft; Batch: DONE_WITH_CONCERNS | Single: flag in recap
   ↓
 Stage 2: Code Quality
   ├─ PASS (no Critical/Important) → Mode check
   └─ NEEDS_FIXES → Fix → Re-review (max 2 rounds)
               ├─ PASS → Mode check
-              └─ Still Critical → Batch: DONE_WITH_CONCERNS | Single: ask user
+              └─ Still Critical → Record in PR, stays draft; Batch: DONE_WITH_CONCERNS | Single: flag in recap
   ↓
 Mode check
-  ├─ Single mode → DONE (Stage 2.5 always skipped)
+  ├─ Single mode → gates passed (Stage 2.5 always skipped)
   └─ Batch mode → Stage 2.5 check
-              ├─ No rule violations → DONE
+              ├─ No rule violations → gates passed
               └─ rule-violation-instance → Scan other in-flight PRs
-                          ├─ No matches / user skips → DONE
-                          └─ User approves → Run fix passes → DONE (failures non-blocking)
+                          ├─ No matches / user skips → gates passed
+                          └─ User approves → Run fix passes → gates passed (failures non-blocking)
+  ↓
+Gates passed + CI green → flip draft to ready (workflow.md 3-4 / batch.md B2-3)
 ```

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -9,7 +9,7 @@ Every PR/MR goes through two review stages before being marked as done — wheth
 
 These are separate concerns. Spec compliance prevents over-building and under-building. Code quality catches bugs and style issues. Combining them into one review loses signal.
 
-**Single mode note**: with only one issue in flight, the main agent runs both stages itself (there is no separate orchestrator/reviewer split). Stage 2.5 (pattern propagation) never runs in Single mode — there are no other in-flight PRs to scan.
+**Single mode note**: with only one issue in flight there is no orchestrator — the main agent is responsible for both stages: run each as a separate fresh-context agent instance where the environment supports one (see Reviewer Dispatch), otherwise review directly with the `SELF-REVIEWED` marker. Stage 2.5 (pattern propagation) never runs in Single mode — there are no other in-flight PRs to scan.
 
 **Batch mode note**: the orchestrator runs a fresh reviewer per stage per issue, and Stage 2.5 is active whenever a rule violation is found with 2+ issues in flight.
 
@@ -31,7 +31,7 @@ Review with:
 - The PR diff (`git diff origin/<default-branch>...<branch-name>`)
 - Instructions below
 
-**Batch mode**: run a dedicated reviewer with the above context — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent performs this review directly on the diff it just produced.
+**Batch mode**: the orchestrator runs a dedicated reviewer with the above context — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent runs the review the same way — a separate fresh-context instance where available, direct self-review with the marker otherwise.
 
 ### Review Criteria
 
@@ -82,7 +82,7 @@ Review with:
 - Project conventions (CLAUDE.md path)
 - Instructions below
 
-**Batch mode**: run a dedicated reviewer — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent performs this review directly.
+**Batch mode**: the orchestrator runs a dedicated reviewer — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent runs the review the same way — a separate fresh-context instance where available, direct self-review with the marker otherwise.
 
 ### Review Criteria
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -267,8 +267,9 @@ reading path regardless.
 [review-gates.md](review-gates.md), fixing and pushing between rounds. Update
 the Gate Results section as each stage completes.
 
-**Orchestrated**: skip — stop after 3-3 and report; the orchestrator runs the
-gates and re-invokes this implementer for fix rounds.
+**Orchestrated**: skip this step — the orchestrator runs the gates and
+re-invokes this implementer for fix rounds. Continue with 3-3 and 3-5, then
+report (3-6); never perform the 3-4 flip.
 
 ### 3-3. Monitor CI
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -28,7 +28,7 @@ The same pipeline runs in one of two contexts:
 | Working environment (2-1) | Worktree by default; reuse one already prepared for this run | Always the worktree the orchestrator created |
 | Checks still failing after 3 attempts (2-4) | Record the failure in the PR body, continue; the PR stays draft | Stop, report `BLOCKED` |
 | Unresolved Critical/High security finding (2-6) | Stop before pushing, report to the user | Stop before pushing, report `BLOCKED` |
-| Review gates (3-2) | Main agent runs both stages itself | Skipped here — the orchestrator runs them after the implementer reports |
+| Review gates (3-2) | Main agent is responsible for both stages (dispatch per review-gates.md) | Skipped here — the orchestrator runs them after the implementer reports |
 | Draft → ready flip (3-4) | Main agent flips after gates + CI pass | Orchestrator flips after gates + CI pass |
 | Final report (3-6) | Chat recap | One status line to the orchestrator |
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/workflow.md
@@ -1,188 +1,123 @@
 # Workflow Detail
 
-## Execution Modes
+The canonical implementation pipeline: understand the issue, resolve decisions,
+implement, verify, and deliver a review-first draft PR/MR that is flipped to
+ready once the machines are done. The pipeline is **autonomous**: it runs from
+invocation to report without routine user interaction. Decisions are resolved
+from the decision stores or by repository convention and **logged, not asked**.
 
-This pipeline runs in one of two modes:
+## Invocation Contexts
 
-- **Interactive** (Single mode) — the main agent executes this workflow directly, with the user present. This is the default.
-- **Autonomous** (Batch mode) — the implementer executes this workflow with no access to the user, coordinated by the orchestrator described in [batch.md](batch.md). The orchestrator runs the implementer as a separate agent instance where the environment supports one, or in the current context sequentially where it does not; either way this workflow is identical. Every point below that normally asks the user has an Autonomous-mode replacement instead.
+The same pipeline runs in one of two contexts:
 
-| Step | Interactive | Autonomous |
+- **Direct** (Single mode) — the main agent executes this workflow itself. The
+  user exists but is interrupted for exactly two reasons: the single batched
+  question of step 1-3 (genuinely undecidable decisions only), and an
+  unresolvable Critical/High security finding (step 2-6, which blocks the
+  push). Everything else completes with concerns recorded in the PR and
+  surfaced in the recap.
+- **Orchestrated** (Batch mode) — an implementer executes this workflow with no
+  user access, coordinated by the orchestrator in [batch.md](batch.md) (as a
+  separate agent instance where the environment supports one, sequentially in
+  the current context otherwise). Anything Direct would ask the user becomes a
+  terminal status instead.
+
+| Divergence point | Direct | Orchestrated |
 |---|---|---|
-| 1-1 missing/vague issue fields | Ask the user, or propose criteria and confirm | Stop and report status `NEEDS_CONTEXT` with what is missing |
-| 1-3 design decisions | User choice gate with numbered options (decisions already recorded in the issue or its parent are settled — do not re-ask) | Follow design decisions recorded in the issue or its parent (Background, Design Decisions); for decisions not recorded, choose the option most consistent with project conventions and note the choice in the PR body; if genuinely undecidable, stop and report `NEEDS_CONTEXT` |
-| 1-6 plan approval | Present as text + user choice gate (Approve / Request changes / Abort) | No gate — the plan stays internal to the implementer and is not presented for approval |
-| 2-1 working environment | The choice made in Phase 0 Setup (Worktree / New branch / Current branch) | Always the worktree the orchestrator already created before dispatch |
-| 2-3 checks fail after 3 attempts | Escalate via user choice gate (continue / skip / abandon) | Stop and report status `BLOCKED` with the error |
-| 2-4 self-review needs human judgment | Escalate via user choice gate | Note the concern in the PR description, continue, and report status `DONE_WITH_CONCERNS` |
-| 3-2 unfixable CI failure | Note in the PR description, tell the user | Note in the PR description and report status `DONE_WITH_CONCERNS` |
+| Undecidable decision / missing critical field (1-1, 1-3) | One batched question; answers written back to the issue | Stop, report `NEEDS_CONTEXT` |
+| Working environment (2-1) | Worktree by default; reuse one already prepared for this run | Always the worktree the orchestrator created |
+| Checks still failing after 3 attempts (2-4) | Record the failure in the PR body, continue; the PR stays draft | Stop, report `BLOCKED` |
+| Unresolved Critical/High security finding (2-6) | Stop before pushing, report to the user | Stop before pushing, report `BLOCKED` |
+| Review gates (3-2) | Main agent runs both stages itself | Skipped here — the orchestrator runs them after the implementer reports |
+| Draft → ready flip (3-4) | Main agent flips after gates + CI pass | Orchestrator flips after gates + CI pass |
+| Final report (3-6) | Chat recap | One status line to the orchestrator |
 
-Every step below is written from the Interactive perspective by default; where behavior diverges, an "Autonomous mode" note follows the step, keyed to the table above.
+## Phase 1: Understand and Decide
 
-## Phase 1: Plan
+### 1-1. Read the Issue
 
-### 1-1. Parse the Issue
+Extract from the issue body: summary, motivation, background/constraints,
+proposal (desired end state), and acceptance criteria.
 
-Extract and organize the following from the issue body:
+**Parent context.** If the issue references a parent (`Parent: #N` line or a
+platform-level parent link), fetch the parent and read its Background, Design
+Decisions, and Task Overview — decisions recorded there bind this task.
 
-| Field | What to look for |
-|---|---|
-| **Summary** | 1–2 sentence overview at the top |
-| **Motivation** | Why this matters (user need, business goal, pain point) |
-| **Background** | Current state, constraints, business rules, related code paths |
-| **Proposal** | Desired end state (what, not how) |
-| **Acceptance Criteria** | Binary pass/fail conditions for completion |
-| **References** | Links, screenshots, related issues |
+**Research comment.** Check the issue (and its parent) for an attached research
+comment — the create-issue Design Flow persists its research findings as an
+issue comment. If one exists, read it first and re-verify only the **delta**
+against the current code (what changed since the comment's date) instead of
+re-researching from scratch. See the platform guide for how to read comments;
+if the platform's CLI does not expose comments, research fresh.
 
-**Parent context**: If the issue references a parent (a `Parent: #N` line in the body, or a platform-level parent link), fetch the parent issue and read its Background, Design Decisions, and Task Overview — they are shared context for every sub-issue. Design decisions recorded there apply to this task.
-
-If any critical field is missing or ambiguous:
-- **Missing**: Ask the user to provide it.
-- **Vague** (e.g., "it should work well"): Propose 2–3 concrete, binary-testable criteria and ask the user to confirm or adjust. Do not proceed until acceptance criteria are specific enough to verify.
-
-**Autonomous mode**: do not ask the user. If a critical field is missing or too vague to act on, stop immediately and return status `NEEDS_CONTEXT` with a specific description of what is missing.
+**Missing or vague critical fields** (no acceptance criteria, or criteria like
+"works well" that cannot be verified): draft concrete, binary-testable
+criteria yourself from the motivation and proposal. If the issue is too vague
+even for that — the intent itself is ambiguous — treat it as an undecidable
+decision: Direct context folds it into the batched question of 1-3;
+Orchestrated context stops with `NEEDS_CONTEXT` and a specific description of
+what is missing.
 
 ### 1-2. Analyze the Codebase
 
-Based on issue context, investigate:
+Investigate what the issue touches: related files and patterns, project
+conventions (agent instructions, existing code), dependencies and their
+constraints, test conventions, and any project commands (checks, auto-fix,
+codegen).
 
-1. **Related files** — Grep/Glob for keywords, class names, routes, or components mentioned in the issue.
-2. **Architecture patterns** — Identify the project's conventions (directory structure, naming, frameworks, abstraction layers).
-3. **Dependencies** — Check what modules/packages are involved; note version constraints.
-4. **Test patterns** — Find existing tests to understand testing conventions (framework, location, naming).
-5. **CLAUDE.md** — Read project-level CLAUDE.md for coding standards, preferred libraries, and workflow rules.
-6. **Existing branches** — Check for branches that reference the issue number (e.g., `git branch -a | grep <issue-number>`). If a partial implementation exists, note what is already done and ask the user whether to continue from it or start fresh.
+**Existing branches**: check for branches referencing the issue number. If a
+stale partial implementation exists, default to a fresh start from the default
+branch and note the branch and the choice under Decisions in the PR body.
 
-Record findings as structured notes for use in the plan.
+### 1-3. Resolve Decisions
 
-### 1-3. Resolve Design Decisions
+Decisions are resolved in this order, and only the last category ever reaches
+the user:
 
-Decisions already recorded in the issue or its parent (e.g., a Design Decisions table, constraints in Background) are settled — follow them, do not re-ask. They were typically resolved with the user when the issue was designed.
+1. **Settled** — recorded in a decision store: the issue body, its parent's
+   body (Design Decisions, Background), the repository's agent instructions,
+   or user-level configuration. Follow them as written; never re-ask, never
+   re-litigate.
+2. **Local and reversible** — naming, choices among roughly equivalent designs,
+   tactical details. Decide now: choose the option most consistent with
+   existing repository conventions, and log the decision and rationale in the
+   PR body's Decisions section. A constraint tied to one piece of code goes in
+   a code comment; commit a lightweight ADR under `docs/adr/` only when a
+   decision contradicts an existing rule or binds future work.
+3. **Genuinely undecidable** — no store records it, no convention points one
+   way, and the outcome materially changes the result (structural shape,
+   irreversibility, cross-task consistency).
+   - **Direct**: collect **all** such decisions and ask them as **one batched
+     question** (user choice, numbered options with a recommendation per
+     decision). Immediately append the answers to the issue's `## Design
+     Decisions` section (create it if absent) using the platform guide's
+     write-back command, then proceed. This is the only routine-flow stop.
+   - **Orchestrated**: stop and report `NEEDS_CONTEXT` listing the decisions.
 
-Before drafting the plan, identify any remaining decisions that require human judgment. Examples:
+When in doubt whether a decision is undecidable or merely local, treat it as
+local and log it — the PR review is the safety net.
 
-- Multiple valid architectural approaches (e.g., REST vs GraphQL, new table vs extend existing)
-- Trade-offs between simplicity and extensibility
-- Ambiguous requirements that could be interpreted differently
-- Technology or library choices not dictated by CLAUDE.md
-- Scope boundaries (what's "good enough" for this issue)
+### 1-4. Plan Internally
 
-For each decision point, ask the user to choose (see Environment Adaptation) from numbered options:
+Form an implementation plan before editing: files to change and how, new
+dependencies, edge cases, how each acceptance criterion will be verified, and
+what is explicitly out of scope. The plan is working state, not a deliverable —
+there is no approval gate and it is not presented for review. Its visible
+residue is the PR body: the AC → evidence mapping and the Decisions section.
 
-1. **Present options** (2–4 choices) with:
-   - A short label for each option
-   - Pros and cons or key trade-offs in the description
-   - Mark the recommended option with "(Recommended)" in its label
-2. **Wait for the user's choice** before proceeding.
+**On Claude Code specifically:** plan mode is opt-in only — enter it solely
+when the user explicitly asked for a plan gate in this run; never by default.
+An unrequested plan gate converts an autonomous run back into a round trip.
 
-**Handling "Other" free-text responses:**
+## Phase 2: Implement and Verify
 
-When the user selects "Other" and provides free-text input, treat their text as the chosen approach. Incorporate it directly into the plan — do NOT re-present a new set of multiple-choice options. Only re-ask if the free-text is genuinely ambiguous (e.g., too vague to determine a concrete implementation direction, or contradicts constraints). If re-asking, quote the user's text and explain specifically what needs clarification.
+### 2-1. Prepare the Working Environment
 
-If no design decisions require human input, skip this step and proceed to 1-4.
+**Direct**: work in a git worktree by default — do not ask. If the session was
+already started on a branch or worktree prepared for this issue (e.g. by the
+host environment), use it as-is and note the branch name under Decisions if it
+deviates from the naming convention below.
 
-**Autonomous mode**: do not present a user choice. Follow design decisions recorded in the issue or its parent (Background, Design Decisions). For decisions not recorded there, choose the option most consistent with existing project conventions, and note the choice and its rationale in the PR body so a human reviewer can revisit it. If the decision is genuinely undecidable (no recorded decision, no convention to lean on, and the outcome materially changes the result), stop and return status `NEEDS_CONTEXT`.
-
-### 1-4. Draft Implementation Plan
-
-Create a plan with this structure:
-
-```
-## Implementation Plan for #<issue-number>
-
-### Summary
-1-2 sentence description of the approach.
-
-### Files to Change
-For each file, describe:
-- **Path**: `path/to/file`
-- **Action**: Create / Modify / Delete
-- **Changes**: What will be added, changed, or removed and why
-
-### New Dependencies (if any)
-- Package name, version, why needed
-
-### Edge Cases & Risks
-- List potential issues and how to handle them
-
-### Verification
-How each acceptance criterion will be verified:
-- Criterion 1 → verification method
-- Criterion 2 → verification method
-
-### Out of Scope
-Explicitly list things NOT included to prevent scope creep.
-```
-
-### 1-5. Self-Evaluate the Plan
-
-Before presenting, verify:
-
-| # | Check | Pass condition |
-|---|---|---|
-| 1 | Covers all acceptance criteria | Every criterion has a verification method |
-| 2 | Stays in scope | No changes unrelated to the issue |
-| 3 | Follows project conventions | Consistent with CLAUDE.md and existing patterns |
-| 4 | Files list is complete | No missing files needed for the change |
-| 5 | Risks identified | Non-obvious edge cases documented |
-
-If any check fails, revise the plan before presenting.
-
-### 1-6. Present and Get Approval
-
-Present the plan as regular **text output**. Clearly state:
-
-- What will change and why
-- Any assumptions or decisions made
-- Questions or trade-offs requiring user input
-
-Then collect approval via a user choice (see Environment Adaptation):
-
-```
-User choice with options:
-- "Approve" — Proceed with implementation.
-- "Request changes" — Revise the plan based on feedback.
-- "Abort" — Cancel the implementation.
-```
-
-**If the user selects "Request changes"** (or provides feedback via "Other"):
-1. Read the user's feedback carefully.
-2. Treat the feedback as specific change requests — incorporate them directly into the revised plan. Do NOT re-present new multiple-choice options based on the feedback. If the user wrote "do X instead of Y", revise the plan to do X.
-3. Re-present the revised plan.
-4. Ask for approval again via a user choice with the same options.
-5. Repeat until the user approves or aborts.
-
-Only re-ask for clarification if the feedback is genuinely ambiguous (e.g., contradicts other requirements, or is too vague to act on). If re-asking, quote the user's text and explain specifically what needs clarification.
-
-**On Claude Code specifically:** do not use plan mode (`EnterPlanMode`/`ExitPlanMode`) for this approval — its approval UI can cause accidental rejections with no way to provide feedback, leading to abandoned sessions.
-
-**Autonomous mode**: skip this step entirely. There is no user to present the plan to — the plan drafted in 1-4 is used directly as the internal basis for implementation, without a gate.
-
-## Phase 2: Implement
-
-### 2-1. Prepare Working Environment
-
-Use the implementation location chosen in Phase 0 Setup.
-
-**Autonomous mode**: the working environment is always the worktree the orchestrator created before starting this implementer — skip the branching below and `cd` into that worktree path.
-
-Branch naming convention (for new branch and worktree):
-
-```
-<type>/<issue-number>-<short-description>
-```
-
-Examples:
-- `feat/42-add-user-search`
-- `fix/108-login-timeout`
-- `refactor/55-extract-auth-module`
-
-Type is inferred from issue labels or content:
-- Bug → `fix/`
-- Feature → `feat/`
-- Technical task / refactor → `refactor/` or `chore/`
-
-**If "Worktree"** (default): Fetch latest, then create a worktree from the default branch. Keep the worktree directory out of version control with a local git exclude (`.git/info/exclude` is per-clone, so it never appears in the PR the way editing `.gitignore` would):
 ```bash
 git fetch origin
 grep -qxF '.worktrees/' .git/info/exclude 2>/dev/null || echo '.worktrees/' >> .git/info/exclude
@@ -190,205 +125,192 @@ git worktree add .worktrees/<branch-name> -b <branch-name> origin/<default-branc
 cd .worktrees/<branch-name>
 ```
 
-**If "New branch"**: Fetch latest and create a branch from the default branch:
-```bash
-git fetch origin
-git checkout origin/<default-branch>
-git checkout -b <branch-name>
-```
+**Orchestrated**: `cd` into the worktree the orchestrator already created —
+never create one.
 
-**If "Current branch"**: Verify the branch is clean (`git status`). Continue on the current branch.
+Branch naming: `<type>/<issue-number>-<short-description>` — type from the
+issue's label or content (`fix/`, `feat/`, `refactor/`, `chore/`).
 
-### 2-1b. Update Issue Status
+### 2-2. Update Issue Status
 
-If the issue tracker supports status updates (e.g., Backlog), update the issue status to "In Progress" after preparing the working environment and before starting implementation. See the platform-specific guide for the command.
+If the issue tracker supports status updates (e.g. Backlog), set the issue to
+"In Progress" now — after decisions are resolved, before code changes. See the
+platform guide.
 
-This step is placed here (after plan approval) rather than in Phase 0, so the issue is not marked "In Progress" if the plan is rejected or abandoned.
+### 2-3. Implement
 
-### 2-2. Implement Changes
+Implement the plan. Guidelines:
 
-Follow the approved plan file by file. For each file:
+- **Follow existing patterns** — match surrounding code in naming, structure,
+  and idiom.
+- **Stay in scope** — no refactoring or "improvements" beyond the issue.
+- **No over-engineering** — the simplest solution that satisfies the
+  acceptance criteria.
+- **Secure by default** — validate input, avoid injection, handle errors at
+  system boundaries.
+- **Regenerate derived files** — if sources that drive code generation changed
+  (schemas, protos, OpenAPI), run the project's regeneration command before
+  checks.
 
-1. Read the file first to understand current state.
-2. Make the planned changes.
-3. Keep changes minimal — only what the plan specifies.
+### 2-4. Run Project Checks (loop, max 3 attempts)
 
-Guidelines:
+Run the auto-fix commands the project defines (formatters, linters with
+`--fix`) once, then loop the project's check suite (tests, lint, type check,
+build): run, fix failures, re-run — until green or 3 attempts are spent.
 
-- **Follow existing patterns** — Match the style of surrounding code (naming, indentation, abstractions).
-- **No unrelated changes** — Do not refactor, clean up, or "improve" code outside the plan scope.
-- **No over-engineering** — Implement the simplest solution that satisfies the acceptance criteria.
-- **Secure by default** — Validate user input, avoid injection vulnerabilities, handle errors at system boundaries.
-- **Regenerate derived files** — If source files that drive code generation were modified (e.g., API schemas, proto files, OpenAPI specs), run the project's regeneration command (check CLAUDE.md) before running checks. Skip if no such command is defined.
+**Still failing after 3 attempts** — **Direct**: stop fixing, record exactly
+what fails and what was tried in the PR body's Risk Areas, and continue; CI
+will fail, so the PR remains a draft and the recap flags it prominently.
+**Orchestrated**: stop and report `BLOCKED` with the failing checks and
+attempts.
 
-### 2-3. Run Project Checks (loop until all pass)
+If the project defines no checks, note that in the PR body.
 
-Check CLAUDE.md for project-specific commands. Common checks:
+### 2-5. Self-Review (loop, max 3 rounds)
 
-| Check | Typical command |
-|---|---|
-| Tests | `npm test`, `pytest`, `go test ./...`, etc. |
-| Lint | `npm run lint`, `ruff check`, `golangci-lint run`, etc. |
-| Type check | `tsc --noEmit`, `mypy .`, etc. |
-| Build | `npm run build`, `go build ./...`, etc. |
-| Format | `prettier --write`, `ruff format`, `gofmt`, etc. |
+Review the full diff (`git diff`) for: logic errors and edge cases, missing
+error handling at boundaries, drift from the issue's decisions and acceptance
+criteria, and convention violations. Fix what has a clear correct solution,
+re-run checks after fixes, re-review. A concern that would previously have
+been escalated (ambiguous business rule, UX trade-off) is resolved by
+convention like any local decision and logged — or, if truly undecidable, it
+belongs in 1-3's batched question, which has already passed: record it under
+Risk Areas instead and let the reviewer rule.
 
-For typed languages (TypeScript, Python with mypy, Go, etc.), always include type-check and build in the check suite to catch type errors locally before pushing.
-
-**Step 0 (once): Auto-fix** — Before entering the check loop, run any auto-fix commands defined in CLAUDE.md (e.g., formatters, linters with `--fix`). This resolves mechanically fixable issues without burning loop attempts. Skip if no auto-fix commands are defined.
-
-| Auto-fix | Typical command |
-|---|---|
-| Format | `prettier --write .`, `ruff format .`, `gofmt -w .`, etc. |
-| Lint fix | `eslint --fix`, `ruff check --fix`, etc. |
-
-Run whatever the project defines. **Loop (max 3 attempts):**
-
-1. Run all checks.
-2. If any fail, fix the issue and re-run all checks.
-3. Repeat until all checks pass or 3 attempts are reached.
-
-If a fix requires a design decision (e.g., how to handle an unexpected edge case), ask the user to choose (see Environment Adaptation) from numbered options with a recommendation and wait for the user's choice.
-
-**If checks still fail after 3 attempts**: Stop and escalate to the user via a user choice (see Environment Adaptation) presenting:
-- Which checks are still failing and what was tried
-- Options: continue trying, skip the failing check, or abandon the implementation
-
-**Autonomous mode**: do not present a user choice. Stop and return status `BLOCKED` with which checks are failing and what was tried.
-
-If the project has no defined checks, skip this step but note it when creating the PR.
-
-### 2-4. AI Self-Review (loop until clean)
-
-After all project checks pass, review the full diff of changes:
-
-```bash
-git diff
-```
-
-Check for:
-- Logic errors, off-by-one, null/undefined risks
-- Security issues (injection, auth bypass, data exposure)
-- Missing error handling at system boundaries
-- Inconsistency with the approved plan
-- Code that doesn't follow project conventions
-
-**Loop (max 3 rounds):**
-
-1. Review the diff.
-2. If issues found:
-   - Fix issues that have a clear correct solution.
-   - If a fix requires human judgment (e.g., ambiguous requirements, UX trade-offs, business logic), ask the user to choose (see Environment Adaptation) from numbered options with a recommendation. Wait for the user's choice.
-3. After fixes, re-run project checks (Step 2-3) to ensure fixes don't break anything.
-4. Re-review the diff.
-5. Repeat until no issues remain or 3 review rounds are reached.
-
-**If issues remain after 3 rounds**: Stop and ask the user to choose (see Environment Adaptation), presenting the remaining issues. Let the user decide whether to:
-- Proceed with known issues
-- Fix manually
-- Abandon the implementation
-
-**Autonomous mode**: do not present a user choice. Note the remaining concerns in the PR description and continue — this issue will be reported as status `DONE_WITH_CONCERNS`.
-
-**After self-review completes**, output a visible summary before proceeding to commit:
+After the loop, output one visible line:
 
 ```
 Self-review complete: N round(s), N issue(s) found, N fixed, N remaining
 ```
 
-Interactive mode: this is shown to the user directly. Autonomous mode: this line is included in the implementer's final report to the orchestrator. This ensures self-review is verifiable and the result is visible at a glance either way.
+### 2-6. Security Review (before any push)
 
-### 2-5. Commit
+The push is the leak boundary — a secret or exploitable defect that leaves the
+machine cannot be recalled by a later fix commit. After checks and self-review
+pass and **before pushing anything**, run a security review of the pending
+changes (see the Security review capability in SKILL.md's Environment
+Adaptation; on Claude Code, run `/security-review`). At minimum it must cover:
+secrets or credentials in the diff, injection, authn/authz changes, data
+exposure, unsafe deserialization, and SSRF.
 
-Write a Conventional Commit message referencing the issue:
+- **Critical/High findings**: fix, re-run checks, re-review — max 2 rounds. If
+  a Critical/High finding remains, **do not push**: Direct reports it to the
+  user and stops; Orchestrated reports `BLOCKED`.
+- **Lower-severity findings**: fix or record under Risk Areas.
+- Record the outcome (tool used, findings, resolution) — it goes in the PR
+  body's Gate Results.
+
+### 2-7. Commit
+
+Conventional Commit referencing the issue:
 
 ```
 <type>: <description>
 
-<body explaining what and why>
+<what changed and why>
 
 Refs #<issue-number>
 ```
 
-Example:
-```
-feat: add user search endpoint
-
-Implement full-text search for users by name and email.
-Search uses existing pg_trgm index for performance.
-
-Refs #42
-```
-
-Guidelines:
-- Subject line under 72 characters.
-- Body explains **what** changed and **why**, not the obvious **how**.
-- Reference the issue with `Refs #N`. Use `Closes #N` only in the PR body, not the commit.
+Subject under 72 characters; use `Closes #N` only in the PR body, never the
+commit.
 
 ## Phase 3: Pull/Merge Request
 
-### 3-0. Detect Code Hosting Platform
+### 3-1. Push and Create a Draft PR/MR
 
-The code hosting platform (for PRs) is independent of the issue tracker. Detect from the git remote URL:
+Detect the code hosting platform from the git remote (it may differ from the
+issue tracker — e.g. Backlog issues + GitHub PRs), push the branch, and create
+the PR/MR **as a draft** (see the platform guide; title under 70 characters,
+no Conventional Commit prefix). Draft status is the "machines still working"
+signal: it is removed only in 3-4.
 
-- `github.com` → GitHub (use `gh` CLI)
-- `gitlab.com` or known GitLab instance → GitLab (use `glab` CLI)
-
-This allows cross-platform setups (e.g., Backlog for issue tracking + GitHub for code hosting).
-
-### 3-1. Push and Create PR/MR
-
-Push and create the PR/MR using the **code hosting** platform's CLI. See the platform-specific guide for exact commands.
-
-PR/MR body format:
+**PR/MR body — ordered for the reviewer.** Human judgment concentrated at the
+PR is the trade for autonomous execution, so the body leads with what needs
+judgment and ends with what doesn't:
 
 ```markdown
-## Summary
-<1-3 bullet points describing what changed>
+## Decisions & Deviations
+<implementation-time decisions with rationale; deviations from the issue text;
+"None" if none — the section is always present>
 
-Closes #<issue-number>
+## Risk Areas
+<what deserves reviewer attention: unresolved concerns, failing checks,
+subtle changes; "None" if none>
+
+## Acceptance Criteria → Evidence
+- [x] <criterion> — <how it was verified: test name, command output, diff ref>
+
+## Gate Results
+- Self-review: <N rounds, N found, N fixed>
+- Security review: <tool, findings, resolution>
+- Spec compliance (Stage 1): <pending → result>
+- Code quality (Stage 2): <pending → result>
+- CI: <pending → result>
 
 ## Changes
-- <file-level description of changes>
+<mechanical file-level list — last, it needs the least judgment>
 
-## Test Plan
-- [ ] <how each acceptance criterion was verified>
-- [ ] <any manual testing steps>
+Closes #<issue-number>
 ```
 
-### 3-1b. Review Gates
+**Repository PR/MR templates take precedence.** When the repository defines a
+template, the template is the skeleton: fill its sections, map the content
+above into semantically matching sections, and append whatever has no match as
+clearly delimited sections after the template body. Review-first ordering
+yields to template order; the chat recap always carries the decisions-first
+reading path regardless.
 
-After the PR/MR is created, every issue — Interactive or Autonomous — goes through the two-stage review described in [review-gates.md](review-gates.md): Stage 1 spec compliance, then Stage 2 code quality.
+### 3-2. Review Gates
 
-**Interactive mode**: the main agent runs both stages itself and fixes/pushes directly; there is no separate reviewer to dispatch. See review-gates.md's single-issue notes for the escalation path when fixes don't converge.
+**Direct**: run Stage 1 (spec compliance) then Stage 2 (code quality) per
+[review-gates.md](review-gates.md), fixing and pushing between rounds. Update
+the Gate Results section as each stage completes.
 
-**Autonomous mode**: the implementer does NOT run the review gates itself. Stop after 3-2 (CI monitoring) and report status back to the orchestrator, which runs the reviewer for each stage (as a separate agent instance where available, or self-review with a `SELF-REVIEWED` marker otherwise — see [review-gates.md](review-gates.md)) and re-invokes this implementer for fix rounds if needed. Stage 2.5 (pattern propagation) only ever runs in Autonomous/batch mode, coordinated by the orchestrator across all in-flight issues — never in Interactive mode.
+**Orchestrated**: skip — stop after 3-3 and report; the orchestrator runs the
+gates and re-invokes this implementer for fix rounds.
 
-### 3-2. Monitor CI
+### 3-3. Monitor CI
 
-After the PR/MR is created, verify that CI passes. See the platform-specific guide for the exact command.
+Watch the PR/MR checks (see the platform guide). On failure: investigate, push
+a fix commit if fixable (max 1 fix round), re-watch. If not fixable or CI is
+not configured, record it under Risk Areas and in Gate Results.
 
-**Loop (max 1 fix attempt):**
+### 3-4. Flip Draft to Ready
 
-1. Run the CI monitoring command and wait for all checks to complete.
-2. If all checks pass → proceed to 3-3.
-3. If a check fails:
-   - Investigate the failure. Common causes: missed auto-fix, stale generated file, type error caught only in CI.
-   - If fixable: push a fix commit and re-run CI monitoring.
-   - If not fixable or CI is not configured: note the failure in the PR description and proceed.
+Only when **both** review-gate stages pass **and** CI is green, mark the PR/MR
+ready for review (see the platform guide). If either never passes within its
+fix rounds, the PR **stays a draft** with the unresolved state recorded in
+Gate Results / Risk Areas — a draft with honest concerns beats a "ready" PR
+that isn't.
 
-**Autonomous mode**: same investigate/fix loop, but if the failure is not fixable within the 1 retry, note it in the PR description and continue — this issue will be reported as status `DONE_WITH_CONCERNS` rather than proceeding silently as if nothing happened.
+**Orchestrated**: the orchestrator performs this flip after it runs the gates
+(see batch.md B2-3).
 
-### 3-3. Comment on Issue
+### 3-5. Comment on the Issue
 
-If the issue tracker supports comments (e.g., Backlog), post a comment on the issue with the PR/MR link. This is especially useful for cross-platform setups where the PR is not automatically linked to the issue.
+If the issue tracker supports comments (e.g. Backlog, or cross-platform setups
+where the PR is not auto-linked), post the PR/MR link on the issue.
 
-### 3-4. Report Status
+### 3-6. Report
 
-**Interactive mode**: return the PR/MR URL to the user directly, along with a plain-language summary of the outcome (equivalent to one of the statuses below).
+**Direct — chat recap**, the session-side report. It must contain:
 
-**Autonomous mode**: return exactly one of the following statuses to the orchestrator, plus the PR/MR URL or failure details:
-- `DONE` — PR created, CI passing, review gates not yet run (orchestrator runs them next)
-- `DONE_WITH_CONCERNS` — PR created but with noted concerns (unfixable CI failure, unresolved self-review issue, or an undecidable design decision that was resolved by convention)
-- `NEEDS_CONTEXT` — missing or too-vague information, cannot proceed (see 1-1, 1-3)
-- `BLOCKED` — failed after retries, with error details (see 2-3)
+- **PR**: URL and state — ready for review, or still draft and why.
+- **Decisions**: every implementation-time decision made (the PR body has the
+  rationale; the recap lists them).
+- **Issue write-backs**: every write performed against the issue (Design
+  Decisions appended, status changes, comments).
+- **Review focus**: the few places a human reviewer should look first.
+- **Gates**: one line per gate — self-review rounds/findings, security review,
+  Stage 1, Stage 2, CI.
+
+**Orchestrated — one status line** to the orchestrator, plus the PR/MR URL or
+failure details:
+
+- `DONE` — draft PR created, CI passing; gates not yet run (orchestrator runs them)
+- `DONE_WITH_CONCERNS` — draft PR created with concerns recorded (unfixable CI
+  failure, remaining self-review issue)
+- `NEEDS_CONTEXT` — undecidable decision or missing critical field (1-1, 1-3)
+- `BLOCKED` — checks failed after retries (2-4) or unresolved Critical/High
+  security finding (2-6)


### PR DESCRIPTION
## Decisions & Deviations

| Decision | Choice | Rationale |
|---|---|---|
| Context naming | `Interactive`/`Autonomous` → **Direct** (Single) / **Orchestrated** (Batch) invocation contexts | Both contexts now run the same autonomous pipeline; the old names implied two different behaviors, the new ones name only who coordinates and where reports go |
| Check-failure semantics per context | Direct: record in PR Risk Areas and continue (PR stays draft); Orchestrated: `BLOCKED` unchanged | #93 removes Single-mode escalations; #93 also says Batch behavior is retained, and `BLOCKED` drives the batch failure cascade |
| Security review placement | New workflow.md step 2-6, after checks + self-review, before commit/push, in **both** contexts | The settled decision names push as the leak boundary; Batch implementers push too, so exempting them would reopen the boundary |
| Security review portability | New "Security review" capability row in Environment Adaptation; `/security-review` appears only as the Claude Code example | AGENTS.md forbids prescribing product-specific tools as the only path |
| Plan-mode claim re-evaluation | The old "accidental-rejection UI" claim is dropped as load-bearing rather than re-asserted; opt-in-only is justified by round-trip cost alone | Required by #93; the UI claim was not re-verified, and the rationale holds regardless of UI quality (recorded in the eval log entry) |
| Backlog write-backs | Issue **comment** via `bee issue comment` (verified command), not a description edit | `bee` description-edit flags could not be verified; inventing flags violates the fact-checking rule |
| Platform branch flows | Removed "New branch / Current branch" sections from all three platform guides | The location question no longer exists; keeping the flows would contradict workflow.md 2-1 |
| Own-PR branch name | Used the host-prepared `claude/aoshimash-skills-issue-93-910a94` instead of `feat/93-…` | Matches new workflow.md 2-1: reuse a branch already prepared for the run |
| No plan-approval gate for this run | Proceeded directly per the settled decisions in #91/#93 and user-level config, deviating from the invoked (pre-rewrite) skill version | The gate being removed is the subject of this issue; the decision stores already record the answer |

## Risk Areas

- **Wholesale rewrite**: workflow.md and SKILL.md are full replacements, not patches — review them as new documents, not diffs.
- **Cross-file step references**: batch.md and review-gates.md reference new workflow.md step numbers (3-3, 3-4, 3-6, 2-6). Verified by grep, but a renumbering slip would silently misroute an implementer.
- **Orchestrated `DONE_WITH_CONCERNS` breadth**: batch.md B2-3 step 5 reports gates-never-passed PRs as `DONE_WITH_CONCERNS`; the batch summary is the only place a human sees that these PRs are still drafts.

## Acceptance Criteria → Evidence

- [x] Zero user interactions on a well-formed issue — workflow.md removes plan approval (1-4), location question (2-1), per-decision questions (1-3), and check/self-review escalations (2-4, 2-5); SKILL.md Phase 0 drops the location step. This PR itself ran invocation → recap with zero questions.
- [x] Undecidable decision → one batched question, answers appended to Design Decisions before implementation — workflow.md 1-3 category 3; write-back commands added to all three platform guides.
- [x] PR body leads with Decisions/Deviations/Risk, maps AC → evidence, mechanical lists last; repo templates take precedence — workflow.md 3-1 body skeleton + template-precedence paragraph; template lookup sections in platform guides. This PR body follows that format.
- [x] Draft PR flipped to ready only after CI + both gates — workflow.md 3-1/3-4, review-gates.md flow diagram end state, batch.md B2-3 step 5.
- [x] Security review before push; Critical/High block the push; outcome in PR body — workflow.md 2-6; Gate Results slot in the 3-1 skeleton; capability row in SKILL.md. Exercised on this PR (see Gate Results).
- [x] Recap reports PR URL, decisions, write-backs, review focus — workflow.md 3-6 Direct report contract; eval criterion 15.
- [x] Plan mode opt-in only — workflow.md 1-4 note + SKILL.md Single Mode note; eval case 11.
- [x] Two-stage gates and Batch mode preserved — review-gates.md stages/rounds unchanged (only Single-mode failure routing changed); batch.md DAG, dispatch, cascade untouched except draft→ready orchestration.
- [x] eval-cases.md rewritten + eval log records a run — 22 new criteria, 24 rewritten cases, 2026-07-27 log entry with a full desk-check table (24/24 pass).

## Gate Results

- Self-review: 2 rounds, 4 issues found, 4 fixed, 0 remaining (stale `escalate in Single` in review-gates.md Reviewer Dispatch; stale "New branch / Current branch" flow labels in 3 platform guides)
- Security review: `/security-review` on the pending diff, before push — 0 findings (docs-only changeset, no secrets, no executable surface)
- Spec compliance (Stage 1): **PASS**, 0 issues — fresh-context reviewer; all 9 ACs mapped to evidence, no scope creep
- Code quality (Stage 2): **PASS** after 1 fix round — fresh-context reviewer; round 1: 0 Critical / 2 Important / 7 Minor → both Important + 4 Minor fixed (commit d998ae4), 3 pre-existing Minors deferred to a follow-up task; re-review: PASS with 2 residual wording Minors, also fixed
- CI: **pass** (claude-review)

## Changes

- `SKILL.md` — rewritten: autonomous principles, Security review capability row, Phase 0 without the location step, Single/Batch summaries
- `references/workflow.md` — rewritten: Invocation Contexts table, decision-store resolution + batched question + write-back, security review step 2-6, draft PR with review-first body, ready flip, recap contract
- `references/review-gates.md` — Single-mode failure routing → record-and-stay-draft; flow diagram ends at the ready flip
- `references/batch.md` — Orchestrated-context wording, implementer instruction (draft PR, stop after 3-3), orchestrator ready flip (B2-3 step 5)
- `references/platform-github.md` / `platform-gitlab.md` — draft create / ready flip / body update / comment read / issue write-back / template lookup commands (gh verified locally, glab against official CLI docs)
- `references/platform-backlog.md` — comment-based write-back, research-comment note, draft/ready delegation to the code host
- `references/eval-cases.md` — criteria and cases rewritten for the autonomous flow; historical log preserved; 2026-07-27 desk-check entry added

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
