### PR TITLE
Close three implement-issue gaps flagged in PR #99 review

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/SKILL.md
@@ -79,7 +79,8 @@ below use capability terms; map them to your environment as follows.
    - GitLab: [references/platform-gitlab.md](references/platform-gitlab.md)
    - Backlog: [references/platform-backlog.md](references/platform-backlog.md)
 2. Obtain the issue identifier(s). If none are provided, list open issues from
-   the platform (when supported) and ask the user to select.
+   the platform (see the platform guide's issue-listing section) and ask the
+   user to select.
 3. **Mode routing:**
    - **Multiple issues referenced** — a list of numbers, "these issues", a
      milestone, a label, or "run sprint" / "スプリント実行" phrasing →
@@ -148,7 +149,8 @@ See [references/batch.md](references/batch.md) for the full procedure.
    build a DAG from the union; detect cycles and ask the user how to resolve
    them; compute parallel execution groups (topological levels); visualize the
    plan; get approval via a user choice (see Environment Adaptation) with
-   options Approve / Reorder / Abort.
+   options Approve / Reorder / Abort (Reorder collects dependency-graph edits
+   and re-presents the plan — see batch.md B1-3).
 2. **Execution loop** — for each group, implement its issues, each in its own
    git worktree, executing [references/workflow.md](references/workflow.md) in
    the **Orchestrated** context (see that file's Invocation Contexts). Where

--- a/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/batch.md
@@ -69,7 +69,19 @@ Group 3 (sequential, after Group 2):
   #105 — Integration tests [Medium] ← depends on #103, #104
 ```
 
-Ask the user to choose (see Environment Adaptation in SKILL.md) — "Proceed with this execution plan?" with options: Approve / Reorder / Abort.
+Ask the user to choose (see Environment Adaptation in SKILL.md) — "Proceed with this execution plan?" with options:
+
+- **Approve** — proceed to Phase B2.
+- **Reorder** — adjust the plan. Execution order is derived from the DAG, so
+  reordering means editing its inputs: collect the user's changes (exclude an
+  issue from the batch, add a dependency edge to force one issue after another,
+  or drop a body-declared edge the user says is stale), apply them to the B1-1
+  mapping, then rebuild the DAG (B1-2) and re-present the plan. Repeat until
+  the user approves or aborts. Platform-registered relationships the user drops
+  are ignored for this batch only — note the override in the re-presented plan;
+  do not edit them on the platform. A requested order that contradicts a kept
+  dependency edge cannot be applied; say which edge conflicts and re-ask.
+- **Abort** — stop without implementing anything.
 
 ## Phase B2: Execution Loop
 
@@ -101,7 +113,7 @@ Run each issue's implementer with an instruction set that includes:
 2. The absolute path to the worktree already created for it (step B2-1) — the implementer works there, it does not create its own.
 3. The absolute paths to this skill's [workflow.md](workflow.md) and the relevant `platform-*.md` guide, with the instruction:
    > "Read these files, then execute workflow.md Phases 1–3 in the **Orchestrated context** inside the given worktree. Create the PR/MR as a draft and leave it a draft. Skip the review gates (3-2) and the ready flip (3-4) — the orchestrator does both; do run CI monitoring (3-3) and the issue comment (3-5). Then return exactly one status line (`DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`) plus the PR/MR URL or failure details, per workflow.md step 3-6."
-4. The project's CLAUDE.md path.
+4. The path to the project's agent instructions (e.g. CLAUDE.md, AGENTS.md), when the project has one.
 
 Resolve the absolute paths to `workflow.md` and the platform guide before starting the implementer (they live alongside this file in the skill's `references/` directory) — do not rely on the implementer inferring them. When running as a separate agent instance, pass this as its dispatch prompt; when running in the current context, follow it directly.
 

--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -644,3 +644,40 @@ All 24 cases pass the desk-check. This entry records a static evaluation
 autonomous flow is the session that produced this rewrite's own PR, which
 followed the new pipeline (no plan gate, security review before push, draft
 PR with review-first body, gates, ready flip, recap).
+
+### 2026-07-27 — PR #99 review follow-ups: Reorder procedure, agent-instructions wording, open-issue listing
+
+Three pre-existing gaps flagged during PR #99's code-quality review but out of
+that PR's scope:
+
+- **Reorder is now a defined procedure** (batch.md B1-3, summarized in
+  SKILL.md's Batch summary): since execution order is derived from the DAG,
+  Reorder collects edits to the DAG's inputs (exclude an issue, add an edge,
+  drop a stale body-declared edge), rebuilds the graph, and re-presents the
+  plan until Approve or Abort. Platform-registered relationships are only
+  overridden for the batch, never edited on the platform; an order that
+  contradicts a kept edge is rejected with the conflicting edge named.
+- **Neutral agent-instructions wording** completed in the files PR #99 did not
+  touch for it: batch.md B2-2 item 4, review-gates.md Stage 2 reviewer context,
+  and the three platform guides' Detect Platform steps and config-example
+  headings now say "the project's agent instructions (e.g. CLAUDE.md,
+  AGENTS.md)" instead of prescribing CLAUDE.md, per AGENTS.md portability
+  rules.
+- **Open-issue listing commands added** for GitHub (`gh issue list --state
+  open --limit 20`, flags verified against local `gh` help) and GitLab
+  (`glab issue list`, open-by-default and `--output json` verified against the
+  official CLI docs), backing SKILL.md Phase 0 step 2, which previously only
+  Backlog's guide supported; SKILL.md now points at the platform guide's
+  issue-listing section instead of hedging with "(when supported)".
+
+Desk-check of the affected cases (static inspection, no live run):
+
+| Case | Result | Notes |
+|------|--------|-------|
+| 13 | Pass | Platform detection reads the same `## Issue Tracker` section whatever the instructions file is named; Backlog guide changes are wording-only |
+| 16 | Pass | Approve path through B1-3 unchanged; Reorder definition is additive |
+| 20 | Pass | Manual-list plan approval offers the same three options; Reorder now has defined semantics instead of none |
+| 22 | Pass | Phase 0 routing unchanged; step 2 listing now resolvable on all three platforms |
+
+No behavior removed: Approve/Abort semantics, the DAG builder, and all
+previously documented platform commands are unchanged.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-backlog.md
@@ -7,7 +7,7 @@
 ## Detect Platform
 
 Check in order:
-1. CLAUDE.md `## Issue Tracker` section with `platform: backlog`
+1. The project's agent instructions (e.g. CLAUDE.md, AGENTS.md): an `## Issue Tracker` section with `platform: backlog`
 2. Ask the user (Backlog cannot be inferred from git remote)
 
 ## Read Issue
@@ -23,7 +23,7 @@ bee issue view PROJ-123 --json
 
 ## List Issues
 
-To let the user select an issue when no identifier is provided (Single mode, Phase 0):
+To let the user select an issue when no identifier is provided (Phase 0 step 2):
 
 ```bash
 bee issue list -p <project_key> -S <open_status_id> -L 20
@@ -112,7 +112,9 @@ Post a comment on the issue (e.g., with PR link):
 bee issue comment PROJ-123 -b "PR created: <pr_url>"
 ```
 
-## CLAUDE.md Config Example
+## Agent Instructions Config Example
+
+Add to the project's agent instructions (e.g. CLAUDE.md, AGENTS.md):
 
 ```markdown
 ## Issue Tracker

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-github.md
@@ -7,7 +7,7 @@
 ## Detect Platform
 
 Check in order:
-1. CLAUDE.md `## Issue Tracker` section with `platform: github`
+1. The project's agent instructions (e.g. CLAUDE.md, AGENTS.md): an `## Issue Tracker` section with `platform: github`
 2. Git remote URL contains `github.com`
 
 ## Read Issue
@@ -20,6 +20,16 @@ Structured JSON:
 ```bash
 gh issue view <number> --json title,body,labels,assignees,state
 ```
+
+## List Open Issues
+
+To let the user select an issue when no identifier is provided (Phase 0 step 2):
+
+```bash
+gh issue list --state open --limit 20
+```
+
+Present the list to the user and ask them to select one.
 
 ## Platform-Level Issue Relationships
 
@@ -229,7 +239,9 @@ gh issue close <number>
 gh issue reopen <number>
 ```
 
-## CLAUDE.md Config Example
+## Agent Instructions Config Example
+
+Add to the project's agent instructions (e.g. CLAUDE.md, AGENTS.md):
 
 ```markdown
 ## Issue Tracker

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
@@ -7,7 +7,7 @@
 ## Detect Platform
 
 Check in order:
-1. CLAUDE.md `## Issue Tracker` section with `platform: gitlab`
+1. The project's agent instructions (e.g. CLAUDE.md, AGENTS.md): an `## Issue Tracker` section with `platform: gitlab`
 2. Git remote URL contains `gitlab.com` or a known GitLab instance
 
 ## Read Issue
@@ -20,6 +20,17 @@ Structured JSON:
 ```bash
 glab issue view <number> --output json
 ```
+
+## List Open Issues
+
+To let the user select an issue when no identifier is provided (Phase 0 step 2):
+
+```bash
+glab issue list
+```
+
+Open issues are listed by default; add `--output json` for structured output.
+Present the list to the user and ask them to select one.
 
 ## Detect Child Items of a Parent
 
@@ -139,7 +150,9 @@ Used by Phase 0's closed-issue check ("Reopen and implement"):
 glab issue reopen <number>
 ```
 
-## CLAUDE.md Config Example
+## Agent Instructions Config Example
+
+Add to the project's agent instructions (e.g. CLAUDE.md, AGENTS.md):
 
 ```markdown
 ## Issue Tracker

--- a/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/review-gates.md
@@ -79,7 +79,7 @@ If spec compliance fails:
 Review with:
 
 - The PR diff
-- Project conventions (CLAUDE.md path)
+- Project conventions (path to the repository's agent instructions, e.g. CLAUDE.md or AGENTS.md)
 - Instructions below
 
 **Batch mode**: the orchestrator runs a dedicated reviewer — a separate agent instance where available, otherwise self-review with the `SELF-REVIEWED` marker (see Reviewer Dispatch above). **Single mode**: the main agent runs the review the same way — a separate fresh-context instance where available, direct self-review with the marker otherwise.


### PR DESCRIPTION
Closes three pre-existing implement-issue gaps flagged during PR #99's code-quality review but out of that PR's scope. **Stacked on #99** (base branch: `claude/aoshimash-skills-issue-93-910a94`); it will retarget to `main` automatically when #99 merges.

## Decisions

- **Reorder defined as DAG-input editing, not free reordering** (`references/batch.md` B1-3). Execution order is derived from the dependency graph ("the DAG is the scheduler", SKILL.md principle 7), so an order the user asks for can only be realized by editing the graph's inputs: exclude an issue, add an edge, or drop a stale body-declared edge — then rebuild and re-present until Approve or Abort. Platform-registered relationships are overridden for the batch only, never edited on the platform; a requested order conflicting with a kept edge is rejected with the edge named. SKILL.md's Batch summary now carries a one-line pointer.
- **Example-position naming for the instructions file.** Remaining prescriptive "CLAUDE.md" wording became "the project's agent instructions (e.g. CLAUDE.md, AGENTS.md)" — the file name appears only as an example, matching the AGENTS.md portability rule and the wording SKILL.md/workflow.md already use after #99. Touched: `batch.md` B2-2 item 4, `review-gates.md` Stage 2 reviewer context, and the three platform guides' Detect Platform steps plus their config-example headings (renamed to "Agent Instructions Config Example").
- **Listing commands verified against primary sources.** `gh issue list --state open --limit 20` verified against local `gh` help output; `glab issue list` (open by default, `--output json`) verified against the official GitLab CLI docs. SKILL.md Phase 0 step 2 now points at "the platform guide's issue-listing section" instead of hedging with "(when supported)", since all three guides now carry a command.

## Changes

- `references/batch.md` — B1-3 approval options expanded with the Reorder procedure; B2-2 neutral wording
- `SKILL.md` — Phase 0 step 2 pointer; Batch summary Reorder pointer
- `references/platform-github.md` / `platform-gitlab.md` — new "List Open Issues" sections; neutral wording
- `references/platform-backlog.md` — neutral wording; listing-section framing aligned to "Phase 0 step 2"
- `references/review-gates.md` — neutral wording in Stage 2 reviewer context
- `references/eval-cases.md` — evaluation-log entry (2026-07-27) with a desk-check of affected cases 13, 16, 20, 22

## Verification

- Desk-check of eval cases 13, 16, 20, 22 recorded in the evaluation log — all pass; no behavior removed (Approve/Abort semantics, DAG builder, and previously documented commands unchanged). SELF-REVIEWED (no independent reviewer available in this session).
- `grep -rn "CLAUDE.md"` over the skill directory: every remaining mention is in example position (`e.g. CLAUDE.md, AGENTS.md`) or the historical eval log.
- CLI flags fact-checked as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
