### PR TITLE
Update the README's implement-issue flow to the autonomous pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,25 @@ The plugin is only one distribution channel. Each skill under `plugins/aoshimash
 
 ## Issue Workflow
 
-`create-issue` and `implement-issue` cover the full issue lifecycle. Each adapts to scale: `create-issue` goes from a quick single issue to a researched, user-annotated design decomposed into an issue hierarchy; `implement-issue` goes from one interactive implementation to a dependency-ordered parallel batch. The issue tracker is the interface between them — either skill also works standalone, since a hand-written issue works with `implement-issue` and a `create-issue` issue can be implemented manually.
+`create-issue` and `implement-issue` cover the full issue lifecycle. Each adapts to scale: `create-issue` goes from a quick single issue to a researched, user-annotated design decomposed into an issue hierarchy; `implement-issue` goes from one autonomous implementation to a dependency-ordered parallel batch. The issue tracker is the interface between them — either skill also works standalone, since a hand-written issue works with `implement-issue` and a `create-issue` issue can be implemented manually.
 
 ```
 create-issue                               implement-issue
 ┌─────────────────────────────┐            ┌──────────────────────────────┐
 │ Lightweight Flow (default)  │            │ Single Mode (default)        │
-│  Gather → Analyze → Draft   │            │  Plan → Approve → Implement  │
-│  → Self-eval → Create       │            │  → PR → Review gates         │
-│                             │            │                              │
-│ Design Flow (escalated)     │  Issues    │ Batch Mode (parent/milestone │
-│  Research → Design          │ ────────→  │  /label/list)                │
-│  → Annotation cycle         │  (tracker) │  Dependency graph            │
-│  → Split Proposal (asks)    │            │  → Parallel worktrees        │
-│  → Issue hierarchy          │            │  → Review gates + pattern    │
+│  Gather → Analyze → Draft   │            │  Understand & decide         │
+│  → Self-eval → Create       │            │  → Implement & verify        │
+│                             │            │  → Draft PR → review gates   │
+│ Design Flow (escalated)     │            │  → CI → automated reviewers  │
+│  Research → Design          │  Issues    │  → Ready → Harvest decisions │
+│  → Annotation cycle         │ ────────→  │                              │
+│  → Split Proposal (asks)    │  (tracker) │ Batch Mode (parent/milestone │
+│  → Issue hierarchy          │            │  /label/list)                │
+│                             │            │  Dependency graph            │
+│                             │            │  → Parallel worktrees        │
+│                             │            │  → Review gates + pattern    │
 │                             │            │    propagation → Summary     │
+│                             │            │  → Harvest (once per batch)  │
 └─────────────────────────────┘            └──────────────────────────────┘
 ```
 
@@ -48,9 +52,11 @@ create-issue                               implement-issue
 # Complex request → research → design → annotate plan → propose a split → create issue(s)
 
 > /implement-issue
-# Single issue → plan → approve → implement → PR → two-stage review
+# Single issue → understand & decide (no routine questions) → implement & verify
+#   → security review → draft PR → two-stage review gates → CI
+#   → automated reviewers → flip to ready → harvest decisions → recap
 # Parent issue / milestone / label / list → confirm batch → dependency graph
-#   → parallel worktrees → review gates → summary
+#   → parallel worktrees → review gates → summary → harvest once
 ```
 
 **Key properties:**
@@ -59,8 +65,12 @@ create-issue                               implement-issue
 - **Works with humans and AI** — Issues created by `create-issue` are readable and implementable by anyone. Issues written by hand work with `implement-issue`. A good issue is the same for both readers: it explains why and what — never how.
 - **Splitting is always proposed, never automatic** — `create-issue` defaults to a single issue; a parent + sub-issue (or nested grandchild) hierarchy is only created after the user confirms a Split Proposal.
 - **Annotation cycle** — in the Design Flow, plans are refined through inline notes in a local markdown file. The file is deleted after issues are created.
+- **Autonomous implementation, decisions logged not asked** — `implement-issue` runs from invocation to PR without routine questions. There is no plan-approval gate: decisions come from the issue, its parent, the repository's agent instructions, or user-level configuration, and land in the PR body instead of in chat. Only genuinely undecidable decisions stop the run, as one batched question whose answers are written back to the issue.
 - **Parallel execution** — in Batch mode, `implement-issue` resolves issue dependencies as a DAG and dispatches independent issues in parallel using git worktrees.
 - **Two-stage review, always** — every PR (single or batch) is reviewed for spec compliance (does it match the issue?) then code quality (is it well-written?). Pattern propagation across in-flight PRs only applies in Batch mode.
+- **Nothing unsafe leaves the machine** — a security review of the pending changes runs after checks and self-review pass and before the branch is pushed. Unresolved Critical/High findings block the push.
+- **Machines finish before humans start** — every PR opens as a **draft** and flips to ready-for-review only once the review gates pass, CI is green, and the repository's own automated reviewers have been responded to. A PR that can't clear them stays a draft with the unresolved state recorded. Human review comments are never auto-addressed — those go through `respond-to-pr-review`.
+- **Decisions are harvested after delivery** — once the PR is ready, decisions that generalize past the issue are offered for promotion into a durable store: the repository's agent instructions (as a separate PR) or user-level configuration. One batched confirmation, nothing written without it, and most runs produce no candidates at all.
 
 ### Design Philosophy
 
@@ -92,9 +102,9 @@ superpowers also contributed a staged workflow with hard approval gates, and bot
 **Autonomy-first revision (2026, original):**
 - Earlier versions gated implementation behind plan approvals and required every design decision to be settled at issue-creation time. Current models plan natively and follow intent-level instructions reliably, while user round trips became the scarce resource — so pre-approval gates are replaced by autonomous execution reviewed post-hoc at the PR
 - Two-layer decision timing — structural decisions (shape of a split, cross-issue consistency, high reversal cost) are recorded in issues at creation time; local, reversible decisions are delegated to implementation time, guided by the decision principles in the [shared rules corpus](plugins/aoshimash-skills/rules/agent-rules.md), and logged in the PR. When in doubt, a decision belongs on the issue side
-- Never ask twice — before asking, check the decision stores (issue body, repository agent instructions, user-level configuration); every answer is written back to the store matching its scope
+- Never ask twice — before asking, check the decision stores (issue body, repository agent instructions, user-level configuration); every answer is written back to the store matching its scope. The loop closes from the write side too: decisions the implementer made on its own are harvested once the PR is delivered, and the ones that generalize are offered for promotion into a durable store in one batched confirmation — a rule that binds every later run is the user's to approve, not the run's
 - Review-first PRs — removing mid-run gates concentrates human judgment at the PR, so the PR body is ordered for the reviewer: decisions and risk areas first, acceptance criteria mapped to verification evidence, mechanical changes last. Machines finish before humans start: PRs stay draft until CI, the internal review gates, and repository-configured automated reviewers are done; human review comments are never auto-addressed
-- This revision is the design contract the skills are being rewritten against; the workflow diagram and typical-usage examples above describe the skills as they are today and will be updated as the rewrites (tracked under [#91](https://github.com/aoshimash/skills/issues/91)) land
+- This revision is the design contract the skills are being rewritten against. `implement-issue` has been rewritten against it ([#93](https://github.com/aoshimash/skills/issues/93), [#94](https://github.com/aoshimash/skills/issues/94), [#95](https://github.com/aoshimash/skills/issues/95)) and the diagram above describes it as it is today; `create-issue` still runs its pre-revision flow until [#96](https://github.com/aoshimash/skills/issues/96) lands. Both are tracked under [#91](https://github.com/aoshimash/skills/issues/91)
 - Informed by Anthropic's published guidance at the time of this revision — [Prompting Claude Fable 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5), [Claude Code best practices](https://code.claude.com/docs/en/best-practices), and [harness design for long-running apps](https://www.anthropic.com/engineering/harness-design-long-running-apps) — and the Claude Code team's published workflow ([How Boris uses Claude Code](https://howborisusesclaudecode.com/)). Full rationale and decision log: [#91](https://github.com/aoshimash/skills/issues/91)
 
 ## Skills
@@ -102,7 +112,7 @@ superpowers also contributed a staged workflow with hard approval gates, and bot
 | Skill | Description |
 |-------|-------------|
 | [create-issue](plugins/aoshimash-skills/skills/create-issue/) | Create well-structured issues on any platform (GitHub, GitLab, Backlog) with codebase analysis — from a quick single issue to a designed issue hierarchy (research → design → annotation cycle → parent + sub-issues) |
-| [implement-issue](plugins/aoshimash-skills/skills/implement-issue/) | Read issues, plan, implement, and open PRs with two-stage review — single-issue interactive by default, with batch mode (dependency graph, worktrees, parallel subagents) for parent issues / milestones / labels / lists |
+| [implement-issue](plugins/aoshimash-skills/skills/implement-issue/) | Read issues, implement autonomously, and open review-first draft PRs — two-stage review, pre-push security review, automated-reviewer response, flip to ready, then post-PR decision harvesting; batch mode (dependency graph, worktrees, parallel agents) for parent issues / milestones / labels / lists |
 | [analyze-sessions](plugins/aoshimash-skills/skills/analyze-sessions/) | Analyze Claude Code session history to detect recurring patterns and propose improvements to skills and settings.json |
 | [respond-to-pr-review](plugins/aoshimash-skills/skills/respond-to-pr-review/) | Process PR review comments one by one — explain, confirm actions, implement fixes, and post reply comments |
 | [merge-renovate-prs](plugins/aoshimash-skills/skills/merge-renovate-prs/) | Merge Renovate PRs one at a time, autonomously by default — verify monitoring/revert preconditions, LLM pre-check, merge, post-merge verification, and auto-revert on failure; interactive per-PR-approval mode available |


### PR DESCRIPTION
## Decisions & Deviations

| Decision | Choice | Rationale |
|---|---|---|
| Include harvesting from the still-open #102 | Yes — documented as part of the current flow | **Requested explicitly**, and #102 itself listed this README drift under Risk Areas as out of its own scope. See Risk Areas: this PR should merge **after** #102 |
| Diagram shape | Kept the two-column ASCII boxes and grew the right box downward; left box padded with blanks | The instruction was to keep the existing diagram style. Both boxes stay at 75 characters per line |
| How much of the pipeline to draw | Named the observable checkpoints (draft PR → gates → CI → automated reviewers → ready → harvest); left internals (self-review rounds, 3-attempt check loop) to the skill docs | The diagram is an orientation aid; the per-step detail belongs in `references/workflow.md` |
| Where the security review appears | Typical-usage block and a Key-properties bullet, not the diagram | It is a gate, not a stage the reader tracks — and the right box was already the taller of the two |
| Design Philosophy touch-up | Two edits: extended the "Never ask twice" bullet with the write side, and replaced the "will be updated as the rewrites land" caveat | The former mirrors #102's `AGENTS.md` change verbatim in intent; the latter was a self-invalidating note that this PR invalidates |
| Per-skill state in the caveat | Named which rewrites landed (#93/#94/#95) vs. pending (#96) instead of dropping the sentence | `create-issue`'s half of the diagram is still pre-revision, so the reader needs to know the two columns are at different stages |
| `create-issue` column | Untouched | #96 is open; its flow is still accurate today |

## Risk Areas

- **Ordering dependency on #102.** `references/harvesting.md` and `workflow.md` step 3-7 exist only on #102's branch — they are not on `main`. Merging this PR first would leave the README describing a step the shipped skill does not have. Content was written against #102's branch as it stands; if that PR's harvesting semantics change in review, the harvesting lines here (diagram row, usage block, Key-properties bullet, "Never ask twice" extension) need the same change.
- **No `implement-issue` files are touched**, so nothing here is verified by the skill's own eval cases — the check is that the README matches `SKILL.md` / `references/workflow.md` / `references/harvesting.md`, done by reading.

## Acceptance Criteria → Evidence

- [x] **Diagram no longer shows a plan-approval gate** — right box now reads `Understand & decide → Implement & verify → Draft PR → review gates → CI → automated reviewers → Ready → Harvest decisions`, matching `SKILL.md` "Single Mode" steps 1–4
- [x] **Typical-usage block matches the current flow** — rewritten to the same sequence, with the pre-push security review and the recap included
- [x] **Skill table entry is current** — "Read issues, implement autonomously, and open review-first draft PRs …", replacing "plan … single-issue interactive by default"
- [x] **Post-PR harvesting is documented** — diagram rows (Single and Batch), usage block, a Key-properties bullet, and the "Never ask twice" bullet; sourced from `references/harvesting.md` (precondition: PR reached ready; one batched confirmation; repository PR or user-level config; once per batch in Batch mode)
- [x] **Design Philosophy checked** — two edits made (see Decisions); the superpowers/Boris-Tane provenance bullets and the "Autonomy-first revision" framing were already correct and are unchanged
- [x] **Diagram style preserved** — verified every line of the block is 75 characters wide, box borders unchanged

## Changes

- `README.md` — flow diagram, typical-usage block, Key properties (3 bullets added, ordering preserved), Design Philosophy (2 bullets edited), skill table row for `implement-issue`

Refs #91