### PR TITLE
Fix invalid glab api --jq usage in the GitLab platform guides

### DIFF
--- a/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/eval-cases.md
@@ -1138,3 +1138,41 @@ worded rule reads as approvable. Hence B's provenance rule: what is promotable i
 the decision the run made in its own words, never a request the run merely read,
 and such requests are reported to the human exactly as `automated-review.md` D
 already requires.
+
+### 2026-07-27 — `glab api` has no `--jq` flag (fact correction)
+
+The "Automated Reviewers" section of `platform-gitlab.md` documented reviewer
+detection as `glab api "projects/:id/merge_requests/<mr-iid>" --jq
+'[.reviewers[].username]'`. `glab api` registers no `--jq`/`-q` flag, so that
+command exits with an unknown-flag error before reaching the API: step A's
+second detection signal (accounts assigned as reviewers on the MR) could not
+have worked on GitLab as written, leaving detection to the `.gitlab-ci.yml` grep
+and bot-authored notes alone. Case 25's GitLab path fails on the previous text
+and passes on the corrected text.
+
+**Corrected fact.** `glab api` registers exactly `--hostname`, `-X/--method`,
+`-F/--field`, `-f/--raw-field`, `--form`, `-H/--header`, `-i/--include`,
+`--paginate`, `--input`, `--silent`, and `--output` — and nothing else. JSON
+filtering is a `jq` pipe over the raw response
+(`glab api "<endpoint>" | jq -r '<expr>'`), the same pattern the "Read MR
+Description" section uses. `jq` was added to the guide's Prerequisites, since it
+is now a required binary rather than a convenience. The filter itself also
+changed shape, in the spirit of the hardening commit `d551ac0`: emit one
+username per line (`.reviewers[]?.username`) rather than a JSON array, which
+`-r` cannot flatten, and let `[]?` absorb an MR whose `reviewers` is null.
+
+**Primary source.** `internal/commands/api/api.go` in the GitLab CLI source,
+fetched 2026-07-27:
+<https://gitlab.com/gitlab-org/cli/-/raw/main/internal/commands/api/api.go>.
+`glab` is not installed in this environment, so the flag set was verified against
+that source only, not by running the command; the replacement filter was run for
+real on jq 1.8.2 against a sample MR payload (populated, null, and absent
+`reviewers`). This is the fix the harvesting entry above flagged and deferred:
+its Stage 2 gate caught the same flag in the new "Read MR Description" section
+and corrected it there, leaving the two pre-existing occurrences for a change of
+their own. The automated-review entry's claim that its pass added "no unverified
+CLI flags" to the GitLab guide holds for the endpoints and for `glab mr checks`,
+but the `--jq` flag carried over from the `gh` commands verified alongside them
+went unchecked. The matching defect in respond-to-pr-review's GitLab guide was
+corrected in the same change; the GitHub guides' `--jq` usages are correct
+(`gh api` does provide the flag) and were left unchanged.

--- a/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md
@@ -3,6 +3,8 @@
 ## Prerequisites
 
 - `glab` CLI installed and authenticated (`glab auth status`)
+- `jq` installed — `glab api` registers no `--jq`/`-q` flag (unlike `gh api`), so
+  JSON filtering is a `jq` pipe over the raw response
 
 ## Detect Platform
 
@@ -141,8 +143,9 @@ project's agent instructions:
 # a reviewer that only runs on the ready transition cannot post while draft)
 grep -n "merge_request_event" .gitlab-ci.yml 2>/dev/null
 
-# Accounts assigned as reviewers on this MR
-glab api "projects/:id/merge_requests/<mr-iid>" --jq '[.reviewers[].username]'
+# Accounts assigned as reviewers on this MR (`glab api` registers no `--jq`
+# flag, unlike `gh api` — filter with a pipe)
+glab api "projects/:id/merge_requests/<mr-iid>" | jq -r '.reviewers[]?.username'
 ```
 
 Bot-authored notes already on the MR are the third signal — see the note

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/eval-cases.md
@@ -211,3 +211,29 @@
 | 2026-03-22 | Case 4 (No PR) | with_skill 100% / without_skill 50% | without_skill lacked structured next step (pre-refactor) |
 | 2026-04-08 | Case 1 (PR #44) | with_skill 5/6 criteria passed | Devin bot comments on refactored skill. Bot tone correct, grouping correct, batch approval worked. Verification Gate criterion not testable (old skill version loaded from marketplace). |
 | 2026-04-08 | Case 2-3, 5-8 | Not tested | Require specific PR scenarios (out-of-scope comments, informational-only, verification gate mismatch, GitLab MR) not available in current environment |
+| 2026-07-27 | Case 8 (GitLab MR) | Desk-check — Fail → Fixed | Every documented `glab api ... --jq` invocation would have exited with "unknown flag"; corrected to `jq` pipes (see below) |
+
+### 2026-07-27 — `glab api` has no `--jq` flag (fact correction)
+
+`platform-gitlab.md` documented five `glab api ... --jq '<expr>'` invocations
+(project ID, MR notes, approvals, and the two discussions lookups). `glab api`
+registers no `--jq`/`-q` flag, so each of those commands exits with an unknown-flag
+error before reaching the API — Case 8 could not have passed as written.
+
+**Corrected fact.** `glab api` registers exactly `--hostname`, `-X/--method`,
+`-F/--field`, `-f/--raw-field`, `--form`, `-H/--header`, `-i/--include`,
+`--paginate`, `--input`, `--silent`, and `--output` — and nothing else. JSON
+filtering is a `jq` pipe over the raw response
+(`glab api "<endpoint>" | jq -r '<expr>'`); the two lookups that pass `--arg nid`
+now pass it to `jq`, where it belongs. `jq` was added to the guide's
+Prerequisites, since it is now a required binary rather than a convenience.
+
+**Primary source.** `internal/commands/api/api.go` in the GitLab CLI source,
+fetched 2026-07-27:
+<https://gitlab.com/gitlab-org/cli/-/raw/main/internal/commands/api/api.go>.
+`glab` is not installed in this environment, so the flag set was verified against
+that source only, not by running the command; all five replacement filters were
+run for real on jq 1.8.2 against sample notes/discussions/approvals payloads.
+The likely origin of the defect is
+`gh api`, which *does* provide `--jq` — the GitHub guide's `--jq` usages are
+correct and were left unchanged.

--- a/plugins/aoshimash-skills/skills/respond-to-pr-review/references/platform-gitlab.md
+++ b/plugins/aoshimash-skills/skills/respond-to-pr-review/references/platform-gitlab.md
@@ -3,6 +3,8 @@
 ## Prerequisites
 
 - `glab` CLI installed and authenticated (`glab auth status`)
+- `jq` installed — `glab api` registers no `--jq`/`-q` flag (unlike `gh api`), so
+  every filter below is a `jq` pipe over the raw JSON response
 
 ## Detect Platform
 
@@ -22,7 +24,7 @@ Extract: `iid` (MR number), `title`, `web_url`.
 Get project ID (needed for API calls):
 
 ```bash
-glab api "projects/:id" --jq '.id'
+glab api "projects/:id" | jq -r '.id'
 ```
 
 ## Fetch Comments
@@ -33,7 +35,7 @@ GitLab uses a unified "notes" system for all comment types on MRs. Notes are dif
 
 ```bash
 glab api "projects/:id/merge_requests/{mr_iid}/notes?sort=asc" \
-  --jq '.[] | {id, body, author: .author.username, bot: .author.bot, type, system, resolvable, resolved, position}'
+  | jq '.[] | {id, body, author: .author.username, bot: .author.bot, type, system, resolvable, resolved, position}'
 ```
 
 ### Classify notes into comment types
@@ -51,7 +53,7 @@ GitLab uses approvals rather than review states. To check if a reviewer has requ
 
 ```bash
 glab api "projects/:id/merge_requests/{mr_iid}/approvals" \
-  --jq '{approved_by: [.approved_by[].user.username], approvals_required: .approvals_required, approvals_left: .approvals_left}'
+  | jq '{approved_by: [.approved_by[].user.username], approvals_required: .approvals_required, approvals_left: .approvals_left}'
 ```
 
 If a reviewer has NOT approved and has left resolvable comments → treat as equivalent to REQUEST_CHANGES for criticality tagging.
@@ -62,7 +64,7 @@ Check if the position still maps to a valid diff location using the discussions 
 
 ```bash
 glab api "projects/:id/merge_requests/{mr_iid}/discussions" \
-  --jq --arg nid "{note_id}" '.[] | select(.notes[0].id == ($nid | tonumber)) | .notes[0].position'
+  | jq --arg nid "{note_id}" '.[] | select(.notes[0].id == ($nid | tonumber)) | .notes[0].position'
 ```
 
 If `position` is null or references a line no longer in the current diff, the comment is outdated.
@@ -85,7 +87,7 @@ Find the discussion ID for the note:
 
 ```bash
 glab api "projects/:id/merge_requests/{mr_iid}/discussions" \
-  --jq --arg nid "{note_id}" '.[] | select(.notes[].id == ($nid | tonumber)) | .id'
+  | jq -r --arg nid "{note_id}" '.[] | select(.notes[].id == ($nid | tonumber)) | .id'
 ```
 
 Post a reply to the discussion:


### PR DESCRIPTION
`glab api` registers no `--jq`/`-q` flag. Every documented `glab api ... --jq '<expr>'`
invocation in the two GitLab platform guides exits with an unknown-flag error before
reaching the API, so the documented step cannot work as written. `gh api` *does* have
`--jq`, which is the likely origin of the defect. #102 caught the same flag in its own
new section and deferred these two occurrences to their own change — this is it.

## Decisions & Deviations

| Decision | Choice | Rationale |
|---|---|---|
| Replacement form | `glab api "<endpoint>" \| jq -r '<expr>'` | Already the pattern used by the "Read MR Description" section added in #102; keeps the two GitLab guides internally consistent |
| `--arg nid` placement | Moved onto `jq` | It was a jq argument all along, sitting behind a glab flag that does not exist |
| `jq` in Prerequisites | Added to both guides | It is now a required binary for the guides' commands, not a convenience — `glab` alone is no longer sufficient |
| Reviewer filter shape | `.reviewers[]?.username` instead of `[.reviewers[].username]` | `-r` cannot flatten a JSON array (verified), and `[]?` absorbs an MR whose `reviewers` is null — same hardening intent as `d551ac0` |
| GitHub guides | Left unchanged | `gh api --jq` is valid; a repo-wide grep confirmed every remaining `--jq` is a `gh` invocation |
| Version bump | Not included | `.claude-plugin/marketplace.json` is bumped post-merge by the `bump-version` workflow |

## Risk Areas

- **`glab` is not installed in this environment**, so no command was run end to end.
  The flag set was verified against the primary source (below) rather than by
  execution. The jq expressions themselves were run for real on jq 1.8.2 against
  sample notes/discussions/approvals/MR payloads, including the null and absent
  `reviewers` cases.
- The evaluation-log entry in `implement-issue` qualifies a claim in the
  automated-review entry ("no unverified CLI flags") rather than deleting it — the
  endpoints in that pass were verified; the flag carried over from the `gh` commands
  was not.
- **Process note, not a code risk:** this PR produced no CI at all while it had a
  merge conflict with `main` (#102 merged mid-change). GitHub does not dispatch
  `pull_request` workflows for a conflicting PR, so "draft, waiting on CI" and
  "conflicting, CI will never start" look identical from `gh pr checks`. Resolved by
  rebasing onto `main`; worth knowing for the skills' own CI-wait step.

## Verification

| Claim | Evidence |
|---|---|
| `glab api` has no `--jq`/`-q` flag | Primary source: [`internal/commands/api/api.go`](https://gitlab.com/gitlab-org/cli/-/raw/main/internal/commands/api/api.go), fetched 2026-07-27 — registers `--hostname`, `-X/--method`, `-F/--field`, `-f/--raw-field`, `--form`, `-H/--header`, `-i/--include`, `--paginate`, `--input`, `--silent`, `--output`, and nothing else |
| No `glab ... --jq` invocations remain | `grep -rn -- '--jq' plugins/` — every remaining hit is either a `gh` invocation or prose describing this defect |
| Replacement filters are valid jq | Each expression run on jq 1.8.2 against a sample payload; `-r` on `[.reviewers[].username]` confirmed to emit a JSON array (hence the reshape) |
| Backslash-continued `\| jq` form is valid shell | Run as written |
| Fact recorded per repo convention | Evaluation-log entry added to both affected skills' `references/eval-cases.md`, each naming the corrected flag set and the primary source |

## Gate Results

- Self-review: **SELF-REVIEWED** (no separate agent instance used). 1 round, 1 issue
  found and fixed — the first draft of the reviewer filter kept the array shape under
  `-r`, which is a no-op.
- CI: **PASS** — `claude-review` green (1m44s), after the rebase that cleared the
  conflict.
- Automated review: `claude-review` detected as the repository's reviewer; **no
  findings posted** — 0 rounds, nothing recorded as remaining.
- Project checks: handled by pre-commit hooks.

## Changes

- `plugins/aoshimash-skills/skills/respond-to-pr-review/references/platform-gitlab.md` — five `--jq` → `jq` pipes; `jq` added to Prerequisites
- `plugins/aoshimash-skills/skills/implement-issue/references/platform-gitlab.md` — "Automated Reviewers" reviewer detection converted and reshaped; `jq` added to Prerequisites
- both skills' `references/eval-cases.md` — evaluation-log entry with the corrected fact and its primary source