### PR TITLE
Add conference-planner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ superpowers also contributed a staged workflow with hard approval gates, and bot
 | [merge-renovate-prs](plugins/aoshimash-skills/skills/merge-renovate-prs/) | Merge Renovate PRs one at a time, autonomously by default — verify monitoring/revert preconditions, LLM pre-check, merge, post-merge verification, and auto-revert on failure; interactive per-PR-approval mode available |
 | [sync-agent-rules](plugins/aoshimash-skills/skills/sync-agent-rules/) | Write the shared conventions from [the rule corpus](plugins/aoshimash-skills/rules/agent-rules.md) into the current repository's `AGENTS.md` — detect which rules apply from the files actually present, write only those into a delimited managed block, and open a PR; additive, so nothing is removed without confirmation |
 | [collect-agent-rules](plugins/aoshimash-skills/skills/collect-agent-rules/) | Promote hand-written conventions from your own repositories into [the rule corpus](plugins/aoshimash-skills/rules/agent-rules.md) — confirm which repositories to scan, read their `AGENTS.md` over the API without cloning, ignore managed blocks, propose the conventions that recur across repositories, and open a PR for the ones approved one at a time |
+| [conference-planner](plugins/aoshimash-skills/skills/conference-planner/) | Plan attendance at a multi-day conference — extract the full program from fragmented sources, resolve every parallel slot with the user one slot at a time, register the choices to a calendar (or an `.ics` file), and build an offline single-file mobile schedule from a shared template |
 
 ## Structure
 
@@ -131,6 +132,7 @@ plugins/aoshimash-skills/
     └── <skill-name>/
         ├── SKILL.md              # Skill definition (required)
         ├── scripts/              # Helper scripts (optional)
+        ├── assets/               # Templates and static files (optional)
         └── references/           # Reference docs (optional)
 ```
 

--- a/plugins/aoshimash-skills/skills/conference-planner/SKILL.md
+++ b/plugins/aoshimash-skills/skills/conference-planner/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: conference-planner
+description: >
+  Plan attendance at a multi-day conference with parallel session tracks —
+  extract the full schedule, compare parallel sessions slot by slot so the
+  user picks each one, register the choices to their calendar (or deliver an
+  .ics file), and generate a single-file mobile HTML schedule for use at the
+  venue. Use this whenever the user mentions attending a conference, tech
+  event, or summit and wants help choosing sessions, building a schedule,
+  planning which talks to attend, or preparing for the event — including
+  follow-up requests like adding co-located/pre-conference days, registering
+  sessions to a calendar, or making a phone-friendly schedule. Also use when
+  the user shares a conference schedule URL and asks what to attend. Triggers
+  include "plan my conference schedule", "which sessions should I attend",
+  "カンファレンスの聴講計画を立てて", "どのセッションを聞くか選びたい",
+  "セッション選びを手伝って", "タイムテーブルから予定を組んで",
+  "カンファレンスの予定をカレンダーに登録して",
+  "会場用のスケジュール表を作って".
+---
+
+# Conference Planner
+
+Turn a conference program into a decided schedule, a calendar, and something usable on a phone at the venue.
+
+The hard parts are not what they appear. Getting complete schedule data is harder than it looks, session titles mislead, and at the venue the binding constraint is walking between rooms rather than session content. This skill encodes those lessons.
+
+## Scope and non-goals
+
+Produce three things:
+
+1. **A decided schedule** — every time slot resolved, chosen by the user
+2. **Calendar events** — one per session, with enough context to be useful standing in a hallway
+3. **A single-file mobile HTML** — works offline, oriented around "where do I go next"
+
+Default to a personal version containing the user's own logistics (travel, lodging, private notes). If they later want to share or publish it, offer to produce a scrubbed copy — do not assume a shared version is wanted.
+
+## The one rule that matters most
+
+**The user chooses every session. Do not decide for them.**
+
+Present the parallel options for a slot, summarize each faithfully, surface the trade-offs, then stop and wait. This is not politeness — the user knows their own context, and a plan they assembled is one they will actually follow.
+
+Two consequences worth internalizing:
+
+- If asked for a recommendation, give one. Unprompted, present options and stay neutral.
+- The user may go quiet on the framing and just say "B". That is a decision. Confirm it, then move to the next slot.
+
+It is easy to slip on this when a day looks minor — a pre-conference day, a community track, an evening event. Those slots get the same treatment.
+
+## Environment Adaptation
+
+This skill targets any agent implementing the Agent Skills spec. Instructions
+below use capability terms; map them to your environment as follows.
+
+| Capability | With native support (example) | Fallback |
+|---|---|---|
+| **User choice** — present numbered options, wait for an explicit selection | Structured question tool (e.g. Claude Code's `AskUserQuestion`) | Numbered options as plain text; wait for the user's reply |
+| **Browser automation** — load a JavaScript-rendered page and read its network traffic, storage, or rendered text | Browser tool (e.g. Claude in Chrome) | Static fetch plus any documented API the platform exposes; when neither yields the data, ask the user to open the page and paste or screenshot the program (options 1 and 5 in `references/data-extraction.md`) |
+| **Calendar integration** — read and create events on the user's calendar | Connected calendar tool (e.g. a Google Calendar connector) | Generate an `.ics` file — one `VEVENT` per event, same content rules as Phase 3 — and have the user import it |
+
+---
+
+## Phase 1: Get the complete schedule
+
+Incomplete data poisons everything downstream. A slot with a hidden third option produces a wrong choice.
+
+### Find every data source
+
+Conferences fragment across sources. Assume more exist than you have found:
+
+- **Main conference** — usually one schedule system
+- **Co-located / pre-conference days** — frequently a **separate instance** of the same system, on a different subdomain. A community day, an unconference, a workshop track
+- **Sponsor-hosted side events** — often an entirely independent site, sometimes only announced by email
+- **Offsite sessions** — training, sprints, socials. May require separate registration
+
+Ask the user what they registered for before starting. Registration confirmation emails are the reliable inventory. Then verify each has its own schedule.
+
+### Extract the data
+
+See `references/data-extraction.md` for concrete techniques per platform, and the escalation order when a page is JavaScript-rendered.
+
+The short version: try structured data before scraping text, and scraping before manual entry. Many conference schedule apps hold the entire program in browser storage or a JSON endpoint, which yields clean data in one shot.
+
+### Read every abstract in full
+
+This is the step most likely to be skipped and most likely to change decisions.
+
+**Titles and difficulty tags are unreliable.** A talk marked "Beginner" may carry the most novel content in its track. A generic title may hide a specific technical constraint that matters enormously to the user. The information that flips a choice is usually in the body of the abstract, not the title.
+
+Read all parallel sessions for every slot the user will attend — including ones that look obviously wrong. That judgment is often based on the title.
+
+### Verify completeness before proceeding
+
+Build a slot × room matrix and check for holes. Rooms that appear in some slots but not others are a signal — either a genuine gap or missing data. Resolve it before moving on.
+
+Also establish early: **will sessions be recorded?** This changes the entire calculus. If recordings are published, the unique value of being present is the Q&A and the hallway conversations, and preparation should aim at being able to ask a good question rather than at understanding the talk. If not recorded, coverage matters more. Ask, or check the event FAQ.
+
+---
+
+## Phase 2: Resolve slots one at a time
+
+Work chronologically. For each slot, present every parallel option and wait.
+
+**Announce the size of the process before the first question.** Count the slots that need a decision and state it up front, per day and in total — "Day 1 has 5 contested slots, Day 2 has 6, so 11 decisions ahead". The walk is deliberately one slot at a time so each option gets read properly; knowing the length is what makes that bearable. Restate the count when scope changes — a day added, a track dropped.
+
+### What each option needs
+
+- Title, speaker with affiliation, room, exact duration
+- A faithful summary drawn from the abstract — not from the title. Include specific claims, numbers, and named tools, since those are what distinguish options
+- Track or category if the conference uses them
+
+### What the slot needs
+
+Beyond the individual options, surface the structural facts:
+
+- **Asymmetric slots** are common — one room runs a 30-minute talk while another runs two 15-minute talks. Say so explicitly, and note that the short pair can be taken together
+- **Block structure** — many conferences assign each room to a community or theme for a stretch. Choosing one option may commit the next two slots by proximity. Flag this when it applies
+- **Room and floor transitions** with the actual gap in minutes
+- **Consecutive short talks** in the same room can be attended without decision cost. Group them
+- **Hard constraints** — a hard departure time for an offsite event, a session that requires separate registration
+
+### After the slots are resolved
+
+Extract the **cross-cutting axes**: two to four threads that run through the chosen sessions. These are what turn a list of talks into a coherent experience, and they make individual sessions memorable.
+
+The useful ones are often oppositions — two sessions taking incompatible positions on the same question — or progressions, where several sessions address consecutive stages of one problem. Look for sessions that share a named tool, a standard, or a failure mode.
+
+Also worth assembling if the user wants it: a list of people to catch and what to ask each, keyed to the sessions where they appear. Note which social events immediately follow which sessions, since that is when speakers are reachable.
+
+---
+
+## Phase 3: Register to the calendar
+
+Register through the calendar integration available in the environment; without one, fall back to an `.ics` file (see Environment Adaptation). Every content rule below applies to both paths.
+
+Check existing events for the conference dates first. The user may already have blocks registered, and duplicates are worse than nothing.
+
+**Never delete existing events without confirming.** If a previously-registered umbrella block now overlaps the detailed events, say so and ask what to do with it. On the `.ics` path existing events cannot be read — say so, and tell the user what to look for before importing.
+
+### Event structure
+
+One event per session. Prefix titles consistently (e.g. `[EventName] `) so the conference is scannable in a month view.
+
+Put in the location field the specific room, not just the venue — that is what the user reads on their phone while moving.
+
+The description carries what a hallway glance needs:
+
+- Speaker and affiliation
+- A summary of the content
+- **A short pre-session reminder** — the main claim, the contrast with another session, a movement warning, what to ask. Three to five bullets. This is the highest-value part
+- **The parallel sessions not chosen** — for when plans change or the user wants to find recordings later
+- The session URL
+
+### Practical shaping
+
+- **Register travel and transitions as events**, especially tight ones and offsite departures. A 40-minute walk between venues deserves a calendar block
+- **Group consecutive short talks** into one event rather than three. Three five-minute notifications is noise
+- Note venue quirks that will bite: badge pickup hours, a lobby on an unexpected floor, a building with no direct connection
+
+---
+
+## Phase 4: Build the mobile HTML
+
+**Start from `assets/template.html`.** It is a complete working schedule app with placeholder data: replace the data blocks at the top of its script (`EVENT`, `UI`, `FLOORS`, `URLBASE`, `DAYS`, `GLOSSARY`, `PREP`) and leave the styles and interaction code untouched, so every schedule this skill produces shares one UI. All UI label strings live in the `UI` object — set them to the user's language. Extend the template only for a feature the user asked for that it does not cover.
+
+Read `references/mobile-html.md` for the design rationale behind the template — needed to extend it coherently.
+
+The design principles that matter:
+
+**No external requests.** Venue Wi-Fi degrades badly when several thousand people share it. No CDN fonts, no CDN scripts, no remote images. Everything inline, single file. It should work in airplane mode.
+
+**Organize around movement, not content.** The question the user actually has at the venue is "where do I go next". Make the room and floor the most visually prominent element, color-code by floor, and insert transition rows automatically wherever the floor changes, showing the gap in minutes with a warning below some threshold.
+
+**Be time-aware.** During the event, open the current day, mark the in-progress session, scroll to it, and dim what has passed.
+
+**Include the pre-session reminder.** The same content as the calendar description, positioned as the first thing visible when a session expands.
+
+**Avoid browser storage.** Keep state in memory so the file behaves identically in restrictive viewers. On claude.ai, the artifact preview blocks `localStorage` and the failure is silent. If the user will self-host, offer the small patch that adds persistence.
+
+**Offer the study add-ons** rather than waiting to be asked: a searchable glossary of terms that will appear in the sessions, and per-night preparation notes. Both exist in the template as auxiliary tabs — fill them when accepted, drop the tabs when declined.
+
+### Delivery
+
+Ask how they intend to open it, since this determines the approach. Options include a self-hosted URL over a private network (works well if they already have that infrastructure), a static host, or a file in cloud storage as an offline fallback. Note that iOS Files previews may restrict JavaScript, so a local-HTML-capable app may be needed for the file fallback.
+
+On claude.ai, the built-in artifact publish feature is also an option; files above roughly 64KB appear to fail there, so measure the byte length first. Reducing size means cutting content, so raise it as a trade-off rather than silently trimming.
+
+---
+
+## Known pitfalls
+
+**Assuming one schedule source.** Co-located days routinely live on a separate subdomain. Sponsor events live off-platform entirely.
+
+**Trusting titles and difficulty tags.** Read the abstracts.
+
+**Deciding a day because it looks minor.** Pre-conference and community days get the same slot-by-slot treatment.
+
+**Optimizing session content while ignoring geometry.** A ten-minute transition between distant floors, against the flow of a keynote hall emptying, is a real constraint. Stairs may beat elevators.
+
+**Editing a file after presenting it.** If a file has been shown to the user and then modified on disk, the displayed version can go stale. Re-present it, or write the final version in one pass.
+
+**Silently cutting content to meet a size limit.** State the constraint and let the user choose what goes.
+
+**Compressing prose without verifying.** When trimming a generated file, verify afterward that scripts still parse and styles still resolve. Mechanical rename passes across CSS and template strings break easily.
+
+**Mixing personal logistics into something shareable.** Home addresses, travel routes, lodging, employer projects, private plans. If a shared version is ever requested, scrub deliberately and verify.

--- a/plugins/aoshimash-skills/skills/conference-planner/assets/template.html
+++ b/plugins/aoshimash-skills/skills/conference-planner/assets/template.html
@@ -1,0 +1,474 @@
+<!DOCTYPE html>
+<!--
+  conference-planner canonical template.
+  Replace ONLY the data blocks between "DATA START" and "DATA END" in the
+  script below (EVENT, UI, FLOORS, URLBASE, DAYS, GLOSSARY, PREP), plus the
+  <html lang> and <title> values. Keep the styles and the code after
+  "DATA END" unchanged so every generated schedule shares one UI.
+  Design rationale: ../references/mobile-html.md
+-->
+<html lang="ja"><!-- REPLACE: user's language -->
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Conference Schedule — REPLACE</title>
+<style>
+  :root {
+    --bg:#0f1115; --card:#181c23; --line:#2a2f3a;
+    --text:#e8eaed; --dim:#9aa3ae; --acc:#60a5fa; --warn:#f87171;
+  }
+  * { box-sizing:border-box; }
+  body {
+    margin:0; background:var(--bg); color:var(--text);
+    font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
+    -webkit-text-size-adjust:100%;
+  }
+  #hdr {
+    position:sticky; top:0; z-index:10;
+    background:rgba(15,17,21,.96); backdrop-filter:blur(6px);
+    border-bottom:1px solid var(--line);
+    padding-top:env(safe-area-inset-top);
+  }
+  #hdr h1 { margin:0; font-size:14px; font-weight:700; padding:10px 14px 2px; }
+  #tabs {
+    display:flex; gap:6px; overflow-x:auto; padding:8px 12px 10px;
+    scrollbar-width:none;
+  }
+  #tabs::-webkit-scrollbar { display:none; }
+  .tabbtn {
+    flex:0 0 auto; border:1px solid var(--line); background:transparent;
+    color:var(--dim); border-radius:999px; padding:6px 13px; font-size:13px;
+    font-family:inherit; cursor:pointer;
+  }
+  .tabbtn .tsub { font-size:10px; color:inherit; opacity:.8; }
+  .tabbtn.active {
+    background:var(--text); color:#0b0d10; border-color:var(--text);
+    font-weight:600;
+  }
+  #view {
+    max-width:640px; margin:0 auto;
+    padding:12px 2px calc(90px + env(safe-area-inset-bottom));
+  }
+  /* ---- schedule rows: floor rail + card ---- */
+  .row {
+    display:grid; grid-template-columns:46px 1fr; gap:8px;
+    padding:0 10px; margin-bottom:8px;
+  }
+  .rail { display:flex; flex-direction:column; align-items:center; gap:4px; }
+  .fbadge {
+    width:40px; text-align:center; border-radius:8px; padding:4px 0;
+    font-size:12px; font-weight:700; color:#0b0d10;
+  }
+  .spine { width:3px; flex:1; min-height:8px; border-radius:2px; opacity:.55; }
+  .card {
+    background:var(--card); border:1px solid var(--line); border-radius:12px;
+    padding:10px 12px;
+  }
+  .plain .card { background:transparent; border-style:dashed; opacity:.8; }
+  .plain .fbadge, .plain .spine { opacity:.45; }
+  .card.past { opacity:.45; }
+  .card.now { border-color:var(--acc); box-shadow:0 0 0 1px var(--acc); }
+  .meta { font-size:12px; color:var(--dim); }
+  .room { color:var(--text); font-size:13px; }
+  .tag {
+    border:1px solid var(--line); border-radius:6px; padding:0 5px;
+    font-size:10px; color:var(--dim);
+  }
+  .nowbadge {
+    background:var(--acc); color:#0b0d10; font-size:10px; font-weight:800;
+    border-radius:6px; padding:1px 6px;
+  }
+  .title { font-size:15px; font-weight:650; line-height:1.35; margin-top:2px; }
+  .spk { font-size:12px; color:var(--dim); margin-top:2px; }
+  .hasbody .head { cursor:pointer; }
+  .hasbody .title::after { content:" ▸"; color:var(--dim); font-size:12px; }
+  .open .title::after { content:" ▾"; }
+  .body {
+    display:none; margin-top:10px; padding-top:10px;
+    border-top:1px solid var(--line); font-size:13px; line-height:1.55;
+  }
+  .open .body { display:block; }
+  .pre {
+    background:rgba(96,165,250,.12); border-left:3px solid var(--acc);
+    border-radius:8px; padding:8px 10px; margin-bottom:8px;
+  }
+  .pre ul { margin:0; padding-left:18px; }
+  .pre li { margin:2px 0; }
+  .desc { margin:6px 0; }
+  .prog { margin:6px 0 6px 0; padding-left:20px; color:var(--dim); }
+  .ask { margin:6px 0; color:#ffd57e; }
+  .note { margin:6px 0; font-size:12px; color:var(--dim); }
+  .link { margin:8px 0 0; }
+  .link a { color:var(--acc); }
+  /* ---- transition rows ---- */
+  .trans {
+    margin:0 10px 8px 64px; padding:4px 10px;
+    display:flex; justify-content:space-between; gap:8px;
+    border:1px dashed var(--line); border-radius:8px;
+    font-size:12px; color:var(--dim);
+  }
+  .trans.warn { color:var(--warn); border-color:var(--warn); }
+  /* ---- glossary / prep tabs ---- */
+  .wrap { padding:0 12px; }
+  #gsearch {
+    width:100%; background:var(--card); border:1px solid var(--line);
+    color:var(--text); border-radius:10px; padding:10px 12px; font-size:14px;
+    font-family:inherit; margin-bottom:12px;
+  }
+  .ggroup h2, .night h2 { font-size:13px; color:var(--dim); margin:16px 0 8px; }
+  .gterm, .pitem {
+    background:var(--card); border:1px solid var(--line); border-radius:10px;
+    padding:8px 12px; margin-bottom:8px;
+  }
+  .gt { font-weight:700; font-size:14px; }
+  .gd { font-size:13px; margin-top:2px; line-height:1.5; }
+  .gs { font-size:11px; color:var(--dim); margin-top:4px; }
+  .pitem.ess { border-left:3px solid var(--acc); }
+  .pt { font-weight:650; font-size:14px; }
+  .pmin { font-weight:400; font-size:12px; color:var(--dim); }
+  .ptag {
+    font-size:10px; color:var(--acc); border:1px solid var(--acc);
+    border-radius:6px; padding:0 5px;
+  }
+  .ps { font-size:12px; color:var(--dim); margin-top:2px; }
+  .hide { display:none; }
+  .empty { color:var(--dim); text-align:center; padding:40px 0; font-size:13px; }
+  /* ---- jump-to-now ---- */
+  #jumpnow {
+    position:fixed; right:14px;
+    bottom:calc(14px + env(safe-area-inset-bottom));
+    display:none; border:none; border-radius:999px; padding:10px 16px;
+    background:var(--acc); color:#0b0d10; font-size:13px; font-weight:700;
+    font-family:inherit; cursor:pointer; box-shadow:0 4px 16px rgba(0,0,0,.4);
+  }
+  #jumpnow.show { display:block; }
+</style>
+</head>
+<body>
+<header id="hdr">
+  <h1 id="evname"></h1>
+  <nav id="tabs"></nav>
+</header>
+<main id="view"></main>
+<button id="jumpnow" type="button"></button>
+<script>
+"use strict";
+/* ================= DATA START — replace everything in this block =================
+   Text fields: title/spk/room/label/... are treated as plain text (escaped).
+   body.pre[] / body.d / body.prog[] / body.ask / body.note and glossary .d
+   are inserted as HTML — simple inline markup like <b> is allowed there.   */
+
+var EVENT = { name: "DevConf 20XX" };                     // REPLACE
+
+var UI = {                                                 // REPLACE: user's language
+  move: "移動",            // transition row label
+  min: "分",               // minutes suffix
+  now: "NOW",              // in-progress badge
+  jumpNow: "現在へ",       // jump-to-now button
+  prepTab: "準備",         // preparation tab label
+  glossaryTab: "用語集",   // glossary tab label
+  searchPlaceholder: "用語・説明を検索",
+  essential: "必須",       // essential prep item tag
+  talk: "セッションページ" // session link label
+};
+
+/* One distinct hue per floor plus offsite; "—" is the muted non-venue color. */
+var FLOORS = {
+  "1F": "#4cc38a", "3F": "#5aa7ff", "5F": "#c78bfa",
+  "OFF": "#f0a04b", "—": "#6b7280"
+};
+
+/* Session-page URL prefix; body.id is appended. Empty string = no links. */
+var URLBASE = "";
+
+/* Dates are placeholders (year 2099) so time-awareness stays inert until
+   real dates are filled in. plain:true = muted row (travel, meals, misc). */
+var DAYS = [
+  { id: "d1", label: "1/1 月", date: "2099-01-01", sub: "Day 1", items: [
+    { t: "09:30", e: "10:00", f: "1F", room: "受付", title: "受付・バッジ受け取り", plain: true },
+    { t: "10:00", e: "10:50", f: "1F", room: "Hall A", title: "Opening Keynote(差し替え)",
+      spk: "Speaker, Affiliation", n: "Keynote",
+      body: {
+        pre: ["直前に読む3〜5行をここに", "主張の要点・他セッションとの対比・移動注意・聞くこと"],
+        d: "アブストラクト由来の内容要約。<b>強調</b>が使える。",
+        ask: "質問候補をここに",
+        note: "選んだ理由、他セッションとの関連",
+        id: ""
+      } },
+    { t: "11:10", e: "11:40", f: "5F", room: "501", title: "選択済みセッション(差し替え)",
+      spk: "Speaker, Affiliation", n: "Track A",
+      body: {
+        pre: ["…"],
+        d: "…",
+        note: "選ばなかった並行セッション: …(予定変更時・録画探しのため)"
+      } },
+    { t: "12:00", e: "13:00", f: "—", room: "", title: "ランチ", plain: true },
+    { t: "13:00", e: "13:45", f: "3F", room: "301",
+      title: "Lightning Talks ×3(連続短編は1カードにまとめる)", n: "LT",
+      body: { prog: ["13:00 タイトル1 — Speaker", "13:15 タイトル2 — Speaker", "13:30 タイトル3 — Speaker"] } },
+    { t: "17:30", e: "18:10", f: "—", room: "", title: "会場 → 懇親会会場(徒歩40分)", plain: true },
+    { t: "18:30", e: "20:30", f: "OFF", room: "Venue B", title: "Evening Event(差し替え)",
+      body: { note: "ハード制約(集合時刻・要別登録など)をここに" } }
+  ]},
+  { id: "d2", label: "1/2 火", date: "2099-01-02", sub: "Day 2", items: [
+    { t: "10:00", e: "10:30", f: "3F", room: "302", title: "Session(差し替え)", spk: "Speaker, Affiliation",
+      body: { d: "…" } },
+    { t: "10:35", e: "11:05", f: "5F", room: "502", title: "5分での5F移動 — 警告表示のデモ", spk: "Speaker, Affiliation",
+      body: { d: "…" } }
+  ]}
+];
+
+/* Study add-on: searchable glossary. Empty array = tab hidden. */
+var GLOSSARY = [
+  { domain: "ドメイン名(差し替え)", terms: [
+    { t: "用語A", d: "定義。<b>強調</b>が使える。", s: ["Day1 10:00 Opening Keynote"] },
+    { t: "用語B", d: "定義", s: [] }
+  ]}
+];
+
+/* Study add-on: per-night preparation notes. Empty array = tab hidden. */
+var PREP = [
+  { night: "12/31(前夜)", items: [
+    { topic: "読む資料(差し替え)", min: 15, serves: "対象セッション: Day1 10:00 Keynote", essential: true },
+    { topic: "余裕があれば読む資料", min: 20, serves: "対象セッション: Day1 11:10", essential: false }
+  ]}
+];
+/* ================= DATA END — do not edit below this line ================= */
+
+var TIGHT_GAP_MIN = 10;
+
+function esc(s) {
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+function toMin(t) { var p = t.split(":"); return (+p[0]) * 60 + (+p[1]); }
+function pad(x) { return String(x).length < 2 ? "0" + x : String(x); }
+function nowInfo() {
+  var n = new Date();
+  return {
+    date: n.getFullYear() + "-" + pad(n.getMonth() + 1) + "-" + pad(n.getDate()),
+    mins: n.getHours() * 60 + n.getMinutes()
+  };
+}
+function fc(f) { return FLOORS[f] || FLOORS["—"]; }
+function dayById(id) {
+  for (var i = 0; i < DAYS.length; i++) if (DAYS[i].id === id) return DAYS[i];
+  return null;
+}
+
+var tab = null;            // current tab id
+var openIds = {};          // open card ids (kept across re-renders)
+
+function transitionRow(from, to, gap) {
+  var warn = gap <= TIGHT_GAP_MIN;
+  return '<div class="trans' + (warn ? " warn" : "") + '">' +
+    '<span>' + esc(UI.move) + " " + esc(from) + " → " + esc(to) + '</span>' +
+    '<span>' + gap + esc(UI.min) + '</span></div>';
+}
+
+function card(it, state, id) {
+  var color = fc(it.f);
+  var b = it.body || {};
+  var body = "";
+  if (b.pre && b.pre.length) {
+    body += '<div class="pre"><ul>';
+    for (var i = 0; i < b.pre.length; i++) body += "<li>" + b.pre[i] + "</li>";
+    body += "</ul></div>";
+  }
+  if (b.d) body += '<p class="desc">' + b.d + "</p>";
+  if (b.prog && b.prog.length) {
+    body += '<ol class="prog">';
+    for (var j = 0; j < b.prog.length; j++) body += "<li>" + b.prog[j] + "</li>";
+    body += "</ol>";
+  }
+  if (b.ask) body += '<p class="ask">Q: ' + b.ask + "</p>";
+  if (b.note) body += '<p class="note">' + b.note + "</p>";
+  if (b.id && URLBASE) {
+    body += '<p class="link"><a href="' + esc(URLBASE + b.id) +
+      '" target="_blank" rel="noopener">' + esc(UI.talk) + "</a></p>";
+  }
+  var hasBody = body !== "";
+  var cls = "card " + state +
+    (hasBody ? " hasbody" : "") + (openIds[id] ? " open" : "");
+  var meta = esc(it.t) + (it.e ? "–" + esc(it.e) : "") +
+    (it.room ? ' · <b class="room">' + esc(it.room) + "</b>" : "") +
+    (it.n ? ' <span class="tag">' + esc(it.n) + "</span>" : "") +
+    (state === "now" ? ' <span class="nowbadge">' + esc(UI.now) + "</span>" : "");
+  return '<div class="row' + (it.plain ? " plain" : "") + '">' +
+    '<div class="rail">' +
+      '<span class="fbadge" style="background:' + color + '">' + esc(it.f) + '</span>' +
+      '<span class="spine" style="background:' + color + '"></span>' +
+    '</div>' +
+    '<div class="' + cls + '" data-id="' + esc(id) + '">' +
+      '<div class="head">' +
+        '<div class="meta">' + meta + '</div>' +
+        '<div class="title">' + esc(it.title) + '</div>' +
+        (it.spk ? '<div class="spk">' + esc(it.spk) + "</div>" : "") +
+      '</div>' +
+      (hasBody ? '<div class="body">' + body + "</div>" : "") +
+    "</div></div>";
+}
+
+function renderDay(day) {
+  var info = nowInfo();
+  var isToday = info.date === day.date;
+  var h = "";
+  for (var i = 0; i < day.items.length; i++) {
+    var it = day.items[i];
+    var prev = day.items[i - 1];
+    // transition row on floor change; skip around non-venue / muted rows
+    if (prev && prev.f !== it.f && it.f !== "—" && prev.f !== "—" &&
+        !it.plain && !prev.plain) {
+      h += transitionRow(prev.f, it.f, toMin(it.t) - toMin(prev.e || prev.t));
+    }
+    var state = !isToday ? "" :
+      info.mins >= toMin(it.t) && info.mins < toMin(it.e || it.t) ? "now" :
+      info.mins >= toMin(it.e || it.t) ? "past" : "";
+    h += card(it, state, "c-" + day.id + "-" + i);
+  }
+  return h || '<div class="empty">—</div>';
+}
+
+function glossaryHtml() {
+  var h = '<div class="wrap"><input id="gsearch" type="search" placeholder="' +
+    esc(UI.searchPlaceholder) + '" autocomplete="off">';
+  for (var i = 0; i < GLOSSARY.length; i++) {
+    var g = GLOSSARY[i];
+    h += '<section class="ggroup"><h2>' + esc(g.domain) + "</h2>";
+    for (var j = 0; j < g.terms.length; j++) {
+      var t = g.terms[j];
+      h += '<div class="gterm" data-k="' + esc((t.t + " " + t.d).toLowerCase()) + '">' +
+        '<div class="gt">' + esc(t.t) + '</div>' +
+        '<div class="gd">' + t.d + "</div>" +
+        (t.s && t.s.length ? '<div class="gs">' + t.s.map(esc).join(" · ") + "</div>" : "") +
+        "</div>";
+    }
+    h += "</section>";
+  }
+  return h + "</div>";
+}
+
+function prepHtml() {
+  var h = '<div class="wrap">';
+  for (var i = 0; i < PREP.length; i++) {
+    var nt = PREP[i];
+    h += '<section class="night"><h2>' + esc(nt.night) + "</h2>";
+    for (var j = 0; j < nt.items.length; j++) {
+      var it = nt.items[j];
+      h += '<div class="pitem' + (it.essential ? " ess" : "") + '">' +
+        '<div class="pt">' + esc(it.topic) +
+          ' <span class="pmin">' + it.min + esc(UI.min) + "</span>" +
+          (it.essential ? ' <span class="ptag">' + esc(UI.essential) + "</span>" : "") +
+        '</div>' +
+        '<div class="ps">' + esc(it.serves) + "</div></div>";
+    }
+    h += "</section>";
+  }
+  return h + "</div>";
+}
+
+function updateJump() {
+  document.getElementById("jumpnow").className =
+    document.querySelector(".card.now") ? "show" : "";
+}
+
+function render() {
+  var view = document.getElementById("view");
+  var d = dayById(tab);
+  if (d) view.innerHTML = renderDay(d);
+  else if (tab === "prep") view.innerHTML = prepHtml();
+  else if (tab === "glossary") view.innerHTML = glossaryHtml();
+  updateJump();
+}
+
+function switchTab(id) {
+  tab = id;
+  var btns = document.querySelectorAll(".tabbtn");
+  for (var i = 0; i < btns.length; i++) {
+    btns[i].className = "tabbtn" +
+      (btns[i].getAttribute("data-tab") === id ? " active" : "");
+  }
+  render();
+}
+
+function buildTabs() {
+  var h = "";
+  for (var i = 0; i < DAYS.length; i++) {
+    var d = DAYS[i];
+    h += '<button type="button" class="tabbtn" data-tab="' + esc(d.id) + '">' +
+      esc(d.label) +
+      (d.sub ? ' <span class="tsub">' + esc(d.sub) + "</span>" : "") +
+      "</button>";
+  }
+  if (PREP.length) h += '<button type="button" class="tabbtn" data-tab="prep">' + esc(UI.prepTab) + "</button>";
+  if (GLOSSARY.length) h += '<button type="button" class="tabbtn" data-tab="glossary">' + esc(UI.glossaryTab) + "</button>";
+  document.getElementById("tabs").innerHTML = h;
+}
+
+document.getElementById("evname").textContent = EVENT.name;
+document.title = EVENT.name;
+document.getElementById("jumpnow").textContent = UI.jumpNow;
+buildTabs();
+
+document.getElementById("tabs").addEventListener("click", function (e) {
+  var b = e.target.closest(".tabbtn");
+  if (b) { switchTab(b.getAttribute("data-tab")); window.scrollTo(0, 0); }
+});
+
+// card expand/collapse: toggle a class, never re-render, so scroll survives
+document.getElementById("view").addEventListener("click", function (e) {
+  if (e.target.closest("a")) return;
+  var c = e.target.closest(".card.hasbody");
+  if (!c) return;
+  var id = c.getAttribute("data-id");
+  if (openIds[id]) { delete openIds[id]; c.classList.remove("open"); }
+  else { openIds[id] = true; c.classList.add("open"); }
+});
+
+// glossary search: show/hide in place, so input focus and cursor survive
+document.getElementById("view").addEventListener("input", function (e) {
+  if (e.target.id !== "gsearch") return;
+  var q = e.target.value.trim().toLowerCase();
+  var terms = document.querySelectorAll(".gterm");
+  for (var i = 0; i < terms.length; i++) {
+    var hit = q === "" || terms[i].getAttribute("data-k").indexOf(q) !== -1;
+    terms[i].className = "gterm" + (hit ? "" : " hide");
+  }
+  var groups = document.querySelectorAll(".ggroup");
+  for (var j = 0; j < groups.length; j++) {
+    groups[j].className = "ggroup" +
+      (groups[j].querySelector(".gterm:not(.hide)") ? "" : " hide");
+  }
+});
+
+document.getElementById("jumpnow").addEventListener("click", function () {
+  var el = document.querySelector(".card.now");
+  if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
+});
+
+// re-render each minute so NOW advances — but only on a day tab, and
+// preserving scroll (open state is kept via openIds)
+setInterval(function () {
+  if (!dayById(tab)) return;
+  var y = window.scrollY;
+  render();
+  window.scrollTo(0, y);
+}, 60000);
+
+(function init() {
+  var today = null;
+  var date = nowInfo().date;
+  for (var i = 0; i < DAYS.length; i++) if (DAYS[i].date === date) today = DAYS[i];
+  switchTab(today ? today.id : DAYS[0].id);
+  if (today) {
+    requestAnimationFrame(function () {
+      var el = document.querySelector(".card.now");
+      if (el) el.scrollIntoView({ block: "center" });
+    });
+  }
+})();
+</script>
+</body>
+</html>

--- a/plugins/aoshimash-skills/skills/conference-planner/assets/template.html
+++ b/plugins/aoshimash-skills/skills/conference-planner/assets/template.html
@@ -11,136 +11,171 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="dark">
 <title>Conference Schedule — REPLACE</title>
 <style>
+  /* Single dark theme by design: session rooms are dim, OLED battery matters.
+     Ink ground with a cool bias; the floor rail is the only color system —
+     everything else stays monochrome so the rail reads at a glance. */
   :root {
-    --bg:#0f1115; --card:#181c23; --line:#2a2f3a;
-    --text:#e8eaed; --dim:#9aa3ae; --acc:#60a5fa; --warn:#f87171;
+    color-scheme:dark;
+    --bg:#0d0f13; --surface:#151920; --raise:#1c212b; --line:#242a36;
+    --text:#eceef2; --dim:#8d95a3; --faint:#5d6574;
+    --acc:#9ecbff; --warn:#ff7a70; --gold:#d6b97b;
   }
   * { box-sizing:border-box; }
   body {
     margin:0; background:var(--bg); color:var(--text);
     font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
       "Hiragino Kaku Gothic ProN", "Noto Sans JP", sans-serif;
-    -webkit-text-size-adjust:100%;
+    font-size:15px; line-height:1.5; -webkit-text-size-adjust:100%;
   }
+  button { font-family:inherit; cursor:pointer; }
+  button:focus-visible, input:focus-visible {
+    outline:2px solid var(--acc); outline-offset:2px;
+  }
+  /* ---- header: hairline + underline tabs ---- */
   #hdr {
     position:sticky; top:0; z-index:10;
-    background:rgba(15,17,21,.96); backdrop-filter:blur(6px);
+    background:rgba(13,15,19,.92); backdrop-filter:blur(10px);
     border-bottom:1px solid var(--line);
     padding-top:env(safe-area-inset-top);
   }
-  #hdr h1 { margin:0; font-size:14px; font-weight:700; padding:10px 14px 2px; }
+  #hdr h1 {
+    margin:0; padding:12px 16px 0;
+    font-size:13px; font-weight:650; letter-spacing:.02em;
+  }
   #tabs {
-    display:flex; gap:6px; overflow-x:auto; padding:8px 12px 10px;
+    display:flex; gap:18px; overflow-x:auto; padding:2px 16px 0;
     scrollbar-width:none;
   }
   #tabs::-webkit-scrollbar { display:none; }
   .tabbtn {
-    flex:0 0 auto; border:1px solid var(--line); background:transparent;
-    color:var(--dim); border-radius:999px; padding:6px 13px; font-size:13px;
-    font-family:inherit; cursor:pointer;
+    flex:0 0 auto; background:none; border:none; padding:8px 1px 9px;
+    border-bottom:2px solid transparent;
+    color:var(--dim); font-size:14px; font-weight:500;
   }
-  .tabbtn .tsub { font-size:10px; color:inherit; opacity:.8; }
+  .tabbtn .tsub {
+    font-size:9px; font-weight:600; letter-spacing:.07em;
+    text-transform:uppercase; color:var(--faint);
+  }
   .tabbtn.active {
-    background:var(--text); color:#0b0d10; border-color:var(--text);
-    font-weight:600;
+    color:var(--text); font-weight:650; border-bottom-color:var(--text);
   }
+  .tabbtn.active .tsub { color:var(--dim); }
   #view {
     max-width:640px; margin:0 auto;
-    padding:12px 2px calc(90px + env(safe-area-inset-bottom));
+    padding:14px 4px calc(90px + env(safe-area-inset-bottom));
   }
-  /* ---- schedule rows: floor rail + card ---- */
+  /* ---- schedule rows: floor rail + borderless cards ---- */
   .row {
-    display:grid; grid-template-columns:46px 1fr; gap:8px;
-    padding:0 10px; margin-bottom:8px;
+    display:grid; grid-template-columns:44px 1fr; gap:10px;
+    padding:0 12px; margin-bottom:10px;
   }
-  .rail { display:flex; flex-direction:column; align-items:center; gap:4px; }
+  .rail { display:flex; flex-direction:column; align-items:center; gap:5px; }
   .fbadge {
-    width:40px; text-align:center; border-radius:8px; padding:4px 0;
-    font-size:12px; font-weight:700; color:#0b0d10;
+    width:38px; text-align:center; border-radius:7px; padding:3px 0;
+    font-size:11px; font-weight:700; letter-spacing:.02em; color:#0b0d10;
   }
-  .spine { width:3px; flex:1; min-height:8px; border-radius:2px; opacity:.55; }
+  .spine { width:2px; flex:1; min-height:8px; border-radius:1px; opacity:.35; }
   .card {
-    background:var(--card); border:1px solid var(--line); border-radius:12px;
-    padding:10px 12px;
+    background:var(--surface); border-radius:14px; padding:12px 14px;
   }
-  .plain .card { background:transparent; border-style:dashed; opacity:.8; }
-  .plain .fbadge, .plain .spine { opacity:.45; }
-  .card.past { opacity:.45; }
-  .card.now { border-color:var(--acc); box-shadow:0 0 0 1px var(--acc); }
-  .meta { font-size:12px; color:var(--dim); }
-  .room { color:var(--text); font-size:13px; }
+  .plain .card { background:none; padding:5px 2px; }
+  .plain .title { font-size:13px; font-weight:500; color:var(--dim); margin-top:0; }
+  .plain .meta { color:var(--faint); }
+  .plain .room { color:var(--dim); font-weight:500; }
+  .plain .fbadge { opacity:.3; }
+  .plain .spine { opacity:.15; }
+  .card.past { opacity:.4; }
+  .card.now { box-shadow:0 0 0 1.5px var(--acc); }
+  .meta {
+    font-size:12px; color:var(--dim);
+    font-variant-numeric:tabular-nums; letter-spacing:.01em;
+  }
+  .room { color:var(--text); font-size:13px; font-weight:650; }
   .tag {
-    border:1px solid var(--line); border-radius:6px; padding:0 5px;
-    font-size:10px; color:var(--dim);
+    display:inline-block; background:var(--raise); border-radius:5px;
+    padding:1px 6px; font-size:9px; font-weight:600;
+    letter-spacing:.06em; text-transform:uppercase; color:var(--dim);
+    vertical-align:1px;
   }
   .nowbadge {
-    background:var(--acc); color:#0b0d10; font-size:10px; font-weight:800;
-    border-radius:6px; padding:1px 6px;
+    display:inline-block; background:var(--text); color:var(--bg);
+    border-radius:5px; padding:1px 6px; font-size:9px; font-weight:800;
+    letter-spacing:.08em; vertical-align:1px;
   }
-  .title { font-size:15px; font-weight:650; line-height:1.35; margin-top:2px; }
+  .title {
+    font-size:15px; font-weight:600; letter-spacing:-.01em;
+    line-height:1.4; margin-top:3px;
+  }
   .spk { font-size:12px; color:var(--dim); margin-top:2px; }
   .hasbody .head { cursor:pointer; }
-  .hasbody .title::after { content:" ▸"; color:var(--dim); font-size:12px; }
+  .hasbody .title::after { content:" ▸"; color:var(--faint); font-size:11px; }
   .open .title::after { content:" ▾"; }
   .body {
-    display:none; margin-top:10px; padding-top:10px;
-    border-top:1px solid var(--line); font-size:13px; line-height:1.55;
+    display:none; margin-top:12px; padding-top:12px;
+    border-top:1px solid var(--line); font-size:13px; line-height:1.6;
   }
   .open .body { display:block; }
   .pre {
-    background:rgba(96,165,250,.12); border-left:3px solid var(--acc);
-    border-radius:8px; padding:8px 10px; margin-bottom:8px;
+    background:var(--raise); border-left:2px solid var(--acc);
+    border-radius:10px; padding:9px 12px; margin-bottom:10px;
   }
-  .pre ul { margin:0; padding-left:18px; }
-  .pre li { margin:2px 0; }
-  .desc { margin:6px 0; }
-  .prog { margin:6px 0 6px 0; padding-left:20px; color:var(--dim); }
-  .ask { margin:6px 0; color:#ffd57e; }
-  .note { margin:6px 0; font-size:12px; color:var(--dim); }
-  .link { margin:8px 0 0; }
+  .pre ul { margin:0; padding-left:16px; }
+  .pre li { margin:3px 0; }
+  .desc { margin:8px 0; }
+  .prog { margin:8px 0; padding-left:20px; color:var(--dim); }
+  .prog li { margin:2px 0; }
+  .ask { margin:8px 0; color:var(--gold); }
+  .note { margin:8px 0; font-size:12px; color:var(--dim); }
+  .link { margin:10px 0 0; }
   .link a { color:var(--acc); }
-  /* ---- transition rows ---- */
+  /* ---- transition rows: quiet text, loud only when tight ---- */
   .trans {
-    margin:0 10px 8px 64px; padding:4px 10px;
-    display:flex; justify-content:space-between; gap:8px;
-    border:1px dashed var(--line); border-radius:8px;
-    font-size:12px; color:var(--dim);
+    margin:2px 12px 12px 66px; display:flex; gap:10px; align-items:baseline;
+    font-size:12px; color:var(--faint);
+    font-variant-numeric:tabular-nums;
   }
-  .trans.warn { color:var(--warn); border-color:var(--warn); }
-  /* ---- glossary / prep tabs ---- */
-  .wrap { padding:0 12px; }
+  .trans.warn { color:var(--warn); font-weight:650; }
+  /* ---- glossary / prep: hairline lists, no boxes ---- */
+  .wrap { padding:0 16px; }
   #gsearch {
-    width:100%; background:var(--card); border:1px solid var(--line);
-    color:var(--text); border-radius:10px; padding:10px 12px; font-size:14px;
-    font-family:inherit; margin-bottom:12px;
+    width:100%; background:var(--surface); border:none; border-radius:12px;
+    color:var(--text); padding:11px 14px; font-size:14px; font-family:inherit;
+    margin-bottom:6px;
   }
-  .ggroup h2, .night h2 { font-size:13px; color:var(--dim); margin:16px 0 8px; }
-  .gterm, .pitem {
-    background:var(--card); border:1px solid var(--line); border-radius:10px;
-    padding:8px 12px; margin-bottom:8px;
+  #gsearch::placeholder { color:var(--faint); }
+  .ggroup h2, .night h2 {
+    font-size:11px; font-weight:650; letter-spacing:.08em;
+    text-transform:uppercase; color:var(--faint); margin:22px 0 4px;
   }
-  .gt { font-weight:700; font-size:14px; }
-  .gd { font-size:13px; margin-top:2px; line-height:1.5; }
-  .gs { font-size:11px; color:var(--dim); margin-top:4px; }
-  .pitem.ess { border-left:3px solid var(--acc); }
-  .pt { font-weight:650; font-size:14px; }
-  .pmin { font-weight:400; font-size:12px; color:var(--dim); }
+  .gterm, .pitem { padding:11px 2px; border-bottom:1px solid var(--line); }
+  .gterm:last-child, .pitem:last-child { border-bottom:none; }
+  .gt { font-weight:650; font-size:14px; letter-spacing:-.01em; }
+  .gd { font-size:13px; color:var(--dim); margin-top:3px; line-height:1.55; }
+  .gs { font-size:11px; color:var(--faint); margin-top:5px; }
+  .pt { font-weight:600; font-size:14px; letter-spacing:-.01em; }
+  .pmin {
+    font-weight:400; font-size:12px; color:var(--faint);
+    font-variant-numeric:tabular-nums;
+  }
   .ptag {
-    font-size:10px; color:var(--acc); border:1px solid var(--acc);
-    border-radius:6px; padding:0 5px;
+    display:inline-block; font-size:9px; font-weight:650;
+    letter-spacing:.06em; text-transform:uppercase; color:var(--acc);
+    border:1px solid var(--acc); border-radius:5px; padding:0 5px;
+    vertical-align:1px;
   }
-  .ps { font-size:12px; color:var(--dim); margin-top:2px; }
+  .ps { font-size:12px; color:var(--dim); margin-top:3px; }
   .hide { display:none; }
-  .empty { color:var(--dim); text-align:center; padding:40px 0; font-size:13px; }
+  .empty { color:var(--faint); text-align:center; padding:48px 0; font-size:13px; }
   /* ---- jump-to-now ---- */
   #jumpnow {
-    position:fixed; right:14px;
-    bottom:calc(14px + env(safe-area-inset-bottom));
-    display:none; border:none; border-radius:999px; padding:10px 16px;
-    background:var(--acc); color:#0b0d10; font-size:13px; font-weight:700;
-    font-family:inherit; cursor:pointer; box-shadow:0 4px 16px rgba(0,0,0,.4);
+    position:fixed; right:16px;
+    bottom:calc(16px + env(safe-area-inset-bottom));
+    display:none; border:none; border-radius:999px; padding:9px 15px;
+    background:var(--text); color:var(--bg); font-size:12px; font-weight:650;
+    letter-spacing:.02em; box-shadow:0 6px 20px rgba(0,0,0,.45);
   }
   #jumpnow.show { display:block; }
 </style>
@@ -175,8 +210,8 @@ var UI = {                                                 // REPLACE: user's la
 
 /* One distinct hue per floor plus offsite; "—" is the muted non-venue color. */
 var FLOORS = {
-  "1F": "#4cc38a", "3F": "#5aa7ff", "5F": "#c78bfa",
-  "OFF": "#f0a04b", "—": "#6b7280"
+  "1F": "#34c48e", "3F": "#4d9ef7", "5F": "#b48af7",
+  "OFF": "#f5a054", "—": "#525a68"
 };
 
 /* Session-page URL prefix; body.id is appended. Empty string = no links. */

--- a/plugins/aoshimash-skills/skills/conference-planner/references/data-extraction.md
+++ b/plugins/aoshimash-skills/skills/conference-planner/references/data-extraction.md
@@ -1,0 +1,146 @@
+# Extracting schedule data
+
+## Contents
+
+- [Escalation order](#escalation-order)
+- [Sessionize](#sessionize)
+- [Other platforms](#other-platforms)
+- [Custom event sites](#custom-event-sites)
+- [Non-web sources](#non-web-sources)
+- [Normalizing what you get](#normalizing-what-you-get)
+- [Completeness checks](#completeness-checks)
+
+---
+
+## Escalation order
+
+Try in this order. Stop as soon as you have complete data with full abstracts.
+
+1. **Static fetch of the schedule page.** Cheapest. Works when the page is server-rendered. Often fails on modern conference sites, which render the program client-side — a fetch returns navigation and a shell with no sessions.
+
+2. **A JSON or API endpoint.** Many schedule platforms expose one for their own front end or for embeds. If you can see the page in a browser, look at what the network tab loaded. This gives clean structured data including full abstracts.
+
+3. **Browser storage.** Some schedule apps cache the entire program client-side so they work offline. This is often the single best source: one read yields sessions, speakers, rooms, and categories together.
+
+4. **Text extraction from the rendered page.** Navigate with a browser tool and pull the text. Workable but lossy — abstracts get truncated, and you may need one page load per session.
+
+5. **Manual entry from what the user can see.** Last resort. If it comes to this, ask the user to paste or screenshot the program rather than guessing.
+
+A browser automation tool is usually required for options 2–4, since the data only exists after JavaScript runs. Without one, work options 1 and 5 plus any documented API the platform exposes (Pretalx below is the clean case) — and prefer asking the user to open the page and paste what they see over guessing at undocumented endpoints.
+
+---
+
+## Sessionize
+
+Widely used, including by CNCF events. Schedule pages look like `https://<event-slug>.sessionize.com/schedule`.
+
+**Browser storage holds everything.** After the schedule page loads, `localStorage` contains a `schedule` key with the full program as JSON:
+
+```js
+const p = JSON.parse(localStorage.getItem('schedule'));
+// p.sessions   — id, title, description, startsAt, endsAt, roomId, speakers[], categoryItems[]
+// p.speakers   — id, fullName, tagLine, bio
+// p.rooms      — id, name
+// p.categories — id, title, items[]  (tracks, difficulty levels, session formats)
+```
+
+Build lookup maps for rooms and speakers, then join. Extract in batches rather than dumping everything at once, since abstracts are long:
+
+```js
+const rooms = {}; (p.rooms||[]).forEach(r => rooms[r.id] = r.name);
+const byId = {}; (p.speakers||[]).forEach(s => byId[s.id] = s.fullName);
+const list = p.sessions.map(s => ({
+  id: s.id,
+  t: (s.startsAt||'').slice(11,16),
+  e: (s.endsAt||'').slice(11,16),
+  room: rooms[s.roomId] || '',
+  title: s.title,
+  spk: (s.speakers||[]).map(x => byId[x]).filter(Boolean).join(', ')
+}));
+```
+
+Then pull descriptions for specific sessions by slicing, to stay within reasonable response sizes:
+
+```js
+const s = p.sessions.find(x => x.title.includes('<keyword>'));
+(s.description || '').replace(/\s+/g, ' ').slice(0, 700)
+```
+
+**Critical: co-located events use separate Sessionize instances.** A community day or pre-conference track will have its own subdomain — for example `<event>-community-day-<year>.sessionize.com` alongside the main `<event>-<year>.sessionize.com`. Loading one does not give you the other. Check for each event the user registered for.
+
+Room names may carry floor prefixes like `4F | 411+412`. Split these — the floor is needed for transition warnings.
+
+---
+
+## Other platforms
+
+**Sched (`sched.com`)** — event sites like `<event>.sched.com`. Has an API for organizers; public schedules are often server-rendered enough for text extraction. Individual session pages carry full abstracts.
+
+**ConfEngine** — used by many agile and regional conferences. Session pages are individually addressable and generally fetchable.
+
+**Pretalx** — open source, common in European and community conferences. Exposes a real REST API at `/api/events/<slug>/talks/` and often an iCal feed. When present, this is the cleanest source available.
+
+**Whova / Bizzabo / Cvent** — mobile-app-first commercial platforms. Web schedules are heavily client-rendered and sometimes require login. Expect to need browser text extraction, and expect abstracts to be truncated in list views.
+
+**Google Sheets or Notion** as the program — occasionally used by community events. Fetchable if published; ask the user for the link.
+
+---
+
+## Custom event sites
+
+Large conferences often build their own program pages over a schedule backend. The visible site and the data source may differ — a Linux Foundation event page, for instance, may render a Sessionize program.
+
+When a custom page resists extraction:
+
+- Look for an embedded iframe pointing at the underlying platform, then go to that platform directly
+- Check for an `.ics` export or "add to calendar" links, which sometimes expose per-session data
+- Check for a printable or "full schedule" view, which is more often server-rendered
+
+Sponsor-hosted side events usually have a simple standalone page with the agenda in HTML. These are easy to fetch but easy to forget — they are announced by email rather than listed on the main site. Detail beyond the agenda (abstracts, speaker bios) is often absent; record that as unknown rather than inferring.
+
+---
+
+## Non-web sources
+
+**PDF programs** — extract text; watch for multi-column layouts scrambling reading order. Cross-check the result against a rendered page image.
+
+**Images or screenshots of a timetable** — read them directly. Confirm ambiguous times with the user rather than guessing.
+
+**Conference mobile apps with no web equivalent** — ask the user to export or screenshot. Do not attempt to reverse engineer app APIs.
+
+---
+
+## Normalizing what you get
+
+Whatever the source, land on a consistent shape per session:
+
+| Field | Notes |
+|---|---|
+| id | Stable identifier from the source, for building URLs |
+| start / end | Local time. Keep the timezone explicit |
+| room | Split floor from room name if combined |
+| floor | Needed for transition detection |
+| title | |
+| speakers | Name plus affiliation. Affiliation informs who to ask what |
+| track | If the conference has them |
+| level | Capture but distrust |
+| abstract | **Full text.** Truncated abstracts cause wrong choices |
+| url | Direct link to the session page |
+
+For sessions where the source genuinely lacks abstracts, mark them as such. An empty abstract and an unfetched abstract are different states, and conflating them leads to presenting a session as thin when it is merely unread.
+
+---
+
+## Completeness checks
+
+Before presenting anything for decision:
+
+**Slot × room matrix.** Lay out every time slot against every room. Holes are either real gaps or missing data — resolve which.
+
+**Room census.** Rooms appearing in only part of the day are suspicious. Some are genuinely used for one block; others indicate a partial extraction.
+
+**Duration sanity.** Sessions whose duration differs from the conference norm are worth a second look. They are often keynotes, panels, lightning talk blocks, or extraction errors.
+
+**Event inventory against registrations.** Compare the schedules you have against what the user registered for. A registered event with no schedule extracted is the most common failure.
+
+**Timezone.** Confirm that extracted times are venue-local. Some sources store UTC.

--- a/plugins/aoshimash-skills/skills/conference-planner/references/eval-cases.md
+++ b/plugins/aoshimash-skills/skills/conference-planner/references/eval-cases.md
@@ -1,0 +1,191 @@
+# Evaluation Test Cases
+
+Cases 1–6 evaluate the planning flow (extraction → slot resolution), cases
+7–8 the calendar phase, cases 9–11 the mobile HTML phase, and case 12 the
+personal/shared boundary.
+
+## How to Run
+
+1. Start a new conversation and trigger the conference-planner skill.
+2. Provide the case's initial input; answer follow-ups as the persona would.
+3. Score the run against the Criteria below.
+4. Record the run in the Evaluation Log at the bottom.
+
+## Criteria
+
+| # | Criterion | Pass condition |
+|---|---|---|
+| 1 | User decides every slot | Parallel options are presented neutrally; a recommendation appears only when the user asked for one; no slot is auto-decided — including pre-conference/community days and evening events |
+| 2 | Process size announced | Before the first slot question, the number of decisions is stated per day and in total; the count is restated when scope changes |
+| 3 | Slot-by-slot pacing | One slot per round, chronological; a terse answer ("B") is confirmed and the flow advances; slots are never batched into one mega-question |
+| 4 | Source inventory from registrations | The user is asked what they registered for; co-located/pre-conference days are checked as separate schedule instances; sponsor/offsite events are considered |
+| 5 | Abstracts read in full | Every parallel option's summary is drawn from the abstract body, with specific claims/numbers/tools; titles and difficulty tags are never the basis of a summary |
+| 6 | Completeness verified | A slot × room matrix (or equivalent) is checked before decisions start; recording availability is established early |
+| 7 | Calendar hygiene | Existing events on the conference dates are checked first; nothing is deleted without confirmation; events carry room in location, pre-session reminder + unchosen parallels in description; travel blocks registered; consecutive short talks grouped |
+| 8 | Calendar fallback | Without a calendar integration, an `.ics` file is produced with the same content rules, and the user is warned that duplicates cannot be detected on this path |
+| 9 | Template-based HTML | The mobile HTML is generated from `assets/template.html` by replacing only the data blocks; UI labels set to the user's language via `UI`; no external requests; no browser storage in the default build |
+| 10 | Product notes stay conditional | claude.ai-specific behavior (artifact preview storage block, ~64KB publish limit) is applied only when that product is in play, never presented as universal |
+| 11 | Study add-ons offered | Glossary and per-night preparation notes are proactively offered; included only when accepted; tabs dropped when declined |
+| 12 | Personal by default, scrubbed on request | Personal logistics are included by default; a shared version is produced only on request, deliberately scrubbed and verified |
+| 13 | Extraction degrades gracefully | Without browser automation, the flow uses static fetch / documented APIs, then asks the user to paste or screenshot — never guesses schedule data |
+| 14 | Size limits surfaced | When a size constraint bites, the trade-off is raised and the user chooses what is cut; content is never trimmed silently |
+
+## Planning Flow Cases
+
+### Case 1: Schedule URL with a "what should I attend" ask
+
+- **Persona**: Engineer attending a two-day conference, shares the Sessionize
+  schedule URL and asks "どのセッションを聞けばいい?"
+- **Expected behavior**: registration inventory question first; extraction via
+  the escalation order; slot × room matrix and recording status before any
+  decision; then slot-by-slot walk where the explicit "which should I attend"
+  ask licenses a per-slot recommendation — but every pick is still confirmed
+  by the user.
+- **Criteria**: 1, 2, 4, 5, 6
+
+### Case 2: Count announcement and pacing
+
+- **Persona**: Attendee with the schedule already extracted in-conversation
+- **Expected behavior**: before the first slot question, the decision count is
+  announced per day and in total; each round covers exactly one slot with all
+  parallel options, structural facts (asymmetric slots, block structure,
+  transitions), and no recommendation unless asked.
+- **Criteria**: 1, 2, 3
+
+### Case 3: Terse mid-flow answers
+
+- **Persona**: User who replies "B", then "2つ目", without further comment
+- **Expected behavior**: each terse reply is treated as a decision, confirmed
+  in one line, and the next slot is presented — no re-litigation, no skipping
+  ahead to batch the remaining slots.
+- **Criteria**: 3
+
+### Case 4: "The community day doesn't matter"
+
+- **Persona**: User who says the pre-conference community day can be decided
+  automatically ("適当でいいよ")
+- **Expected behavior**: the day still gets the slot-by-slot treatment; the
+  agent may compress presentation but does not silently pick sessions; the
+  community day's schedule is fetched from its own instance (separate
+  subdomain), not assumed to be inside the main program.
+- **Criteria**: 1, 3, 4
+
+### Case 5: Extraction without browser automation
+
+- **Persona**: User on an agent with no browser tool; the schedule page is
+  client-rendered so a static fetch returns an empty shell
+- **Expected behavior**: static fetch attempted; documented APIs considered
+  (e.g. Pretalx); then the user is asked to open the page and paste or
+  screenshot the program. No session data is invented; unfetched abstracts
+  are marked as unfetched, not treated as empty.
+- **Criteria**: 5, 13
+
+### Case 6: Hidden third option
+
+- **Persona**: User whose extracted slot shows two rooms, but the room census
+  shows a third room active in adjacent slots
+- **Expected behavior**: the hole in the slot × room matrix is resolved
+  (re-extraction or explicit confirmation that the room is dark) before the
+  slot is presented for decision.
+- **Criteria**: 5, 6
+
+## Calendar Cases
+
+### Case 7: Existing umbrella block
+
+- **Persona**: User whose calendar already holds an all-day "Conference" block
+  on both days
+- **Expected behavior**: existing events are read before writing; the overlap
+  is reported and the user is asked what to do with the umbrella block —
+  nothing is deleted or duplicated without confirmation. Events follow the
+  structure rules (prefix, room in location, reminder + unchosen parallels in
+  description); travel blocks and grouped short talks appear.
+- **Criteria**: 7
+
+### Case 8: No calendar integration
+
+- **Persona**: User on an agent with no calendar tool connected
+- **Expected behavior**: an `.ics` file is generated with one VEVENT per
+  event, same content rules; the user is told existing events could not be
+  checked and what to look for before importing.
+- **Criteria**: 7, 8
+
+## Mobile HTML Cases
+
+### Case 9: Standard build
+
+- **Persona**: User asking for the venue schedule file ("会場用のHTMLを作って")
+- **Expected behavior**: output is `assets/template.html` with only the data
+  blocks replaced; UI strings in the user's language; transition rows appear
+  where floors change with warnings on tight gaps; glossary and prep-note
+  add-ons are offered before building; delivery method is asked.
+- **Criteria**: 9, 11
+
+### Case 10: Publish on claude.ai with a large file
+
+- **Persona**: User on claude.ai whose filled schedule exceeds 64KB and who
+  asks to publish it as an artifact
+- **Expected behavior**: byte length is measured; the limit is raised as a
+  trade-off with options for what to cut; nothing is trimmed silently. On any
+  other delivery path the 64KB note never appears.
+- **Criteria**: 10, 14
+
+### Case 11: Self-host persistence
+
+- **Persona**: User who will host the file on their home server and wants
+  checked-off sessions remembered
+- **Expected behavior**: the default build ships without browser storage; the
+  persistence patch is offered as a separate addition for the self-hosted
+  copy, with the claude.ai preview limitation explained only if that context
+  applies.
+- **Criteria**: 9, 10
+
+## Boundary Case
+
+### Case 12: "Share it with my team"
+
+- **Persona**: User who, after receiving a personal schedule containing hotel
+  and travel details, asks for a version to share with colleagues
+- **Expected behavior**: a scrubbed copy is produced deliberately — personal
+  logistics, private notes, and employer-sensitive content removed — and the
+  scrub is verified before delivery; the personal version is left intact.
+- **Criteria**: 12
+
+## Evaluation Log
+
+### 2026-07-30 — Initial import (desk-check)
+
+Skill imported into the repository from a standalone `.skill` package, with
+these changes: Environment Adaptation section added (user choice, browser
+automation, calendar integration — each with a fallback); `.ics` fallback for
+Phase 3; claude.ai-specific notes made conditional; decision-count
+announcement added to Phase 2; Japanese triggers added to the description;
+canonical `assets/template.html` added and Phase 4 rewritten around it;
+placeholder session id and UI-language note fixed in `mobile-html.md`.
+
+`assets/template.html` verified mechanically per the Verification section of
+`mobile-html.md`: script body parses (`new Function`), every class emitted by
+the render code exists in the stylesheet, no external URLs, 18,858 bytes.
+
+Desk-check of the cases against the skill text (static inspection):
+
+| Case | Result | Notes |
+|------|--------|-------|
+| 1 | Pass | Phase 1 "Ask the user what they registered for"; matrix + recording checks; "If asked for a recommendation, give one" |
+| 2 | Pass | Phase 2 "Announce the size of the process before the first question" |
+| 3 | Pass | "The user may go quiet … That is a decision. Confirm it, then move to the next slot" |
+| 4 | Pass | "Deciding a day because it looks minor" pitfall; co-located separate-instance warnings in SKILL.md and data-extraction.md |
+| 5 | Pass | Environment Adaptation browser-automation fallback; data-extraction.md escalation note + "unfetched ≠ empty" |
+| 6 | Pass | "Verify completeness before proceeding" + data-extraction.md room census |
+| 7 | Pass | Phase 3 duplicate check + "Never delete existing events without confirming" + event structure rules |
+| 8 | Pass | Phase 3 `.ics` path + "existing events cannot be read — say so" |
+| 9 | Pass | Phase 4 "Start from `assets/template.html`" + template's UI object + add-on offer |
+| 10 | Pass | claude.ai notes are prefixed "On claude.ai," in SKILL.md and mobile-html.md |
+| 11 | Pass | "Avoid browser storage" principle + mobile-html.md Persistence section |
+| 12 | Pass | Scope section personal default + "Mixing personal logistics" pitfall + mobile-html.md verification item |
+
+All 12 cases pass the desk-check. This entry records a static evaluation
+(instructions inspected against expected behavior); no live conversational
+run was performed for the import. Cases 1 (full extraction against a live
+Sessionize instance) and 9 (template fill on a real program) exercise the
+highest-risk paths and are the first candidates for a live run.

--- a/plugins/aoshimash-skills/skills/conference-planner/references/mobile-html.md
+++ b/plugins/aoshimash-skills/skills/conference-planner/references/mobile-html.md
@@ -1,0 +1,242 @@
+# The mobile schedule HTML
+
+> The canonical implementation is `../assets/template.html` — a complete
+> working app with placeholder data. Generate a schedule by replacing its data
+> blocks, not by writing new HTML, so every schedule shares one UI. This file
+> records the design behind the template; read it before extending the
+> template so additions stay coherent.
+
+## Contents
+
+- [What it is for](#what-it-is-for)
+- [Hard constraints](#hard-constraints)
+- [Layout: the floor rail](#layout-the-floor-rail)
+- [Transition rows](#transition-rows)
+- [Time awareness](#time-awareness)
+- [Session cards](#session-cards)
+- [Tabs](#tabs)
+- [Data shape](#data-shape)
+- [Implementation skeleton](#implementation-skeleton)
+- [Optional: glossary](#optional-glossary)
+- [Optional: preparation notes](#optional-preparation-notes)
+- [Persistence](#persistence)
+- [Verification](#verification)
+
+---
+
+## What it is for
+
+One question, asked while standing up with a bag on one shoulder: **where do I go next, and what is this talk about.**
+
+Everything else is secondary. A beautiful schedule that requires two taps to find the room number has failed.
+
+---
+
+## Hard constraints
+
+**Zero external requests.** Venue Wi-Fi collapses under a few thousand attendees. No CDN fonts, no CDN scripts, no remote images, no analytics. System font stack only. The file must render fully in airplane mode.
+
+**Single file.** One `.html` with inline `<style>` and `<script>`. It gets emailed, dropped in cloud storage, added to a home screen. Multiple files break all of that.
+
+**No browser storage in the default build.** Use in-memory state so the file behaves identically in restrictive viewers. On claude.ai, the artifact preview blocks `localStorage` and `sessionStorage`, and the failure is silent. Offer a persistence patch separately if the user will self-host.
+
+**Mobile viewport first.** Include `viewport-fit=cover` and respect `env(safe-area-inset-*)` so a sticky header does not collide with a notch.
+
+---
+
+## Layout: the floor rail
+
+A two-column grid per row. Left column is narrow (~46px) and carries the floor; right column is the session card.
+
+```
+┌────┬──────────────────────────────┐
+│ 5F │ 11:30–12:00 · 501            │
+│ ▏  │ Session title                │
+│ ▏  │ Speaker, Affiliation         │
+└────┴──────────────────────────────┘
+```
+
+The floor badge is filled with a per-floor color, and a thin vertical spine in the same color runs down beside the card. Scrolling the day produces a visible color band — the user reads their movement pattern without reading any text.
+
+Assign one distinct hue per floor plus one for offsite. Keep them saturated enough to distinguish in sunlight. A dark theme reads better in dim session rooms and uses less battery on OLED.
+
+Non-session rows (travel, meals, registration) get a muted dashed treatment so they recede.
+
+---
+
+## Transition rows
+
+Insert automatically between consecutive items whose floor differs. Compute the gap from the previous item's end to the next item's start:
+
+```
+    ┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+    │ 移動 5F → 3F  ┄┄┄┄┄┄┄  10分
+```
+
+Below a threshold (10 minutes works well), switch to a warning color. This is the single most useful automatic feature — it surfaces problems that are invisible when reading a schedule as a list.
+
+UI label strings — the 移動/分 in the example above, tab names, badges — live in the template's `UI` object. Set them to the user's language; the examples in this file show a Japanese build.
+
+Skip the row when either side is a non-venue item, to avoid noise around travel and meals.
+
+---
+
+## Time awareness
+
+On load, compare today's date against the event days:
+
+- **During the event** — open the current day's tab, add a `NOW` badge to the in-progress session, scroll it into view, and dim sessions already ended
+- **Outside the event** — open the first day
+
+Re-render on a one-minute interval so the current session advances without interaction. Provide a "jump to now" control, since the user will have scrolled away.
+
+Guard the interval so it only re-renders when a day tab is active — re-rendering a glossary while the user is typing in a search box destroys their input.
+
+---
+
+## Session cards
+
+Collapsed, a card shows time, room, title, speaker, and track. Tapping expands it.
+
+Expanded, order the content by what is needed soonest:
+
+1. **The pre-session reminder** — first, because it is what gets read in the 90 seconds before a talk starts. Three to five bullets: the main claim, the contrast with another session, a movement warning, what to ask. Visually distinct (tinted background, accent border)
+2. **Content summary** — from the abstract
+3. **Agenda** — for single-track events with an internal running order
+4. **Question candidates**
+5. **Notes** — why this session was chosen, connections to others
+6. **Link** to the session page
+
+The reminder being first is deliberate. Descriptions are read the night before; reminders are read in the doorway.
+
+---
+
+## Tabs
+
+One per event day, then auxiliary tabs. Keep them in a horizontally scrolling sticky row with the scrollbar hidden.
+
+Auxiliary tabs worth having, in rough priority: preparation notes, glossary. Resist adding more — every tab is a swipe between the user and their room number.
+
+---
+
+## Data shape
+
+Keep all content in plain data structures at the top of the script, separate from rendering. Editing content should never require touching layout code.
+
+```js
+const DAYS = [{
+  id: "d1", label: "7/29 水", date: "2026-07-29", sub: "Day 1",
+  items: [{
+    t: "11:30", e: "12:00",        // start, end — "HH:MM"
+    f: "5F", room: "501",           // floor drives color and transitions
+    title: "…",
+    spk: "Speaker, Affiliation",
+    n: "Track",                     // small tag
+    plain: false,                   // true = muted row (travel, meals)
+    body: {
+      pre:  ["…"],                  // pre-session reminder bullets
+      d:    "…",                    // content summary (may contain <b>)
+      prog: ["…"],                  // agenda, for single-track events
+      ask:  "…",                    // question candidate
+      note: "…",                    // rationale, cross-references
+      id:   "…"                     // session id for URL construction
+    }
+  }]
+}];
+```
+
+Floor-to-color mapping lives in a small lookup so adding a floor is one line.
+
+---
+
+## Implementation skeleton
+
+```js
+const FC = {"1F":"var(--f1)","3F":"var(--f3)","5F":"var(--f5)","OFF":"var(--off)","—":"var(--none)"};
+const toMin = t => { const [h,m] = t.split(":").map(Number); return h*60+m; };
+const esc = s => String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;");
+
+function nowInfo() {
+  const n = new Date();
+  const p = x => String(x).padStart(2,"0");
+  return { date: `${n.getFullYear()}-${p(n.getMonth()+1)}-${p(n.getDate())}`,
+           mins: n.getHours()*60 + n.getMinutes() };
+}
+
+function renderDay(day) {
+  const { date, mins } = nowInfo();
+  const isToday = date === day.date;
+  let h = "";
+  day.items.forEach((it, i) => {
+    const prev = day.items[i-1];
+    // transition row on floor change
+    if (prev && prev.f !== it.f && it.f !== "—" && prev.f !== "—") {
+      const gap = toMin(it.t) - toMin(prev.e || prev.t);
+      h += transitionRow(prev.f, it.f, gap, gap <= 10);
+    }
+    const state = !isToday ? ""
+      : mins >= toMin(it.t) && mins < toMin(it.e || it.t) ? "now"
+      : mins >= toMin(it.e || it.t) ? "past" : "";
+    h += card(it, state, `c-${day.id}-${i}`);
+  });
+  return h;
+}
+
+// escape only user-visible plain text; body fields intentionally allow <b>
+```
+
+Expansion toggles a class rather than rebuilding, so scroll position survives. When a re-render is unavoidable, save `window.scrollY` and the set of open card ids, then restore both.
+
+---
+
+## Optional: glossary
+
+Worth adding when sessions will use unfamiliar vocabulary and the user wants to look things up mid-talk.
+
+A search box filtering across both term and definition, with terms grouped by domain. Tag each entry with the sessions where it appears, so the user can see why a term is present.
+
+Include terms that will actually cause a stall — newly announced tools, project-specific jargon, acronyms introduced without expansion. Terms the user works with daily are wasted space, though when in doubt keep them: knowing a term and recalling it under time pressure are different.
+
+When filtering re-renders the list, preserve focus and cursor position in the search input.
+
+---
+
+## Optional: preparation notes
+
+If the user wants study material, organize it by **the night before** rather than by priority tier. "What do I read tonight" is the actual question; "what is most important overall" is not actionable at 23:00 after a day of talks.
+
+Per night, list topics with an estimated reading time and the sessions each serves. Note which are essential and which can wait for the morning commute. Keep the total honest — a night after an evening event has less capacity than a night at home.
+
+---
+
+## Persistence
+
+If the user self-hosts, three lines add persistence for read-state or checkboxes:
+
+```js
+// on change
+localStorage.setItem('state', JSON.stringify([...doneSet]));
+
+// on init
+try { doneSet = new Set(JSON.parse(localStorage.getItem('state') || '[]')); } catch(e) {}
+```
+
+Mention this rather than including it by default. On claude.ai, the artifact preview blocks browser storage and the failure is silent.
+
+---
+
+## Verification
+
+Before delivering, confirm mechanically:
+
+**The script parses.** Extract the script body and construct a function from it. A stray backtick inside a template literal — easy to introduce when generating code through a shell heredoc — produces a file that renders as a blank page.
+
+**Every class used exists in the CSS.** Collect class names from `class="..."` attributes including template-interpolated ones, collect selectors from the stylesheet, and diff. Mechanical renames across CSS and template strings break this quietly.
+
+**The document closes properly** and tag counts balance.
+
+**No external URLs** except session links intended to be tapped.
+
+**No personal content** if a shared version was requested — check for addresses, routes, lodging, employer projects, private plans.
+
+If the file will go through a size-limited publish path, measure the byte length rather than estimating.


### PR DESCRIPTION
## Decisions

Imports the standalone `conference-planner.skill` package into the plugin, adapted to repository conventions. Decisions made during the import (all confirmed with the user in-session):

1. **Agent portability via fallbacks, not `compatibility`.** Every capability the skill uses now has a baseline fallback, so the skill stays baseline-usable and `compatibility` is omitted: browser automation → static fetch / documented APIs / user paste; calendar integration → generated `.ics`; user choice → numbered plain-text options.
2. **claude.ai-specific behavior is conditional.** The artifact-preview `localStorage` block and the ~64KB publish limit are now "On claude.ai, …" notes in `SKILL.md` and `references/mobile-html.md`.
3. **Slot-by-slot pacing kept, size announced.** Deliberate choice against batching: the user reads each slot's abstracts while deciding. Phase 2 now announces the decision count (per day and total) before the first question.
4. **UI unification via a canonical template.** `assets/template.html` is a complete working app; generation replaces only its data blocks (`EVENT`, `UI`, `FLOORS`, `URLBASE`, `DAYS`, `GLOSSARY`, `PREP`). UI label strings live in the `UI` object so language is a data swap. Phase 4 and `mobile-html.md` are rewritten around it.
5. **Study add-ons are offered, not buried.** Glossary and per-night preparation notes exist as template tabs; the skill now instructs offering them proactively and dropping the tabs when declined.
6. **Japanese triggers** added to the description alongside the English ones.

## Verification

- `assets/template.html` verified per the skill's own Verification section: script body parses (`new Function`), every class emitted by render code resolves in the stylesheet, zero external URLs, 18,858 bytes.
- Interactive smoke test via headless Chromium: card expansion shows the pre-session reminder first; a 5-minute floor transition renders as a warning row; glossary search filters correctly and retains input focus; mobile viewport (390×844) renders the floor rail, transition rows, and muted plain rows as designed.
- `references/eval-cases.md`: 12 cases / 14 criteria; initial desk-check recorded in the Evaluation Log — all 12 pass on static inspection. Cases 1 and 9 (live Sessionize extraction, real template fill) are flagged as first candidates for a live run.

## Mechanical changes

- README: skill table row + `assets/` line in the structure tree.
- `references/data-extraction.md`: one note on degrading without browser automation; `references/mobile-html.md`: canonical-template pointer, conditional claude.ai phrasing, placeholder session id, UI-language note.

Plugin version bump left for post-merge per repo practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPQveK2NDixZPRcNJy7qeC