### PR TITLE
Record four skill-authoring rules in the agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,15 @@ Skills follow the [skill-creator](https://github.com/anthropics/skills) best pra
 - Keep SKILL.md under 500 lines. Split detailed content into `references/` files.
 - Each skill should have eval test cases in `references/eval-cases.md`. Run them after changes and record results in the evaluation log.
 
+### Writing instructions that hold up
+
+A skill is executed, not read. These four rules exist because each was learned from a defect that shipped past a review round.
+
+- **Do not write a claim the mechanism does not deliver.** Any sentence asserting that something guarantees, confines, enforces, or catches — and any sentence calling something verified — must be checkable against the instruction or command beside it. Two forms recur: an evidence citation ("verified live") for something not actually observed in this session, and a capability claim ("X enforces Y") where X does not. Where the mechanism is partial, name the part it covers and record the rest as a known limit; never round up.
+- **Run every command as written before recording it as verified.** Extract it from the file and run *that*, not a retyped copy. A verification that exercises a differently-typed command proves nothing about the one that ships.
+- **A list read a policy depends on must be complete.** Pass `--paginate` with `per_page=100` on paginated API reads. Where a command takes a `--limit`, compare the number of rows actually **fetched** against that limit — a client-side-filtered count checks nothing — and raise the limit until the fetched count is strictly below it. A read that may be short is an unknown, and an unknown resolves the way that policy's failures resolve.
+- **Model eval fixtures on real artifacts from this repository.** A fixture that hands the agent the classification under test — a pre-labelled input, an idealized body, a state the platform cannot produce — grades recall of the case rather than the behaviour. At least one fixture per behavioural rule should come from a real PR, issue, or branch.
+
 ## Issue Skill Design Axis
 
 The issue-lifecycle skills (`create-issue`, `implement-issue`) share one non-negotiable design axis. Changes to either skill must preserve it:


### PR DESCRIPTION
Four skill-authoring rules harvested from the #109 batch, added to `AGENTS.md`'s Skill Development section. You approved each rule's text verbatim before it was written.

This PR carries no implementation — it is separated from the milestone PR (#126) deliberately, so a reviewer of a code change is never handed a rules change to adjudicate.

## The rules, and what each one cost to learn

**Do not write a claim the mechanism does not deliver.**
Found **20+ times across seven PRs**, and it kept recurring *after* it was added to every implementer's dispatch constraints. It was also the batch's final blocking item: a fail-open closed on the keyword side was announced as closed in general, and the announcement replaced the correct disclosure that had covered the other side. The two recurring forms are an evidence citation ("verified live") for something not observed in the session, and a capability claim ("X enforces Y") where X does not.

**Run every command as written before recording it as verified.**
A `git for-each-ref 'refs/remotes/origin/*'` pattern returned two refs instead of ten, because `*` does not cross `/` and every per-issue branch contains one. It survived a full review round — the verification run had executed `for-each-ref` **without its pattern argument**, so a different command was checked from the one in the file.

**A list read a policy depends on must be complete.**
Four independent fail-opens shipped from this across #110, #114, #111 and #112 — the most repeated mechanical defect in the batch. Two variants: a missing `--paginate` (a human comment past item 30 made a PR look human-free and mergeable), and a `--limit` compared against a *client-side-filtered* count rather than the fetched one, which checks nothing.

**Model eval fixtures on real artifacts from this repository.**
Idealized fixtures hid five Criticals. In the sharpest case, a happy-path fixture was built on a state the platform cannot produce — a registered closing reference on a non-default-base PR — so no case in that suite could ever have surfaced the defect it was written to cover.

## Provenance

Harvested once for the whole #109 batch (eight merged PRs), per the skill's harvesting step: one batched confirmation, one branch, one PR. Contributing issues: #109, #110, #111, #112, #114.

## Gates

Only CI applies to a harvest PR, and the recap says why the rest is waived: there is no issue whose spec to check the diff against and no code to review, so the two review gates do not apply; the automated review response does not apply because this PR carries no derived implementation; and no separate security review is run because the diff is one documentation file whose exact content you read and approved minutes earlier.

Relates to #109
Relates to #110
Relates to #111
Relates to #112
Relates to #114
