### PR TITLE
Record the CI version bump and the automated reviewer in the agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,8 @@ Neutral vocabulary — use the capability term in skill instructions; reserve pr
 ## Git Conventions
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `docs:`, `chore:`)
+- Never edit the plugin version by hand. `.github/workflows/bump-version.yml` bumps `metadata.version` and `plugins[0].version` in `.claude-plugin/marketplace.json` on every merge to `main` whose PR touched `plugins/`, classifying the bump level from the diff.
+
+## Automated Reviewers
+
+- `claude-review` — GitHub Actions workflow `.github/workflows/claude-code-review.yml`, running `/code-review:code-review` on `opened` / `synchronize` / `ready_for_review` / `reopened`; posts on drafts: yes


### PR DESCRIPTION
Two conventions harvested from the run that produced #132, promoted here so a later run does not re-derive them. Each was approved verbatim by the user before this PR was opened.

## Rules added

**1. The plugin version is bumped by CI, never by hand** — under `Git Conventions`.

> Never edit the plugin version by hand. `.github/workflows/bump-version.yml` bumps `metadata.version` and `plugins[0].version` in `.claude-plugin/marketplace.json` on every merge to `main` whose PR touched `plugins/`, classifying the bump level from the diff.

The decision that produced it: #132 changes files under `plugins/`, so the run had to establish whether it owed a version bump. Answering that took reading the workflow and the history of the version fields — the version lives in `.claude-plugin/marketplace.json`, not in `plugins/aoshimash-skills/.claude-plugin/plugin.json`, which carries none. Recorded so the next run neither repeats the investigation nor hand-edits a field the merge is about to rewrite.

**2. The repository's automated reviewer is declared** — new `Automated Reviewers` section.

> `claude-review` — GitHub Actions workflow `.github/workflows/claude-code-review.yml`, running `/code-review:code-review` on `opened` / `synchronize` / `ready_for_review` / `reopened`; posts on drafts: yes

The decision that produced it: #132's automated-review step detected this reviewer from the workflow definition and read its triggers to establish that it posts on drafts (so it is waited for rather than deferred). `implement-issue`'s `automated-review.md` treats a declared `## Automated Reviewers` section as authoritative and skips the remaining detection signals, so declaring it removes that detection from every later run in this repository. The skill is explicit that adding the section is the user's call, not the run's — hence this PR rather than a write during the run.

## Notes

- Branched from `main` in its own worktree, so the diff cannot contain #132's implementation changes.
- Review gates, the automated-review response, and a separate security review are waived for a promotion PR by `harvesting.md` E: there is no issue spec to check the diff against, no code to review, and the whole content is text the user approved verbatim minutes earlier. CI is the only gate that applies.

Relates to #128
